### PR TITLE
Assign #19 and #21, close the CI-acceptance item, correct the protection claim

### DIFF
--- a/artifacts/project-plan-breakdown/04-compliance-and-policy-system.md
+++ b/artifacts/project-plan-breakdown/04-compliance-and-policy-system.md
@@ -162,11 +162,14 @@ the one failure class this repository exists to prevent.
 - **Status:** READY — both defects are diagnosed and neither is blocked on anything
 - **Tracked by:** GitHub issues
   [#10](https://github.com/mikeycdavis/EngineeringStandards/issues/10) and
-  [#11](https://github.com/mikeycdavis/EngineeringStandards/issues/11). Note that `Tracked by` here
-  points at GitHub rather than at a backlog item — this repository has no
-  `artifacts/backlog/`, and the audit's reference resolver only understands backlog ids
-  (issue [#5](https://github.com/mikeycdavis/EngineeringStandards/issues/5)), so these pointers are
-  verified by hand until that coupling is fixed.
+  [#11](https://github.com/mikeycdavis/EngineeringStandards/issues/11)
+- **Why these pointers are hand-verified.** `Tracked by` here names GitHub rather than a backlog
+  item, because this repository has no `artifacts/backlog/` and the audit's reference resolver
+  understands only backlog ids — the coupling defect owned by section 08. Kept out of the
+  `Tracked by` field deliberately: an issue mentioned in passing inside that field is
+  indistinguishable, to any automated ownership check, from an issue the item claims. That is the
+  same use/mention problem the detectors have, one layer up, and it made the
+  claimed-exactly-once invariant unverifiable until this prose was moved.
 - **Evidence:** both issues are open as of 2026-08-11 and neither has a fix on `develop`. This is
   the only item in this section that is not complete.
 - **Purpose:** The policy template names an exception as one of the four ways to resolve a forbidden

--- a/artifacts/project-plan-breakdown/07-distributed-validation-and-ci.md
+++ b/artifacts/project-plan-breakdown/07-distributed-validation-and-ci.md
@@ -107,12 +107,29 @@ someone to lie to make the build go green.
 
 ### Accept the reusable check on real CI infrastructure
 
-- **Status:** BLOCKED — not failed, and the distinction is the point of this item
-- **Evidence:** the workflow is implemented and has produced real verdicts — the run on `e06c59f`
-  executed both jobs and reported `24 passed, 4 failed, 22 skipped` from inside and the same counts
-  from outside, which is the placement invariant demonstrated on real infrastructure rather than in a
-  local two-checkout regression. Acceptance is blocked because GitHub Actions has intermittently been
-  unable to start a runner for this account.
+- **Status:** COMPLETE — 2026-08-11, accepted on executed runs after the account runner capability
+  was restored. Previously `BLOCKED`; that state is described below because *blocked* was the
+  correct answer for as long as it held, and this item's purpose was to keep it distinguishable from
+  *failed*.
+- **Evidence:** on the PR #18 branch, both jobs executed and both verdicts were read from their logs
+  rather than inferred from conclusions:
+
+  | Job | Steps | Verdict |
+  | --- | --- | --- |
+  | `validate` — framework inside the target | 7 | `NON_COMPLIANT` · 100% · 24 passed, 4 failed, 22 skipped · 21 automated, 7 manual-review, 9 not-evaluated |
+  | `validate-self / validate` — framework pinned externally | 16 | **identical on every field** |
+
+  The required `test` job ran alongside them: `success`, 12 steps. **The two verdicts agreeing field
+  for field is the evaluator placement invariant established on real CI**, which is a stronger claim
+  than this item's acceptance criteria asked for — they required only that a run carry real
+  information. A local two-checkout regression could never have established it, because the thing in
+  question is whether *placement* changes the answer.
+
+  **The prior blocked period, kept rather than deleted:** for six or more pushes across 2026-08-10
+  and 2026-08-11, every job terminated in under five seconds with `steps: 0` and the annotation
+  *"The job was not started because recent account payments have failed…"*. Those runs were never
+  recorded as failures of this item, which is what made today's acceptance meaningful — had they
+  been counted as reds, the restoration would have looked like a fix to code that was never broken.
 - **Purpose:** Establish that the distributed check works where it is meant to work. Local evidence
   is not the same claim.
 - **Deliverables:** a green-or-honestly-red run of `validate-self / validate` on the current tip,
@@ -126,11 +143,14 @@ someone to lie to make the build go green.
     accepted are three states.
 - **Verification:**
   ```bash
+  gh api repos/:owner/:repo/actions/runs/<id>/jobs \
+    --jq '.jobs[] | "\(.name) concl=\(.conclusion) steps=\(.steps|length)"'
   gh api repos/:owner/:repo/check-runs/<id>/annotations
   ```
-  Read the annotation before diagnosing any red on this item.
-- **Dependencies:** the reusable workflow above. Blocked on account infrastructure, not on any code
-  in this repository — nothing here can unblock it.
+  Read the annotation before diagnosing any red on this item — the step count is what separates a
+  verdict from an infrastructure block, and the log is empty in the latter case.
+- **Dependencies:** the reusable workflow above. Was blocked on account infrastructure, never on any
+  code in this repository; restored 2026-08-11.
 
 ### Arrange this repository's gate so honesty and green can coexist
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -8,12 +8,18 @@ Before the plan repair, eleven GitHub issues, four recorded rule rejections, and
 deferred design questions existed as a parallel obligation system that no plan item claimed. A plan
 that omits its own open work will always report itself complete.
 
-**Every open GitHub issue is claimed by exactly one plan item.** Thirteen are open. Seven are claimed
-here — #1, #4, #5, #6, #7, #8, #17 — and the other six are claimed where their subject lives:
-[#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
+**Every open GitHub issue is claimed by exactly one plan item.** Fifteen are open. Nine are claimed
+here — #1, #4, #5, #6, #7, #8, #17, #19, #21 — and the other six are claimed where their subject
+lives: [#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
 [#3](06-must-never-standards.md) by the detectors, and
 [#2, #9 and #16](07-distributed-validation-and-ci.md) by the adoption path. None is rejected as
 out of release scope.
+
+**Ownership is asserted by an item's `Tracked by` field, not by an issue being mentioned.** Sections
+03 and 04 reference #4, #5 and #7 while section 08 owns them; a link-count would report those as
+claimed two and three times over. Anyone re-checking this invariant should test for the field, not
+for the link — the use/mention distinction ([ADR 0009](../adr/0009-detectors-distinguish-instances-of-a-subject-from-discussion-of-it.md))
+applies to the plan reading itself, not only to detectors.
 
 **Updated 2026-08-11**, after an adoption attempt against two repositories surfaced three defects.
 Two are new — [#16](07-distributed-validation-and-ci.md) (adoption eligibility resolved too late) and
@@ -141,16 +147,36 @@ that approval deliberately does not cover.
   version the item warned against — worse than the beforehand version, better than no record. That
   gap is itself the finding, and it is left standing below in its original wording rather than
   softened to match what happened.
-- **Evidence — the conditions as measured when the item was written, both of which still held at the
-  moment of the merge:**
+- **Evidence:** the conditions as measured when the item was written. One of the two was misread at
+  the time and is corrected below; both are left visible rather than rewritten.
   - **Actions cannot establish the required `test` result.** The jobs queued for the pull request
     completed in under five seconds having executed **zero steps**. The reason is in the check-run
     annotation, not the log: *"The job was not started because recent account payments have failed
     or your spending limit needs to be increased."* A job that never started carries no information
     about the code in either direction.
-  - **GitHub cannot currently enforce the protected path.** `GET /branches/develop/protection` and
-    `GET /rulesets` both return **403 — "Upgrade to GitHub Pro or make this repository public"**,
-    which is consistent with `mergeStateStatus` reading `UNSTABLE` rather than `BLOCKED`.
+  - **~~GitHub cannot currently enforce the protected path.~~ CORRECTED 2026-08-11 — this was
+    wrong.** What was measured: `GET /branches/develop/protection` and `GET /rulesets` both returned
+    **403 — "Upgrade to GitHub Pro or make this repository public"**. What was concluded: that
+    protection had lapsed. That conclusion did not follow. A 403 on a read establishes that **the
+    API could not be queried**, not that the thing being queried was absent — *visibility* was
+    unavailable, not enforcement.
+
+    Once the account capability was restored, the ruleset **"Protect main branches"** was found
+    `enforcement: active`, `created_at: 2026-08-08`, requiring `test`, pull requests, linear
+    history, and blocking deletion and force-push. It had almost certainly been enforcing
+    throughout. The 404 that now answers `/branches/develop/protection` means only that `develop`
+    was never governed by *classic* branch protection — the ruleset is a different mechanism at a
+    different endpoint, and reading one endpoint's silence as the other's absence was the error.
+
+    **This is Standard 44 R12 against the framework's own reasoning**: a negative result is evidence
+    about the search mechanism before it is evidence about the world. A 403 is not even a negative
+    result — it is the search failing to run. The invariant was written into this repository's
+    standards and then violated by it within two days.
+
+    **What does not change:** `mergeStateStatus: UNSTABLE` was still not permission, the required
+    check still genuinely could not execute, and the merge still occurred with its documented
+    prerequisites unmet. One of the two stated prerequisites was misdiagnosed; the other was real,
+    and it was sufficient on its own.
 - **Purpose:** Keep the distinction the whole framework rests on. Local verification is evidence
   about the change; it is not a substitute for a required CI check when the plan says merge through
   the protected path. **`mergeStateStatus: UNSTABLE` is not permission** — it is the absence of an
@@ -429,6 +455,81 @@ that approval deliberately does not cover.
   `5b4b917`. That commit is an ancestor of `origin/develop` — the reconciliation landed. The issue
   is nonetheless still open, and the R4 text above is what is actually there, so the reconciliation
   did not close it.
+
+### Decide how the plan-item field parser handles qualified headings
+
+- **Status:** READY
+- **Tracked by:** GitHub issue
+  [#19](https://github.com/mikeycdavis/EngineeringStandards/issues/19)
+- **Evidence:** open as of 2026-08-11. The parser in
+  [`scripts/standards.mjs`](../../scripts/standards.mjs) matches
+  `/^\s*-\s+\*\*([^:*]+):\*\*\s*(.*)$/` and compares the captured name against a fixed
+  `PLAN_FIELDS` list. **Four occurrences**, all in this file, all authored as ordinary prose:
+  `Acceptance Criteria` twice, `Verification` once, `Evidence` once.
+- **Purpose:** Two distinct failure shapes, and the second is the reason this is a defect rather
+  than a syntax constraint:
+  - **Qualifier before the colon** — `- **Acceptance Criteria — the resumption condition:**` parses,
+    and the content is filed under a key nothing reads. The parser *has* the field and discards it.
+  - **Qualifier with no colon** — `- **Verification — what was established.**` does not match at all.
+
+  **The fourth occurrence widened the defect materially.** `Evidence` is not in `PLAN_FIELDS`, so
+  its loss produced **no symptom whatsoever** — R7 never reported it, the audit stayed at zero
+  findings, and it was found only by a one-off script written during the 2026-08-11 plan audit. So
+  the impact is not confined to required fields generating a misleading *"missing required field"*
+  message; for optional fields, a qualified heading disappears silently and permanently.
+- **Deliverables:** a decision on the owning layer and the fix, plus a regression. Deliberately not
+  chosen here — the parser could recognise a known field name as a prefix, or the plan format and
+  templates could make the exact token mechanically unavoidable. A third option is compatible with
+  either: report an unrecognised field key as its own finding, so a near-miss explains itself.
+- **Acceptance Criteria:**
+  - A qualified heading is either accepted or produces a finding that names the heading as the
+    cause. `(no Acceptance Criteria)` against an item that visibly has one is the outcome to remove.
+  - The fix covers fields outside `PLAN_FIELDS`, or the plan explicitly records that it does not and
+    why. Fixing only the required fields would leave the silent case exactly as it is.
+  - A prefix-matching fix must not misread `- **Verification of the digest:**` as the `Verification`
+    field. Whichever direction is taken needs a known-negative fixture, not only a known-positive.
+- **Verification:** `npm test` with the new fixtures; plant a qualified heading of each shape in a
+  fixture plan item and confirm the chosen behaviour, including for a non-required field.
+- **Dependencies:** none.
+- **Repairing the four instances is not fixing this.** The malformed `Evidence` heading in this file
+  was corrected in the same change that created this item. That removed one specimen; the parser
+  behaviour is unchanged and the next qualified heading will do the same thing.
+
+### Decide which layer detects unresolved merge-conflict metadata
+
+- **Status:** READY
+- **Tracked by:** GitHub issue
+  [#21](https://github.com/mikeycdavis/EngineeringStandards/issues/21)
+- **Evidence:** open as of 2026-08-11, and **reproduced on `develop` rather than hypothesised**.
+  Three cherry-pick conflict markers reached `develop` in this file, introduced by `8870a43` and
+  removed by `18857e9`. While they were present the repository passed `inventory`, `fidelity`,
+  `policy`, `diagrams`, 229 tests, and a self-audit reporting **0 errors and 0 warnings**.
+  `git diff --check` detects them in one command and names the lines.
+- **Purpose:** Unresolved merge metadata can sit in a tracked file — in the canonical release-gate
+  artifact, inside a plan item's `Verification` field — while every gate reports clean. The plan
+  parser reads `- **Field:**` lines and ignores all others, Markdown renders markers as ordinary
+  text, and the tests assert behaviour rather than file-content shape. The defect was found by
+  external review, not by this repository's own tooling.
+- **Deliverables:** a decision on the owning enforcement layer, and a check with fixtures. **The
+  layer is deliberately not chosen here**, because the incident does not settle it. The question
+  underneath: is unresolved merge metadata a *finding about the repository*, or a *hygiene
+  precondition* that should fail before the evaluator is asked anything? Candidates are a repository
+  hygiene command run by CI alongside the existing invariant checks, an `audit` finding category, or
+  an extension of an existing validation layer.
+- **Acceptance Criteria:**
+  - **Known positive:** a file containing genuine unresolved markers is detected.
+  - **Known negative:** documentation that *mentions* conflict-marker syntax is not flagged —
+    including issue #21 itself, this plan item, and any standard or design document explaining merge
+    conflicts. A naive content scan would flag the very documents describing the rule, which is the
+    use/mention defect ([ADR 0009](../adr/0009-detectors-distinguish-instances-of-a-subject-from-discussion-of-it.md))
+    that has already shipped five times here.
+  - The regression is a known-negative guard, not only a known-positive one.
+- **Verification:** `npm test` with both fixtures; `git diff --check` exits 0 on a clean tree.
+- **Dependencies:** none.
+- **One specimen removed is not one class prevented.** `18857e9` deleted the markers that reached
+  `develop` and the repository is currently clean. That establishes nothing about whether the next
+  ones would be caught, and this item stays open until a check with both fixtures exists. The two
+  claims are kept separate deliberately.
 
 ---
 


### PR DESCRIPTION
Reconciliation of the 2026-08-11 post-merge plan audit. **Three plan files, no code, no policy, no workflow, no rule changes.**

## The six edits

| | |
| --- | --- |
| **#19 → section 08** | new item; records that qualified headings are discarded *silently* for optional fields |
| **#21 → section 08** | new item; owning enforcement layer deliberately **not** chosen |
| **07 CI-acceptance** | `BLOCKED` → `COMPLETE` on executed runs |
| **Protection claim** | corrected: visibility was unavailable, not enforcement |
| **Issue count** | 13 → 15 |
| **`**Evidence — …**`** | → canonical `**Evidence:**`, substance unchanged |

## Two constraints held explicitly

**#21 stays open.** `18857e9` removed the markers that reached `develop`; the repository is clean today. That establishes nothing about whether the next ones would be caught. The item closes when a check with **known-positive and known-negative** fixtures exists — the negative matters because a naive scan would flag issue #21 itself, this plan item, and any document explaining merge conflicts.

**#19 stays open**, and the fourth occurrence made it worse rather than better. `Evidence` is not in `PLAN_FIELDS`, so the malformed heading produced **no symptom at all** — the audit stayed at zero findings and it surfaced only via a one-off script. The defect is not "R7 emits a misleading missing-field message"; it is that for any unrequired field, a qualified heading is dropped without trace.

## The correction worth reading

I recorded that a 403 on `/branches/develop/protection` meant protection had lapsed. It did not follow. **A 403 on a read establishes that the API could not be queried, not that the thing queried was absent.** Once billing was restored, the ruleset "Protect main branches" was found `enforcement: active`, `created_at: 2026-08-08` — enforcing throughout.

That is Standard 44 R12 — *a negative result is evidence about the search mechanism before it is evidence about the project* — violated by this repository two days after writing it into its own standards. A 403 isn't even a negative result; it's the search failing to run. Corrected in place with the original claim struck rather than deleted.

What does **not** change: `UNSTABLE` was still not permission, the required check still genuinely could not execute, and PR #15 still merged with its prerequisites unmet. One of two stated prerequisites was misdiagnosed; the other was real and sufficient alone.

## One thing the audit found while checking itself

`#5` resolved to **two** owners — section 08's item, plus a parenthetical mention of it inside section 04's `Tracked by` prose. A mention inside that field is indistinguishable, to any automated ownership check, from a claim. Moved to its own bullet: the detectors' use/mention problem one layer up, which had made the claimed-exactly-once invariant unverifiable in the very paragraph asserting it.

## Verification

```
open issues        15
claimed            15
unclaimed           0
multiply claimed    0
malformed field headings   0

inventory / fidelity / policy / diagrams   OK
npm test                                   229 passed, 0 failed
audit                                      0 error(s), 0 warning(s)
git diff --check                           exit 0
validate                                   NON_COMPLIANT — 24/4/22
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
