### PR TITLE
Remove the conflict markers committed into section 08

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -181,12 +181,9 @@ that approval deliberately does not cover.
   gh api repos/:owner/:repo/check-runs/93929943347/annotations -q '.[].message'
   #   "The job was not started because recent account payments have failed..."
   ```
-<<<<<<< HEAD
   The first command verifies the deliverable. The second and third verify the *absence* of the
   evidence the acceptance criterion required, and are recorded here so that absence stays legible
   rather than being rediscovered from the commit graph later.
-=======
->>>>>>> 344d15a (An adoption attempt found three defects; two of them were new)
 - **Dependencies:** account-side restoration of the plan capability that provides both Actions
   minutes and private-repository branch protection. This is **outside this repository and outside
   what any agent working in it can do** — nothing in the codebase can unblock it, and no amount of


### PR DESCRIPTION
Deletes three leftover cherry-pick conflict markers from `artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md`. No prose changes.

Reported by Codex on PR #18 ([comment 3761854750](https://github.com/mikeycdavis/EngineeringStandards/pull/18#discussion_r3761854750)). The finding is correct and the markers reached `develop`.

## What happened

Introduced by `8870a43` — mine. I staged with `git add -A` after the working tree had picked up a conflicted cherry-pick resolution, ran the gate, saw it green, and committed without reading the diff.

```
c489ecc  markers=0
5b807de  markers=0
8870a43  markers=1   ← introduced here
```

The resolution is unambiguous: the `HEAD` side held the paragraph explaining what the three verification commands establish, and the `344d15a` side was empty. Only the three marker lines are removed.

## Why the gate missed it

Worth stating plainly, because this is the repository whose product is catching this class of defect:

- The audit's plan-item parser reads `- **Field:**` lines and ignores every other line, so `<<<<<<< HEAD` is invisible to it.
- Markdown renders conflict markers as ordinary paragraph text — nothing fails, nothing looks broken to a renderer.
- The 229 tests assert behaviour, not file-content shape.

`git diff --check` catches it in one command, exits non-zero, and names the line numbers. I did not run it.

## Verification

```
git diff --check                 exit 0, no output
repo-wide marker scan            no matches
inventory / fidelity / policy / diagrams   OK
npm test                         229 passed, 0 failed
audit                            0 error(s), 0 warning(s)
```

## Not included

A conflict-marker check in CI, and any change to the audit. Both are plausible responses and neither belongs in a PR whose job is removing three lines. Flagged for the queued post-merge plan audit to decide and own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
