### PR TITLE
Correct the rejection count in the workflow comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   # A SEPARATE JOB, and the separation is a governance decision rather than a layout preference.
   #
   # `validate` is the authoritative verdict (ADR 0004) and this repository is intentionally
-  # NON_COMPLIANT: three rules carry recorded human rejections, so the honest result is exit 1. While
+  # NON_COMPLIANT: four rules carry recorded human rejections, so the honest result is exit 1. While
   # this step lived inside `test`, the required check could never pass, and combined with PR-only
   # protection that left no legal path to change `develop` — every pull request needed a check
   # designed to fail, and its failure was the correct answer.
@@ -74,7 +74,7 @@ jobs:
   # on every push, pull request and dispatch, applies the same policy, and propagates the same exit
   # status; a failure here still turns the whole workflow red. `test` is required and can pass;
   # `validate` is visible and not required, and becomes required only when this repository can
-  # satisfy it honestly. A baseline exception declaring today's three failures acceptable would make
+  # satisfy it honestly. A baseline exception declaring today's four failures acceptable would make
   # that day arrive sooner by encoding non-compliance as a passing condition, and is refused.
   #
   # No `needs: test`. The two answer different questions and one pull request should be able to

--- a/.github/workflows/standards-dogfood.yml
+++ b/.github/workflows/standards-dogfood.yml
@@ -1,10 +1,10 @@
 # Dogfooding the reusable check on the repository that defines it.
 #
 # **This job is expected to be red, and a green run is a defect report.** This repository is
-# intentionally `NON_COMPLIANT`: three rules carry recorded human rejections, so the authoritative
+# intentionally `NON_COMPLIANT`: four rules carry recorded human rejections, so the authoritative
 # local verdict is exit 1. The acceptance target for this workflow is not that GitHub turns green —
 # it is that the distributed check reproduces the local verdict faithfully. Success looks like the
-# job summary reporting the same counts and the same three failing rules a local
+# job summary reporting the same counts and the same four failing rules a local
 # `npm run validate` reports, and exiting 1 for the same reason.
 #
 # A green run would mean the verdict changed somewhere in transport, which is the failure this step


### PR DESCRIPTION
Four present-tense comment claims said the repository carries **three** recorded human rejections. Since `review-scm-no-shared-history-rewrite-003` the authoritative count is **four**.

```text
.github/workflows/ci.yml:68              "three rules carry recorded human rejections"
.github/workflows/ci.yml:77              "today's three failures acceptable"
.github/workflows/standards-dogfood.yml:4    "three rules carry recorded human rejections"
.github/workflows/standards-dogfood.yml:7    "the same three failing rules a local ... reports"
```

## Nothing executable changed

Stripping comments and blank lines from both files, before and after:

| File | before | after | |
| --- | --- | --- | --- |
| `ci.yml` | `772e005d57e18c20` | `772e005d57e18c20` | identical |
| `standards-dogfood.yml` | `5836036a8eee054c` | `5836036a8eee054c` | identical |

No pin change, no trigger change, no job topology change, no exit handling change, no `validate` semantics change, and no branch-protection change. `validate` remains visible and not required.

## Deliberately not changed

`artifacts/adr/0013-...md:85` also says "the three recorded rejections", but it sits under *"**Recorded 2026-08-11.** That happened"*, describing the state at the branch-protection correction — which was genuinely three then. Retrofitting a count into a dated decision record is worse than the stale reading, so it is raised for the owner rather than decided here.

## Expected state

```text
local gate    inventory / fidelity / policy / diagrams pass, 229/229 tests, audit exit 0
validate      NON_COMPLIANT, 23 passed / 4 failed / 23 skipped
```

One attestation staled — `testing.no-fabricated-results`, whose reviewed paths include `ci.yml`. That is the freshness model working, and it needs an owner re-review rather than a digest refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)