### PR TITLE
Constrain the lifetime, because recognising the state kept failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,26 @@ non-required job on GitHub, and for the same reason: this repository is intentio
 `NON_COMPLIANT` while recorded rejections stand. Its real exit code is recorded and printed, never
 suppressed. See [docs/local-ci.md](docs/local-ci.md).
 
+**Run state became invocation-owned** ([ADR 0014](artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md)).
+`scripts/standards.mjs` no longer performs its work at module load. Importing it now runs nothing;
+`main(args)` returns an exit code, and only the CLI boundary at the foot of the file terminates the
+process. The findings sink, the repository surface, and the source cache are constructed per
+invocation and cannot outlive it.
+
+Behaviour is unchanged, and that is asserted rather than claimed: `audit --json` and
+`validate --json` are byte-identical to a fresh process, and exit codes 0 / 1 / 2 are preserved.
+`test/invocation-ownership.test.mjs` carries the falsifiers, including a negative control that
+restores the old lifetime for one object and still passes every behavioural check — only the
+identity assertion catches it.
+
+[ADR 0007](artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md) is
+superseded as a control and kept unrepaired. Its binding table was incomplete at five consecutive
+reviews; that incompleteness is the evidence for retiring enumeration, so repairing it first would
+have destroyed the finding.
+
+`architecture.no-hidden-global-state` goes stale as a result, which is expected: its evidence
+changed, and it returns for owner review rather than being refreshed.
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ source extraction still agrees with it, and CI fails if it does not.
   — the must-never layer is built from the catalog's `forbidden` level, reuses existing rules rather
   than duplicating them, and caps the verdict where a prohibition went unexamined.
 - [artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md](artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md)
-  — the CLI scripts are commands, not libraries; module scope is run scope, and process exit is the
-  reset boundary. Standard 51 R1's required record for this repository's own global state.
+  — **superseded as a control by ADR 0014**, and kept unrepaired as the evidence for why: module
+  scope was run scope, and the enumeration of governed bindings was incomplete at five consecutive
+  reviews.
 - [artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md](artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)
   — a detector may say what is present in the working tree; saying *committed* or *tracked* requires
   asking the repository, and until that seam exists both directions of the gap are disclosed.
@@ -134,6 +135,10 @@ source extraction still agrees with it, and CI fails if it does not.
 - [artifacts/adr/0010-human-review-may-always-contribute-negative-evidence.md](artifacts/adr/0010-human-review-may-always-contribute-negative-evidence.md)
   — **Proposed.** Approval and rejection are not symmetric operations and should not share one
   permission; a rejection cannot manufacture a pass, so it cannot violate monotonicity.
+- [artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md](artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md)
+  — execution-specific mutable state is owned by an invocation and cannot outlive it, and importing
+  the evaluator does not execute an audit. Replaces enumeration as Standard 51 R1's control, because
+  recognising every representation of state failed where constraining its lifetime does not.
 
 ## Design documents
 

--- a/artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md
+++ b/artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md
@@ -1,8 +1,39 @@
 # 0007 — The CLI scripts are single-run programs, and their module scope is their run scope
 
-- **Status:** Accepted
+- **Status:** Superseded as a control by
+  [ADR 0014](0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md) (2026-08-13).
+  Retained in full as historical evidence.
 - **Date:** 2026-08-09
 - **Deciders:** Project owner
+
+## This record is evidence now, not a control
+
+**Nothing below has been corrected, and the binding table has deliberately not been repaired.** Eight
+written bindings absent from it and one stale row were known at the time this status changed. They
+were left exactly as they were, because they are the evidence that justified retiring enumeration:
+repairing them first would have destroyed the finding and produced a table that looked authoritative
+for exactly as long as it took someone to add another binding.
+
+Three lessons are the reason this document is kept rather than deleted.
+
+1. **The categorical rule was stronger than its table, and the rule was right.** "A script that holds
+   run state is governed the moment it exists" never failed. What failed was every attempt to write
+   down which bindings that was.
+2. **The table lagged on ordinary bindings, not exotic ones.** The misses were plain accumulators and
+   derived run state declared at module level in the usual way — not clever constructs. A control that
+   cannot see the ordinary case is not a control.
+3. **Mechanical analysis did not rescue it.** This record already said the declaration scan could not
+   see the alias-mediated write to `surfaceLoss`. A later, genuinely capable AST analysis went further
+   and was worse: it produced confident, plausible, materially wrong measurements — twice — because its
+   semantic model was incomplete, and it never failed while doing so.
+
+ADR 0014 removes the need to solve that recognition problem, by constraining lifetime instead of
+attempting to enumerate representations. The governing invariant is now **execution-specific mutable
+state is owned by an invocation**, established behaviourally against fresh-process oracles, with one
+retained static invariant — **only the CLI boundary may terminate the process** — kept precisely
+because it is closed and checkable in a way that "find every shape of mutable state" is not.
+
+Read the rest of this document as the record of what was tried, what it cost, and why it changed.
 
 ## Context
 
@@ -213,3 +244,16 @@ is the part that would break silently.
 its reset boundary is named, and the conditions that would invalidate the decision are named. It
 remains a `manual-review` rule — this record is the evidence a reviewer reads, not a substitute for
 reading it.
+
+## Postscript — the invalidating condition was met
+
+The section above named the conditions under which this decision would no longer hold, and said the
+refactor at that point was known: *move the run block into an exported entry point that constructs
+every binding per call and passes them through.* That is what
+[ADR 0014](0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md) does.
+
+The trigger was not a second caller. It was the control itself: the enumeration this record depended
+on could not be made reliable, and two attempts to mechanise it — a declaration scan and a full AST
+analysis — each reported clean on state they could not see. This decision anticipated its own
+replacement and named the refactor correctly. It did not anticipate that the reason would be the
+table rather than a new consumer.

--- a/artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md
+++ b/artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md
@@ -1,0 +1,159 @@
+# 0014 — Run state is owned by an invocation, not recognised by a table
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Deciders:** Project owner
+- **Supersedes as a control:** [ADR 0007](0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md).
+  0007 is retained as historical evidence, and its binding table is deliberately **not** repaired.
+
+## Context
+
+[Standard 51](../../standards/51-architecture-integrity.md) R1 asks a decision record to name **what
+the state is**, **who owns it**, and **how it is reset**. ADR 0007 answered that by declaring the
+module scope to be the run scope and enumerating the module-level bindings that carried run state.
+
+The enumeration was the weak part, and 0007 said so itself: it recorded that the table had been
+incomplete at every review, that a declaration scan could not see alias-mediated writes, and that
+completeness was a review obligation rather than a mechanical guarantee. It lagged again at the fifth
+review. The rule text was categorical and remained correct; what kept failing was the ability to
+*recognise* every binding the rule governed.
+
+Two candidate controls were prototyped outside this repository before either was proposed for it.
+
+### Candidate A — recognition
+
+Derive the executable scope, find every representation of module-level mutable state, and make the
+table mechanically complete.
+
+Scope derivation worked, and worked better than expected: seven entrypoints from `package.json`
+scripts, sixteen modules by transitive import, including a state-holding module the table had not
+named. It also found the alias-mediated `surfaceLoss` case that ADR 0007 recorded as invisible to a
+declaration scan — `direct=0, alias=5` — which was the negative control the design had to pass.
+
+It then failed the adversarial round.
+
+| Round | Cases | Caught |
+| --- | --- | --- |
+| Straightforward mutations | 8 | 8 |
+| Adversarial representations | 6 | **1** |
+
+The five misses included closure-hidden state, cross-module mutation, and writes reached through a
+further alias. Every miss produced a **valid execution carrying wrong assurance** — the control
+reported clean on a program that held exactly the state it existed to find.
+
+### Candidate B — construction
+
+Change the lifetime boundary instead. Every run-sensitive mutable object is created by the invocation
+that uses it and cannot outlive it. How the state is *represented* stops mattering, because nothing
+at module scope remains to be recognised, aliased, or hidden behind a closure.
+
+The property is not "module scope is empty". Frozen lookup tables, extension sets, and matching
+configuration such as `VENDOR_MARKERS` stay where they are: they are framework-owned data with no
+mutation sites, and their values do not depend on which repository is being audited.
+
+## The decisive argument is failure-mode asymmetry, not cleanliness
+
+Candidate B is also tidier. That is not why it wins, and B was explicitly not credited for it.
+
+- **Candidate A's failures were silent.** A missed representation yields a passing control and a
+  false assurance, which is the defect
+  [`ai.no-fabricated-capabilities`](../../rules/ai.json) exists to prohibit.
+- **Candidate B's failures were loud.** Four defects arose while prototyping the transformation — a
+  temporal-dead-zone crash from a destructured declaration, a function appearing in its own consumer
+  list, mis-rewritten shorthand properties, and a recursive call forwarding pre-rename argument
+  names. All four crashed immediately.
+
+A third data point belongs here and is recorded against this project's own work rather than against
+the rejected candidate. The first closure measurement reported a twenty-four-function blast radius by
+counting parameters as captures. Corrected, the true count was zero — the detectors already take
+`files` and `contents` explicitly — and a *different* twenty-four appeared later for an unrelated
+reason. A real AST analysis produced a confident, plausible, materially wrong architectural
+measurement twice, without failing, because its semantic model was incomplete. That is the class of
+tool Candidate A proposed as the primary control, and it is the reason the correctness of this
+prohibition must not depend on a recognition problem.
+
+## Decision
+
+**Accept Candidate B. Retire enumeration as the control.**
+
+The governing invariant is about lifetime:
+
+> **Execution-specific mutable state is owned by an invocation. No such state survives outside the
+> invocation that created it, and importing the evaluator does not execute an audit.**
+
+One small static invariant is retained alongside the behavioural suite, because it is closed and
+mechanically checkable in a way that "find every possible shape of mutable state" is not:
+
+> **Only the CLI boundary may terminate the process.**
+
+## Evidence
+
+Ten falsifiers, carried into the repository as tests. Each compares against a **fresh-process
+oracle** — a separate `node` invocation of the same command — so a contaminated in-process run cannot
+agree with itself.
+
+| Property | How it is established |
+| --- | --- |
+| Import performs no run | importing the module produces no walk and no output |
+| Process termination is the CLI's alone | zero `process.exit` / `process.exitCode` below the CLI boundary |
+| Rendered output unchanged | `audit --json` and `validate --json` byte-identical to the fresh-process oracle |
+| Exit codes unchanged | 0 / 1 / 2 across the three paths |
+| Sequential independence | A→B, B→A, and A→A each equal their own oracle |
+| Failure paths do not contaminate | a failed run followed by another equals that target's oracle |
+| Concurrent independence, same root | two concurrent runs each equal the oracle |
+| Concurrent independence, different roots | concurrent runs over two repositories each equal their own oracle |
+| No shared identity | the findings sink, the repository surface, and the source cache are distinct objects per invocation |
+| Completed results are inert | mutating a finished run's objects cannot affect a later run |
+
+Every comparison reads the bytes the invocation itself rendered. An earlier version of the
+concurrency test compared against a single patched `process.stdout.write`, where two runs interleave
+into one buffer; it reported a pass, that pass could not distinguish independence from interleaving,
+and it was discarded rather than counted.
+
+**The negative control is the most important entry, and it cuts both ways.** Restoring the
+pre-refactor lifetime for one object — a module-level source cache reused by every invocation — leaves
+**nine of the ten behavioural checks green**. Only the identity assertion fails. Output equality is
+therefore *not* sufficient evidence of independence, which is the recognition burden Candidate A
+could not carry, appearing inside this project's own test suite. The control is kept as a test.
+
+## `sources`, characterised rather than excused
+
+The source cache was the last module singleton, and the question asked of it was: *can any supported
+invocation produce a different correct value for an already-cached key without reloading the module?*
+
+**Measured answer: no, today.** Every accessor call site keys on a path drawn from the current run's
+file list, `CODE_EXT` is a subset of `TEXT_EXT`, and every code file in that list is written during
+the read phase. No invocation can read an entry it did not itself write.
+
+**It is still run-sensitive, and it is not an admissible exception.** Its values are the audited
+project's file contents: the same key yields a different correct value for a different target. Its
+inertness is a whole-program property that nothing enforces — it holds only while every read site
+iterates the current surface, and a detector that queried a constructed path (an import target, a
+sibling file, a path from configuration) would break it silently. It also grows without bound across
+in-process invocations.
+
+It therefore moves by **construction** — a new map per invocation — and never by clearing a shared
+one at run start. Clearing makes sequential runs look independent while leaving two concurrent runs
+sharing a single object, which is precisely the defect only the identity assertion detects.
+
+## What this decision does not claim
+
+- **Not arbitrary concurrent safety.** What is established is that two independent concurrent
+  invocations remain independent under the tested execution paths. It is not a proof of correctness
+  under arbitrary interleaving, and no such claim is made.
+- **Not validated by the prototypes.** The candidates were mechanical transforms of a sandbox copy,
+  used to decide between two designs. The repository implementation is **hand-written and must
+  re-earn every property above on its own terms.** The tests are the evidence; the prototype is only
+  the reason to attempt the change.
+
+## Consequences
+
+- ADR 0007's binding table stops being a control. Its omissions are the evidence for this decision
+  and are preserved unrepaired.
+- The order-dependence 0007 recorded still holds: `detectUnverifiedFunctionality` reads findings
+  produced earlier in the same run. Ownership changes where the findings live, not the ordering.
+  Preserving that order remains a requirement of any future change.
+- `architecture.no-hidden-global-state` is a `manual-review` rule whose evidence was ADR 0007. That
+  evidence changes here, so the existing attestation goes stale. **That is correct and expected.** It
+  must not be recomputed or refreshed to make the verdict green; it returns for owner review with
+  this record and the implementation as its subject.

--- a/project-policy.yml
+++ b/project-policy.yml
@@ -508,6 +508,24 @@ attestations:
           revision: "7b35ed3"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "d0019fcdb1a6e348037478fac4be5a1b"
+      - id: "review-architecture-no-hidden-global-state-006"
+        supersedes: "review-architecture-no-hidden-global-state-005"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-16"
+        evidence: "RE-REVIEWED 2026-08-16 against committed repository content at 9a92d12, and THE BASIS OF APPROVAL HAS CHANGED. Every prior event in this sequence approved ADR 0007's model: module-scoped run state, recognised by an enumeration table, reset by process exit. This event does not. It approves ADR 0014's model, in which lifetime rather than a binding table is the mechanism, and it explicitly does NOT approve ADR 0007's enumeration or its process-exit reset. The reason is recorded across events 001 to 005 and is the reason the control was replaced: the record was found incomplete at four consecutive reviews, the table lagged the code across consecutive cycles, and event 005 recorded four bindings the table never reached. Human enumeration was not a sufficient control against hidden global state, and event 002 said so; PR #26 replaces it rather than attempting a fifth correction. Standard 51 R1 now points to ADR 0014. VERIFIED IN THE IMPLEMENTATION rather than assumed from the decision: argument state is derived per main(args); the findings array and the source cache are constructed by createRun(); repository surface state is created inside the invocation; detectors receive the run explicitly as a parameter rather than reaching for it; and the sole process-lifetime boundary sits after main. VERIFIED IN THE TESTS, which exercise the properties independently rather than illustrating them: sequential runs, failed-run isolation, same-root and different-root concurrency, object-identity separation between runs, mutation of a completed result not reaching a later one, byte equivalence against a fresh-process oracle, and the no-process-exit-below-the-boundary invariant. The identity assertion is retained deliberately because the negative control demonstrates that output equality alone cannot detect a shared cache. THE INSTALLED-BIN FIX AT 9a92d12 DOES NOT UNDERMINE THIS BASIS, and was examined for exactly that: it canonicalises the two path representations only at the CLI boundary, and a dedicated regression asserts that importing either the real module or its symlink remains inert, so the import-inertness property this model rests on is now tested in both directions rather than assumed. ADR 0007 REMAINS DELIBERATELY INACCURATE HISTORICAL EVIDENCE. Its table is not repaired, and repairing it is neither required nor desirable for this review; it is preserved as the record of a control that failed in a documented way. It is therefore no longer a reviewed path of this attestation, because an approval must not be read as attesting to a document knowingly left inaccurate."
+        reference: "artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md
+            - scripts/standards.mjs
+            - scripts/inventory.mjs
+            - scripts/fidelity.mjs
+            - test/invocation-ownership.test.mjs
+          revision: "9a92d12"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "9c8e7e0d8cc686945e088e5fcccc1168"
 
   architecture.no-duplicate-implementations:
     reviews:
@@ -792,6 +810,23 @@ attestations:
           revision: "1fa3869"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "577dc01c2ff161cfa2e7a12b6caa901b"
+      - id: "review-architecture-no-boundary-bypass-003"
+        supersedes: "review-architecture-no-boundary-bypass-002"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-16"
+        evidence: "RE-REVIEWED 2026-08-16 against committed repository content at 9a92d12. Of the four reviewed paths, PR #26 changes only standards/51-architecture-integrity.md; scripts/compliance.mjs, scripts/catalog.mjs and test/compliance.test.mjs are byte-identical to 1fa3869. The R2 row is substantively unchanged: the edits replace the R1 worked-example reference from ADR 0007 to ADR 0014, which is a change to what R1 cites and not to what R2 requires. THE SEPARATION HOLDS AND WAS CHECKED RATHER THAN ASSUMED against the three ways this rule can actually be broken: the invocation-ownership refactor does not move rule identity into the evaluator, does not move applicability into the catalog, and does not move evidence production into the policy. The new CLI boundary and the invocation-owned run state are changes to which object owns a lifetime INSIDE the evaluator, which is internal ownership rather than a shortcut around one of the three boundaries. THE SYMLINK REPAIR IS NOT A BYPASS, and was examined as a candidate for one: the previous string comparison accidentally refused the package's own legitimate installed entrypoint and silently did nothing, exiting 0 without running; resolving canonical file identity makes that entrypoint reach the same CLI boundary as any other invocation rather than routing around it, and import inertness is preserved. The Linux regression verifies both halves — that the symlinked entrypoint executes and produces byte-identical output to direct invocation, and that importing by either path still runs nothing. LIMITATION CARRIED FORWARD UNCHANGED: the for convenience qualifier in this rule is a claim about intent, which the available evidence does not reach. This approval establishes the structural boundaries and does not confer a general ability to infer motive."
+        reference: "standards/51-architecture-integrity.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - scripts/compliance.mjs
+            - scripts/catalog.mjs
+            - test/compliance.test.mjs
+            - standards/51-architecture-integrity.md
+          revision: "9a92d12"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "17f517c0a61cf04f53535006fe1ab908"
 
   # Checkpoint item 10, the third REJECTED entry. Judged by the same standard as item 11: the
   # prohibited conduct occurred and reached shared history, and being caught does not unmake it.

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -15,7 +15,7 @@
  */
 
 import { readdir, readFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { loadCatalog, assertBindings, coverage } from "./catalog.mjs";
@@ -2524,6 +2524,36 @@ export async function main(args) {
 // testable against a fresh-process oracle, and it is the property ADR 0014 turns into a test.
 // ---------------------------------------------------------------------------
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Compared on canonical paths, because the two sides describe the same file in different
+// representations and a string comparison silently answered "no".
+//
+// `import.meta.url` is where Node *resolved* this module: loading an ESM entry point follows
+// symlinks. `process.argv[1]` is the path the process was *invoked* with, symlink intact. When this
+// package is installed, npm links `node_modules/.bin/standards` to `scripts/standards.mjs`, so the
+// two name the same file by different spellings, the comparison is false, and the CLI does nothing while
+// exiting 0.
+//
+// That is a false success at the one place consumers are told to gate their build (ADR 0004):
+// `standards validate` reporting no findings because it never ran, which is indistinguishable from
+// a clean repository to every caller. Reproduced on Linux before this was changed — invoked directly
+// the command exits 1 with a 2914-byte verdict; invoked through the bin link it exited 0 with no
+// output at all.
+//
+// Canonicalising does not widen what counts as direct invocation. It makes two spellings of one path
+// comparable; an imported module's `argv[1]` is the *importing* entry point, a genuinely different
+// real file, so importing this module still runs nothing. Both properties are asserted in
+// test/invocation-ownership.test.mjs — the symlink form must execute, and the import form must not.
+function invokedDirectly(argv1) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(SELF);
+  } catch {
+    // An unresolvable argv[1] is not this file being run. Falling back to the original comparison
+    // keeps that case behaving as it always did rather than inventing a new answer for it.
+    return import.meta.url === pathToFileURL(argv1).href;
+  }
+}
+
+if (invokedDirectly(process.argv[1])) {
   process.exitCode = (await main(process.argv.slice(2))).exitCode;
 }

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -16,7 +16,7 @@
 
 import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { loadCatalog, assertBindings, coverage } from "./catalog.mjs";
 import { evaluate, envelope } from "./compliance.mjs";
@@ -513,26 +513,28 @@ function regexLiteralEnd(text, open) {
   return -1;
 }
 
-/** Populated once per run, alongside `contents`, so the split cost is paid a single time. */
-const sources = new Map();
-const sourceOf = (f) => sources.get(f)?.code ?? "";
-const structureOf = (f) => sources.get(f)?.structure ?? "";
-const commentsOf = (f) => sources.get(f)?.comments ?? "";
-
 const MAX_FILES = 20000;
 const MAX_READ_BYTES = 400_000;
 const MAX_EVIDENCE = 12;
 
 // ---------------------------------------------------------------------------
 // Argument parsing
+//
+// Derived from the arguments the invocation was given, never from `process.argv` — ADR 0014. Reading
+// the process here would make the invocation's own configuration a property of the process, which is
+// the lifetime this design removes.
 // ---------------------------------------------------------------------------
 
-const argv = process.argv.slice(2);
-const subcommand = argv[0];
-const JSON_OUT = argv.includes("--json");
-const STRICT = argv.includes("--strict");
-const dirFlag = argv.find((a) => a.startsWith("--dir="))?.slice("--dir=".length);
-const positional = argv.slice(1).find((a) => !a.startsWith("--"));
+function parseArgs(argv) {
+  return {
+    argv,
+    subcommand: argv[0],
+    json: argv.includes("--json"),
+    strict: argv.includes("--strict"),
+    dirFlag: argv.find((a) => a.startsWith("--dir="))?.slice("--dir=".length),
+    positional: argv.slice(1).find((a) => !a.startsWith("--")),
+  };
+}
 
 function usage(stream = process.stderr) {
   stream.write(
@@ -567,15 +569,26 @@ const EXIT_OK = 0;
 const EXIT_FINDINGS = 1;
 const EXIT_INVOCATION = 2;
 
-if (!subcommand || subcommand === "--help" || subcommand === "-h") {
-  usage(process.stdout);
-  process.exit(subcommand ? EXIT_OK : EXIT_INVOCATION);
-}
 const COMMANDS = new Set(["audit", "validate", "init"]);
-if (!COMMANDS.has(subcommand)) {
-  process.stderr.write(`standards: unknown subcommand '${subcommand}'\n\n`);
-  usage();
-  process.exit(EXIT_INVOCATION);
+
+/**
+ * Returns an exit code when the invocation cannot proceed, and `null` when it can.
+ *
+ * It returns rather than exits. Nothing below the CLI boundary may terminate the process (ADR 0014):
+ * a helper that calls `process.exit` cannot be tested, cannot be called twice, and takes a decision
+ * that belongs to the caller.
+ */
+function checkInvocation({ subcommand }) {
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    usage(process.stdout);
+    return subcommand ? EXIT_OK : EXIT_INVOCATION;
+  }
+  if (!COMMANDS.has(subcommand)) {
+    process.stderr.write(`standards: unknown subcommand '${subcommand}'\n\n`);
+    usage();
+    return EXIT_INVOCATION;
+  }
+  return null;
 }
 
 /**
@@ -590,7 +603,6 @@ if (!COMMANDS.has(subcommand)) {
  * regardless of it. One command cannot hold both without a flag selecting which contract applies,
  * and a flag that changes the exit contract is a trap.
  */
-const VALIDATING = subcommand === "validate";
 
 // ---------------------------------------------------------------------------
 // init — bootstrap (Standard 33)
@@ -599,7 +611,7 @@ const VALIDATING = subcommand === "validate";
 // bootstrap command slower than the thing it bootstraps.
 // ---------------------------------------------------------------------------
 
-if (subcommand === "init") {
+async function runInit({ argv, dirFlag, positional, json }, emit) {
   const dryRun = argv.includes("--dry-run");
   const modeFlag = argv.find((a) => a.startsWith("--mode="))?.slice("--mode=".length) ?? null;
   const overwrite = argv
@@ -612,23 +624,23 @@ if (subcommand === "init") {
     report = await planInit(target, { mode: modeFlag, overwrite });
   } catch (error) {
     process.stderr.write(`standards init: ${error.message}\n`);
-    process.exit(EXIT_INVOCATION);
+    return EXIT_INVOCATION;
   }
 
   // The dry run and the real run share one computation, so the report cannot disagree with what
   // apply() then does (Standard 33 R5).
   if (!dryRun) await applyInit(target, report);
 
-  if (JSON_OUT) {
-    process.stdout.write(JSON.stringify({ ...report, dryRun }, null, 2) + "\n");
+  if (json) {
+    emit(JSON.stringify({ ...report, dryRun }, null, 2) + "\n");
   } else {
-    process.stdout.write(renderInit(report, { dryRun }) + "\n");
+    emit(renderInit(report, { dryRun }) + "\n");
   }
 
   // A conflict is unfinished work, not a failure of the command: nothing was changed and the
   // operator has to decide. Exit 1 so a script notices, distinct from 2 which means init could
   // not run at all.
-  process.exit(report.conflicts.length > 0 ? EXIT_FINDINGS : EXIT_OK);
+  return report.conflicts.length > 0 ? EXIT_FINDINGS : EXIT_OK;
 }
 
 // ---------------------------------------------------------------------------
@@ -646,15 +658,70 @@ function findRoot(start) {
   }
 }
 
-const target = dirFlag ?? positional ?? ".";
-if (!existsSync(target)) {
-  process.stderr.write(`standards: no such directory: ${target}\n`);
-  process.exit(EXIT_INVOCATION);
-}
-const root = dirFlag ? path.resolve(dirFlag) : findRoot(target);
+/**
+ * Everything one invocation owns, constructed once per run and passed explicitly — ADR 0014.
+ *
+ * **Construction, not reset.** Each object below is created here, per call. There is deliberately no
+ * `reset()` and no `clear()` at run start: clearing makes sequential runs look independent while
+ * leaving two concurrent runs sharing one object, and only an identity assertion can tell those two
+ * situations apart. Creating removes the possibility instead of policing it.
+ *
+ * **What is NOT here.** Frozen lookup tables, extension sets and matching configuration stay at
+ * module scope. Their values do not depend on which repository is being audited and they have no
+ * mutation sites; the invariant is that no *execution-specific* mutable state outlives its
+ * invocation, not that module scope is empty.
+ *
+ * `sources` is here because it is execution-specific: its values are the audited project's file
+ * contents, so the same key yields a different correct value for a different target.
+ */
+function createRun({ root, strict, json }) {
+  const findings = [];
+  const sources = new Map();
 
-/** Repo-relative path with forward slashes, so output is stable across platforms. */
-const rel = (p) => path.relative(root, p).split(path.sep).join("/");
+  return {
+    root,
+    strict,
+    json,
+    findings,
+    sources,
+
+    /** Repo-relative path with forward slashes, so output is stable across platforms. */
+    rel: (p) => path.relative(root, p).split(path.sep).join("/"),
+
+    has: (p) => existsSync(path.join(root, p)),
+
+    sourceOf: (f) => sources.get(f)?.code ?? "",
+    structureOf: (f) => sources.get(f)?.structure ?? "",
+    commentsOf: (f) => sources.get(f)?.comments ?? "",
+
+    /**
+     * `label` is the Standard 44 evidence label and is not decorative. A detection that rests on a
+     * file existing at a path with a defined meaning is OBSERVED. A detection that rests on matching
+     * a naming convention or a content pattern is INFERRED — reporting a heuristic as observed is the
+     * fabrication error R2 prohibits.
+     *
+     * This remains the only writer of `findings`, which is what keeps the accumulator auditable. The
+     * single-writer property ADR 0007 identified is preserved; what changed is the lifetime.
+     */
+    addFinding({ id, category, severity = "info", label, evidence, message, standardRef, rule }) {
+      const shown = evidence.slice(0, MAX_EVIDENCE);
+      const omitted = evidence.length - shown.length;
+      findings.push({
+        id,
+        category,
+        severity,
+        label,
+        evidence: shown,
+        message: omitted > 0 ? `${message} (${evidence.length} total; ${omitted} not listed)` : message,
+        standardRef: standardRef ?? R.baseline,
+        // The canonical rule this finding is evidence for (Standard 26, ADR 0002). Descriptive
+        // "observed/detected" findings carry none: they report what the repository HAS, not whether
+        // it complies, and binding them to a rule would manufacture a verdict out of an observation.
+        rule: rule ?? null,
+      });
+    },
+  };
+}
 
 /**
  * Walk the tree, recording what could not be walked.
@@ -670,7 +737,8 @@ const rel = (p) => path.relative(root, p).split(path.sep).join("/");
  * loss is that an exclusion is a *decision* about what is not the project's code, and a decision
  * nobody can see is indistinguishable from a tool that quietly went blind.
  */
-async function collectFiles(dir, acc, loss, excluded) {
+async function collectFiles(dir, acc, loss, excluded, run) {
+  const { root, rel } = run;
   if (acc.length >= MAX_FILES) {
     loss.capped = true;
     return acc;
@@ -704,7 +772,7 @@ async function collectFiles(dir, acc, loss, excluded) {
         loss.excluded.push({ path: rel(full), reason: "ignored by the repository" });
         continue;
       }
-      await collectFiles(full, acc, loss, excluded);
+      await collectFiles(full, acc, loss, excluded, run);
     } else if (entry.isFile()) {
       // Ignored FILES are dropped without a per-file record. A generated artifact sitting beside
       // tracked code is not a surface anyone expected to be audited, and listing each one would
@@ -740,33 +808,11 @@ async function readText(file) {
 
 // ---------------------------------------------------------------------------
 // Finding construction
+//
+// `findings` and its single writer `addFinding` live on the run object (`createRun`), because the
+// accumulator belongs to the invocation that produced it. Detectors receive the run and destructure
+// what they need; none of them touches the array directly.
 // ---------------------------------------------------------------------------
-
-const findings = [];
-
-/**
- * `label` is the Standard 44 evidence label and is not decorative. A detection that rests on a file
- * existing at a path with a defined meaning is OBSERVED. A detection that rests on matching a naming
- * convention or a content pattern is INFERRED — reporting a heuristic as observed is the fabrication
- * error R2 prohibits.
- */
-function addFinding({ id, category, severity = "info", label, evidence, message, standardRef, rule }) {
-  const shown = evidence.slice(0, MAX_EVIDENCE);
-  const omitted = evidence.length - shown.length;
-  findings.push({
-    id,
-    category,
-    severity,
-    label,
-    evidence: shown,
-    message: omitted > 0 ? `${message} (${evidence.length} total; ${omitted} not listed)` : message,
-    standardRef: standardRef ?? R.baseline,
-    // The canonical rule this finding is evidence for (Standard 26, ADR 0002). Descriptive
-    // "observed/detected" findings carry none: they report what the repository HAS, not whether it
-    // complies, and binding them to a rule would manufacture a verdict out of an observation.
-    rule: rule ?? null,
-  });
-}
 
 const uniq = (xs) => [...new Set(xs)].sort();
 
@@ -779,7 +825,8 @@ const MANIFESTS = [
   "pom.xml", "build.gradle", "build.gradle.kts", "Gemfile", "composer.json",
 ];
 
-function detectArchitecture(files, contents) {
+function detectArchitecture(files, contents, run) {
+  const { rel, addFinding } = run;
   const archDoc = files.find((f) => rel(f).toLowerCase() === "docs/architecture.md");
   if (archDoc) {
     addFinding({
@@ -813,7 +860,8 @@ function detectArchitecture(files, contents) {
   });
 }
 
-function detectCapabilities(files, contents) {
+function detectCapabilities(files, contents, run) {
+  const { rel, addFinding } = run;
   const evidence = [];
   const notes = [];
 
@@ -867,7 +915,8 @@ const API_CONTENT = [
   /func\s+\w*Handler\s*\(\s*w\s+http\.ResponseWriter/,
 ];
 
-function detectApis(files, contents) {
+function detectApis(files, contents, run) {
+  const { rel, addFinding, structureOf } = run;
   const specs = files.filter((f) =>
     /(^|\/)(openapi|swagger)\.(ya?ml|json)$/i.test(rel(f)),
   );
@@ -918,7 +967,8 @@ const JOB_CONTENT = [
  */
 const JOB_PACKAGES = "celery|sidekiq|bullmq|bull|agenda|node-cron|apscheduler|resque";
 
-function detectJobs(files, contents) {
+function detectJobs(files, contents, run) {
+  const { rel, addFinding, structureOf, sourceOf } = run;
   const workflowCron = files.filter((f) => {
     if (!/\.github\/workflows\/.*\.ya?ml$/.test(rel(f))) return false;
     const text = contents.get(f) ?? "";
@@ -973,7 +1023,8 @@ const INTEGRATION_SDK = [
   ["@slack/|slack_sdk", "Slack"], ["octokit|PyGithub", "GitHub"],
 ];
 
-function detectIntegrations(files, contents) {
+function detectIntegrations(files, contents, run) {
+  const { rel, addFinding, sourceOf } = run;
   const envTemplates = files.filter((f) =>
     /(^|\/)\.env\.(example|template|sample)$|(^|\/)appsettings\.(Example|Template)\.json$/i.test(rel(f)),
   );
@@ -1024,7 +1075,8 @@ const AI_SDK = [
   ["mistralai", "Mistral"],
 ];
 
-function detectAiInterfaces(files, contents) {
+function detectAiInterfaces(files, contents, run) {
+  const { rel, addFinding, sourceOf } = run;
   const skillFiles = files.filter((f) => /(^|\/)SKILL\.md$/.test(rel(f)));
   const promptFiles = files.filter((f) => /(^|\/)prompts?\//i.test(rel(f)) || /prompt.*\.md$/i.test(rel(f)));
   const declared = [...skillFiles, ...promptFiles];
@@ -1066,14 +1118,14 @@ function detectAiInterfaces(files, contents) {
 // Detectors — absence, unfinished work, and discrepancy
 // ---------------------------------------------------------------------------
 
-const has = (p) => existsSync(path.join(root, p));
 const TEST_RE = /(^|\/)(tests?|spec|__tests__)\/|\.(test|spec)\.[jt]sx?$|_test\.(go|py)$|Tests?\.cs$|test_.*\.py$/i;
 const CI_FILES = [
   ".github/workflows", "azure-pipelines.yml", ".gitlab-ci.yml", "Jenkinsfile",
   ".circleci/config.yml", ".travis.yml", "bitbucket-pipelines.yml",
 ];
 
-function detectMissingDocs(files, contents) {
+function detectMissingDocs(files, contents, run) {
+  const { rel, addFinding } = run;
   const missing = [];
   if (!files.some((f) => rel(f).toLowerCase() === "docs/architecture.md")) missing.push("docs/architecture.md");
   const readme = files.find((f) => /^readme\.md$/i.test(rel(f)));
@@ -1098,7 +1150,8 @@ function detectMissingDocs(files, contents) {
  * the file existing is not the same as the file being correct or current, and the catalog says so
  * rather than leaving a reader to infer it (Standard 24 R2).
  */
-function detectArchitectureArtifacts() {
+function detectArchitectureArtifacts(run) {
+  const { has, addFinding } = run;
   const manifest = ["PROJECT.md", "artifacts/project-manifest.md"];
   if (!manifest.some((f) => has(f))) {
     addFinding({
@@ -1151,7 +1204,8 @@ function detectArchitectureArtifacts() {
  * plan or an untouched template is a judgement no scan makes, and Standard 44's Implementation
  * section says so rather than implying this check covers it.
  */
-function detectMissingPlanningArtifacts(files, contents) {
+function detectMissingPlanningArtifacts(files, contents, run) {
+  const { has, addFinding, rel } = run;
   const dir = "artifacts/project-plan-breakdown";
   if (!has(dir)) {
     addFinding({
@@ -1198,7 +1252,8 @@ function detectMissingPlanningArtifacts(files, contents) {
   }
 }
 
-function detectMissingAuditInfrastructure(files) {
+function detectMissingAuditInfrastructure(files, run) {
+  const { rel, has, addFinding } = run;
   const tests = files.filter((f) => TEST_RE.test(rel(f)));
   const ci = CI_FILES.filter((c) => has(c));
   const missing = [];
@@ -1218,7 +1273,8 @@ function detectMissingAuditInfrastructure(files) {
   });
 }
 
-function detectUnverifiedFunctionality(files) {
+function detectUnverifiedFunctionality(files, run) {
+  const { rel, findings, addFinding } = run;
   const tests = files.filter((f) => TEST_RE.test(rel(f)));
   if (tests.length > 0) return; // per-capability coverage mapping is not attempted; see the report note
   const capabilities = findings.filter((f) =>
@@ -1267,7 +1323,8 @@ const UNFINISHED_CODE = [
   [/\b(it|test|describe)\.skip\(|\bxit\(|@pytest\.mark\.skip|\[Ignore\]|\bt\.Skip\(/, "skipped tests"],
 ];
 
-function detectUnfinished(files) {
+function detectUnfinished(files, run) {
+  const { rel, commentsOf, structureOf, addFinding } = run;
   const byKind = new Map();
   const record = (kind, f) => {
     if (!byKind.has(kind)) byKind.set(kind, []);
@@ -1296,7 +1353,8 @@ function detectUnfinished(files) {
 
 const ENTRYISH = /(^|\/)(index|main|app|Program|Startup|__init__|__main__|setup|conftest)\.[a-z]+$/i;
 
-function detectDeadCode(files, contents) {
+function detectDeadCode(files, contents, run) {
+  const { rel, addFinding } = run;
   const candidates = files.filter((f) => {
     const r = rel(f);
     if (!/\.(m?[jt]sx?|py|cs|go|rb)$/.test(r)) return false;
@@ -1330,7 +1388,8 @@ function detectDeadCode(files, contents) {
   });
 }
 
-function detectOpenQuestions(files, contents) {
+function detectOpenQuestions(files, contents, run) {
+  const { rel, addFinding } = run;
   const qFile = files.find((f) => rel(f) === "artifacts/project-baseline/open-questions.md");
   if (!qFile) return;
   const text = contents.get(qFile) ?? "";
@@ -1406,7 +1465,8 @@ const canonicalStatus = (raw) => {
   return STATUS_ALIASES[first.toLowerCase()] ?? upper;
 };
 
-async function detectPlanDiscrepancies(files, contents) {
+async function detectPlanDiscrepancies(files, contents, run) {
+  const { rel, root, addFinding } = run;
   const planFiles = files.filter((f) => /^artifacts\/project-plan-breakdown\/.+\.md$/.test(rel(f)));
   if (planFiles.length === 0) return;
 
@@ -1527,7 +1587,8 @@ function looksLikeRepositoryPath(p) {
   return true;
 }
 
-function detectDocDiscrepancies(files, contents) {
+function detectDocDiscrepancies(files, contents, run) {
+  const { rel, root, addFinding } = run;
   const readme = files.find((f) => /^readme\.md$/i.test(rel(f)));
   if (!readme) return;
   const text = contents.get(readme) ?? "";
@@ -1566,7 +1627,8 @@ function detectDocDiscrepancies(files, contents) {
   });
 }
 
-function detectStandardsViolations(files, contents) {
+function detectStandardsViolations(files, contents, run) {
+  const { has, rel, addFinding } = run;
   const violations = [];
   if (has("artifacts/project-baseline")) {
     if (!has("artifacts/project-baseline/reconstructed-baseline.md")) {
@@ -1650,7 +1712,8 @@ const ENV_PERMITTED = /\.(example|template|sample|vault)$/;
 // environment files. One definition of what counts, in the detector that owns it.
 const ENV_PATHSPECS = ["*.env*"];
 
-function detectCommittedEnvFiles(files, repoRoot, repo) {
+function detectCommittedEnvFiles(files, repoRoot, repo, run) {
+  const { rel, addFinding } = run;
   const isCandidate = (p) => ENV_FILE_RE.test(p) && !ENV_PERMITTED.test(p);
 
   // Present on disk, and used only to describe what a reader can see when the index cannot be read.
@@ -1728,7 +1791,8 @@ const SECRET_PATTERNS = [
   [/\bsk_live_[A-Za-z0-9]{16,}/, "Stripe live secret key"],
 ];
 
-function detectSecretsInArtifacts(files, contents) {
+function detectSecretsInArtifacts(files, contents, run) {
+  const { rel, sourceOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     const p = rel(f);
@@ -1830,7 +1894,8 @@ function carriesJustification(raw, structure, from, to) {
  * still holds the justification comment, because that is the one thing the structural view removes.
  * The span is what binds them: two readings of one site, not two searches of one file.
  */
-function detectSwallowedExceptions(files, contents) {
+function detectSwallowedExceptions(files, contents, run) {
+  const { rel, structureOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
@@ -1891,7 +1956,8 @@ const CERT_BYPASS = [
   /ServerCertificateCustomValidationCallback\s*=\s*[^;]*=>\s*true/,
 ];
 
-function detectCertBypass(files) {
+function detectCertBypass(files, run) {
+  const { rel, structureOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
@@ -1936,7 +2002,8 @@ const SQL_STATEMENT = String.raw`(SELECT\b[\s\S]*?\bFROM|INSERT\s+INTO|UPDATE\b[
 const SQL_TEMPLATE = new RegExp("`[^`]*\\b" + SQL_STATEMENT + "\\b[^`]*\\$\\{[^}]+\\}[^`]*`", "i");
 const SQL_FSTRING = new RegExp('f["\'][^"\']*\\b' + SQL_STATEMENT + '\\b[^"\']*\\{[^}]+\\}[^"\']*["\']', "i");
 
-function detectSqlConcat(files) {
+function detectSqlConcat(files, run) {
+  const { rel, sourceOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
@@ -1960,7 +2027,8 @@ function detectSqlConcat(files) {
 
 const SEVERITY_ORDER = { error: 0, warning: 1, info: 2 };
 
-function renderHuman(fileCount, surface) {
+function renderHuman(fileCount, surface, run) {
+  const { root, findings, strict } = run;
   const lines = [];
   lines.push(`standards audit — ${path.basename(root)} (${root.split(path.sep).join("/")})`);
   lines.push(`${fileCount} file(s) scanned, ${findings.length} finding(s).`);
@@ -2032,376 +2100,430 @@ function renderHuman(fileCount, surface) {
   lines.push("clean run means nothing matched the patterns — not that the repository is compliant.");
   lines.push("Per-capability test coverage, dead-code reachability, and most standards requirements");
   lines.push("are not mechanically checked. See design/standards-audit-cli.md.");
-  if (STRICT && failing > 0) lines.push(`--strict: exiting 1 because ${failing} finding(s) need attention.`);
+  if (strict && failing > 0) lines.push(`--strict: exiting 1 because ${failing} finding(s) need attention.`);
   return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Main — one invocation, start to finish
+//
+// Every mutable object below is created here and dies here (ADR 0014). `main` returns an exit code
+// rather than calling process.exit, so it can be called twice, called concurrently, and compared
+// against a fresh-process run. Only the CLI boundary at the foot of this file terminates anything.
 // ---------------------------------------------------------------------------
 
-const surfaceLoss = { dirs: [], capped: false, excluded: [] };
+export async function main(args) {
+  /**
+   * Returns `{ exitCode, stdout, run, surface }`, not a bare code.
+   *
+   * The extra fields exist so independence can be *falsified*. A concurrency test that compares
+   * against a globally patched `process.stdout.write` cannot distinguish two independent runs from
+   * two interleaved ones, so each invocation hands back the bytes it wrote and the objects it owned,
+   * and the test compares those. They are observation, not CLI surface: the rendered JSON envelope
+   * is unchanged, and no consumer reads these.
+   */
+  const written = [];
+  const emit = (s) => {
+    written.push(String(s));
+    return process.stdout.write(s);
+  };
+  let run = null;
+  let surface = null;
+  const done = (exitCode) => ({ exitCode, stdout: written.join(""), run, surface });
 
-// What the repository already treats as not-its-own. Asked before the walk so the answer costs one
-// subprocess rather than one per candidate directory, and so an unavailable repository degrades to
-// "exclude nothing" in one place instead of at every decision point.
-const ignored = ignoredEntries(root);
-const exclusions = {
-  dirs: new Set(ignored.ok ? ignored.directories : []),
-  files: new Set(ignored.ok ? ignored.files : []),
-};
-const files = await collectFiles(root, [], surfaceLoss, exclusions);
-const contents = new Map();
-const unreadableFiles = [];
-const truncatedFiles = [];
-for (const f of files) {
-  if (!TEXT_EXT.has(path.extname(f))) continue;
-  const read = await readText(f);
-  if (!read.ok) unreadableFiles.push(f);
-  else if (read.truncated) truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
-  contents.set(f, read.text);
-  if (isCode(f)) sources.set(f, splitSource(read.text, path.extname(f)));
-}
+  const cli = parseArgs(args);
+  const invalid = checkInvocation(cli);
+  if (invalid !== null) return done(invalid);
 
-// Evidence-surface findings: what the audit could NOT search.
-//
-// These carry `rule: null` deliberately. Evidence loss is a property of the run, not a violation by
-// the project, and binding it to a rule would make one unreadable file fail every rule whose
-// detector would have read it — one defect producing dozens of findings, and a second compliance
-// owner for every detector in the file. Detector results stay scoped to what they actually saw;
-// this says how much that was.
-if (unreadableFiles.length) {
-  addFinding({
-    id: "evidence-unreadable-file",
-    category: "evidence-surface",
-    severity: "warning",
-    label: "OBSERVED",
-    evidence: uniq(unreadableFiles.map(rel)),
-    message: `${unreadableFiles.length} file(s) could not be read. Nothing was searched in them, so no clean result covers them.`,
-    standardRef: R.search,
-  });
-}
-if (surfaceLoss.dirs.length) {
-  addFinding({
-    id: "evidence-unreadable-dir",
-    category: "evidence-surface",
-    severity: "warning",
-    label: "OBSERVED",
-    evidence: uniq(surfaceLoss.dirs.map(rel)),
-    message: `${surfaceLoss.dirs.length} directory(ies) could not be listed. Anything beneath them is outside every result in this run.`,
-    standardRef: R.search,
-  });
-}
-if (truncatedFiles.length) {
-  addFinding({
-    id: "evidence-truncated-file",
-    category: "evidence-surface",
-    // Informational rather than a warning: the cap is a deliberate bound, not a fault, and findings
-    // from the prefix are kept. What it must never be is invisible.
-    severity: "info",
-    label: "OBSERVED",
-    evidence: uniq(truncatedFiles),
-    message: `${truncatedFiles.length} file(s) exceeded the ${MAX_READ_BYTES}-byte read cap and were searched in part.`,
-    standardRef: R.search,
-  });
-}
-if (surfaceLoss.capped) {
-  addFinding({
-    id: "evidence-file-cap",
-    category: "evidence-surface",
-    severity: "warning",
-    label: "OBSERVED",
-    evidence: [`${MAX_FILES} file limit`],
-    message: `The walk stopped at the ${MAX_FILES}-file cap. Files beyond it were never collected and are outside every result in this run.`,
-    standardRef: R.search,
-  });
-}
-// Exclusions are reported through the envelope and the header, deliberately NOT as a finding.
-//
-// A finding carries `evidence`, and evidence is read as "paths this run has something to say
-// about". An excluded tree is the opposite: the run has nothing to say about it, by decision. Every
-// consumer that scans findings for paths — including this repository's own regression that a
-// vendored tree must not appear in the findings — would read the exclusion record as the very
-// pollution it exists to prevent, and could not tell the two apart.
-//
-// So it goes where the other properties-of-the-run live, beside `fileCapReached`, and the header
-// states it in the same breath as the scanned count.
-const evidenceSurface = {
-  complete: !unreadableFiles.length && !surfaceLoss.dirs.length && !truncatedFiles.length && !surfaceLoss.capped,
-  unreadableFiles: uniq(unreadableFiles.map(rel)),
-  unreadableDirectories: uniq(surfaceLoss.dirs.map(rel)),
-  truncatedFiles: uniq(truncatedFiles),
-  fileCapReached: surfaceLoss.capped,
-  excludedDirectories: surfaceLoss.excluded,
-  // Recorded because the exclusion set is only as good as the source that produced it. A run with
-  // no repository excluded nothing, and a reader comparing two runs needs to know which they have.
-  exclusionsFrom: ignored.ok ? "repository" : "unavailable",
-};
+  if (cli.subcommand === "init") return done(await runInit(cli, emit));
 
-// Descriptive first: detectUnverifiedFunctionality reads the capability findings they produce.
-detectArchitecture(files, contents);
-detectCapabilities(files, contents);
-detectApis(files, contents);
-detectJobs(files, contents);
-detectIntegrations(files, contents);
-detectAiInterfaces(files, contents);
-
-detectMissingDocs(files, contents);
-detectArchitectureArtifacts();
-detectMissingPlanningArtifacts(files, contents);
-detectMissingAuditInfrastructure(files);
-detectUnverifiedFunctionality(files);
-detectUnfinished(files);
-detectDeadCode(files, contents);
-detectOpenQuestions(files, contents);
-await detectPlanDiscrepancies(files, contents);
-detectDocDiscrepancies(files, contents);
-detectStandardsViolations(files, contents);
-
-// Availability is probed once and shared: the env detector and attestation freshness both need the
-// repository, and asking twice would spend a second subprocess to learn the same thing.
-const repoAvailability = repositoryAvailable(root);
-const envCheck = detectCommittedEnvFiles(files, root, repoAvailability);
-detectSecretsInArtifacts(files, contents);
-detectSwallowedExceptions(files, contents);
-detectCertBypass(files);
-detectSqlConcat(files);
-
-// ---------------------------------------------------------------------------
-// Verdict — catalog + policy + findings (Standards 25, 27, 30)
-//
-// The three-way separation is deliberate and must not be violated here: the catalog defines rule
-// identity and metadata, project-policy.yml defines what applies to THIS project, and everything
-// above produces evidence. Nothing in this section redefines a rule or invents applicability.
-
-const catalog = await loadCatalog();
-assertBindings(
-  catalog,
-  findings.map((f) => f.rule).filter(Boolean),
-);
-
-if (!VALIDATING) {
-  // audit: evidence only. No status, no score, no policy required — ADR 0004.
-  if (JSON_OUT) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          schemaVersion: SCHEMA_VERSION,
-          repo: root.split(path.sep).join("/"),
-          auditedAt: new Date().toISOString(),
-          // What the run could not search. Additive field: a consumer that ignores it reads the
-          // findings exactly as before, and one that reads it can tell a clean result from an
-          // unexamined one.
-          evidenceSurface,
-          findings,
-        },
-        null,
-        2,
-      ) + "\n",
-    );
-  } else {
-    process.stdout.write(renderHuman(files.length, evidenceSurface) + "\n");
-    process.stdout.write(
-      "\nThis is evidence, not a verdict. Run `standards validate` for a compliance status.\n",
-    );
+  const target = cli.dirFlag ?? cli.positional ?? ".";
+  if (!existsSync(target)) {
+    process.stderr.write(`standards: no such directory: ${target}\n`);
+    return done(EXIT_INVOCATION);
   }
-  process.exit(STRICT && findings.some((f) => f.severity !== "info") ? EXIT_FINDINGS : EXIT_OK);
-}
+  const root = cli.dirFlag ? path.resolve(cli.dirFlag) : findRoot(target);
+  const validating = cli.subcommand === "validate";
 
-// ---------------------------------------------------------------------------
-// validate — the verdict (Standards 25, 27, 30)
-//
-// The three-way separation must not be violated here: the catalog defines rule identity and
-// metadata, project-policy.yml defines what applies to THIS project, and everything above produces
-// evidence. Nothing in this section redefines a rule or invents applicability.
+  run = createRun({ root, strict: cli.strict, json: cli.json });
+  const { rel, findings, sources, addFinding } = run;
 
-const policy = await loadProjectPolicy(root);
+  const surfaceLoss = { dirs: [], capped: false, excluded: [] };
 
-/**
- * The version-identity guard — a verdict may not be reported for version X unless the framework
- * executing the run identifies itself as X.
- *
- * `standardVersion` declares which framework version governs a project, and nothing resolves that
- * declaration: every run evaluates against the catalog on disk, whichever version that happens to
- * be. While this repository was the framework's only consumer the two were the same working tree
- * and could not disagree, so the gap was recorded and deferred (Standard 21 R5).
- *
- * Distribution ends that. Once a project pins a version and a workflow checks out a ref, the pin
- * and the ref are independent sources of truth: a policy declaring 2.0.0 can be evaluated by 2.1.0,
- * and the envelope would carry `standardVersion: "2.0.0"` beside a verdict the 2.0.0 rule set never
- * produced. That is not a compliance failure — it is a provenance lie, and a verdict that misstates
- * which rules produced it is the false green this tool exists to refuse.
- *
- * This is an honesty guard, NOT historical rule-set resolution. It detects the disagreement and
- * stops; it cannot evaluate the declared version, and does not pretend to. Standard 21 R5 remains
- * unimplemented and this narrows rather than closes it.
- *
- * Exit 2, beside the unreadable-policy case below: the policy and the framework disagree about what
- * is being evaluated, which is a configuration error. Exit 1 would assert the project failed a
- * rule, and no rule was reached. No envelope is emitted in either output mode — an envelope carries
- * a `status`, and that status is precisely the claim that must not be made. The JSON branch emits a
- * typed error instead of nothing, so a consumer parsing stdout gets a loud object rather than a
- * parse failure it might mistake for an empty result.
- *
- * A missing or malformed `standardVersion` cannot reach here: the schema makes it required and pins
- * it to a full semver triple, so loadProjectPolicy() has already returned `document: null` and the
- * configuration path below owns that case. The guard is deliberately confined to `validate` —
- * `audit` reports evidence and claims no standards version, so widening it there would attach a
- * version precondition to a command whose contract does not depend on one.
- */
-const FRAMEWORK_VERSION = (
-  await readFile(path.join(path.dirname(SELF), "..", "VERSION"), "utf8")
-).trim();
-const declaredVersion = policy.document?.standardVersion;
-
-if (declaredVersion && declaredVersion !== FRAMEWORK_VERSION) {
-  const message =
-    `project-policy.yml declares standardVersion ${declaredVersion}, but the framework executing ` +
-    `this run is ${FRAMEWORK_VERSION}. No verdict was produced: a compliance status reported under ` +
-    `a version that did not evaluate it would misstate its own provenance.`;
-  if (JSON_OUT) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          error: "VERSION_MISMATCH",
-          policyStandardVersion: declaredVersion,
-          frameworkVersion: FRAMEWORK_VERSION,
-          message,
-          historicalResolution: "not implemented (Standard 21 R5)",
-        },
-        null,
-        2,
-      ) + "\n",
-    );
-  } else {
-    process.stderr.write(
-      `VERSION_MISMATCH\n  ${message}\n\n` +
-        `  Resolving a historical rule set is not implemented (Standard 21 R5), so this run cannot\n` +
-        `  evaluate ${declaredVersion}. Either execute the framework at ${declaredVersion}, or update\n` +
-        `  project-policy.yml to ${FRAMEWORK_VERSION} deliberately and review the failures the newer\n` +
-        `  rule set reports. Upgrading the governing version is an engineering event, not a default.\n`,
-    );
+  // What the repository already treats as not-its-own. Asked before the walk so the answer costs one
+  // subprocess rather than one per candidate directory, and so an unavailable repository degrades to
+  // "exclude nothing" in one place instead of at every decision point.
+  const ignored = ignoredEntries(root);
+  const exclusions = {
+    dirs: new Set(ignored.ok ? ignored.directories : []),
+    files: new Set(ignored.ok ? ignored.files : []),
+  };
+  const files = await collectFiles(root, [], surfaceLoss, exclusions, run);
+  const contents = new Map();
+  // The repository surface this invocation measured. Named so two runs can be compared by identity.
+  surface = { files, contents, surfaceLoss };
+  const unreadableFiles = [];
+  const truncatedFiles = [];
+  for (const f of files) {
+    if (!TEXT_EXT.has(path.extname(f))) continue;
+    const read = await readText(f);
+    if (!read.ok) unreadableFiles.push(f);
+    else if (read.truncated) truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
+    contents.set(f, read.text);
+    if (isCode(f)) sources.set(f, splitSource(read.text, path.extname(f)));
   }
-  process.exit(EXIT_INVOCATION);
-}
 
-/**
- * Digest the paths each attestation says it reviewed, so a material change to them makes the
- * attestation stale (ADR 0005 rule 4).
- *
- * Content-based rather than revision-based on purpose: invalidating every attestation on every
- * commit would make the mechanism unusable, and it would be abandoned. Digesting what was actually
- * reviewed invalidates on material change, which is the real requirement.
- */
-function attestationFreshness(document, repoRoot, repo) {
-  const out = new Map();
-  for (const [ruleId, record] of Object.entries(document?.attestations ?? {})) {
-    // Freshness describes what may establish the rule now, so it is computed for the newest review
-    // event. Earlier events keep their own recorded provenance and are reported by
-    // `npm run attestations`; they are history, and history does not go stale.
-    const against = currentReview(ruleId, record)?.reviewedAgainst;
-    if (!against?.paths?.length) continue;
-    out.set(ruleId, classifyFreshness(repoRoot, against, repo));
+  // Evidence-surface findings: what the audit could NOT search.
+  //
+  // These carry `rule: null` deliberately. Evidence loss is a property of the run, not a violation by
+  // the project, and binding it to a rule would make one unreadable file fail every rule whose
+  // detector would have read it — one defect producing dozens of findings, and a second compliance
+  // owner for every detector in the file. Detector results stay scoped to what they actually saw;
+  // this says how much that was.
+  if (unreadableFiles.length) {
+    addFinding({
+      id: "evidence-unreadable-file",
+      category: "evidence-surface",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: uniq(unreadableFiles.map(rel)),
+      message: `${unreadableFiles.length} file(s) could not be read. Nothing was searched in them, so no clean result covers them.`,
+      standardRef: R.search,
+    });
   }
-  return { states: out, repo };
-}
-
-const { states: freshness, repo } = attestationFreshness(policy.document, root, repoAvailability);
-
-// Repository content is the source of truth for attestation freshness, and its absence is a fact
-// about the search mechanism rather than about the project (Standard 44 R12). It is reported as an
-// infrastructure finding carrying no rule, exactly as evidence-surface loss is, so that it can never
-// become a second compliance owner — the affected attestations independently fail to establish their
-// rules, and that is where the compliance consequence lives. It does not exit 2: one unavailable
-// provenance source must not discard every other result the run established.
-if (!repo.available && freshness.size > 0) {
-  addFinding({
-    id: "repository-evidence-unavailable",
-    category: "evidence-surface",
-    severity: "warning",
-    label: "OBSERVED",
-    evidence: [...freshness.keys()],
-    message:
-      `Attestation freshness could not be established for ${freshness.size} rule(s): ${repo.reason}. ` +
-      `Repository content identifies what was reviewed; without it, no approval establishes a rule.`,
-    standardRef: R.search,
-  });
-}
-// A rule whose evidence could not be obtained was not evaluated this run, whatever the static set
-// says. Withdrawing it here rather than letting it report a clean pass is what keeps `nobody could
-// look` distinct from `nobody found anything` — a distinction that matters most for a `forbidden`
-// rule, which is satisfied by absence and would otherwise pass precisely when it knows least
-// (Standard 45 R6).
-const evaluatedThisRun = EVALUATED_RULES.filter(
-  (id) => !(id === "scm.no-committed-env-files" && envCheck.evaluated === false),
-);
-
-const verdict = evaluate({
-  catalog,
-  policy: policy.document,
-  findings,
-  evaluated: evaluatedThisRun,
-  today: new Date().toISOString().slice(0, 10),
-  freshness,
-});
-
-// Framework maturity, read from this framework's own inventory rather than the target repository.
-// It travels beside the verdict and never inside it: a coverage improvement must never be able to
-// look like a compliance improvement.
-const totalStandards = await (async () => {
-  try {
-    const inventoryPath = path.join(path.dirname(SELF), "..", "artifacts/standards-source-inventory.json");
-    const inv = JSON.parse(await readFile(inventoryPath, "utf8"));
-    return inv.expectedCount ?? inv.standards?.length ?? null;
-  } catch {
-    return null;
+  if (surfaceLoss.dirs.length) {
+    addFinding({
+      id: "evidence-unreadable-dir",
+      category: "evidence-surface",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: uniq(surfaceLoss.dirs.map(rel)),
+      message: `${surfaceLoss.dirs.length} directory(ies) could not be listed. Anything beneath them is outside every result in this run.`,
+      standardRef: R.search,
+    });
   }
-})();
+  if (truncatedFiles.length) {
+    addFinding({
+      id: "evidence-truncated-file",
+      category: "evidence-surface",
+      // Informational rather than a warning: the cap is a deliberate bound, not a fault, and findings
+      // from the prefix are kept. What it must never be is invisible.
+      severity: "info",
+      label: "OBSERVED",
+      evidence: uniq(truncatedFiles),
+      message: `${truncatedFiles.length} file(s) exceeded the ${MAX_READ_BYTES}-byte read cap and were searched in part.`,
+      standardRef: R.search,
+    });
+  }
+  if (surfaceLoss.capped) {
+    addFinding({
+      id: "evidence-file-cap",
+      category: "evidence-surface",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: [`${MAX_FILES} file limit`],
+      message: `The walk stopped at the ${MAX_FILES}-file cap. Files beyond it were never collected and are outside every result in this run.`,
+      standardRef: R.search,
+    });
+  }
+  // Exclusions are reported through the envelope and the header, deliberately NOT as a finding.
+  //
+  // A finding carries `evidence`, and evidence is read as "paths this run has something to say
+  // about". An excluded tree is the opposite: the run has nothing to say about it, by decision. Every
+  // consumer that scans findings for paths — including this repository's own regression that a
+  // vendored tree must not appear in the findings — would read the exclusion record as the very
+  // pollution it exists to prevent, and could not tell the two apart.
+  //
+  // So it goes where the other properties-of-the-run live, beside `fileCapReached`, and the header
+  // states it in the same breath as the scanned count.
+  const evidenceSurface = {
+    complete: !unreadableFiles.length && !surfaceLoss.dirs.length && !truncatedFiles.length && !surfaceLoss.capped,
+    unreadableFiles: uniq(unreadableFiles.map(rel)),
+    unreadableDirectories: uniq(surfaceLoss.dirs.map(rel)),
+    truncatedFiles: uniq(truncatedFiles),
+    fileCapReached: surfaceLoss.capped,
+    excludedDirectories: surfaceLoss.excluded,
+    // Recorded because the exclusion set is only as good as the source that produced it. A run with
+    // no repository excluded nothing, and a reader comparing two runs needs to know which they have.
+    exclusionsFrom: ignored.ok ? "repository" : "unavailable",
+  };
 
-const report = envelope({
-  verdict,
-  project: policy.document?.project,
-  standardVersion: policy.document?.standardVersion,
-  auditedAt: new Date().toISOString(),
-  repo: root.split(path.sep).join("/"),
-  frameworkCoverage: coverage(catalog, { evaluated: EVALUATED_RULES, totalStandards }),
-});
+  // Descriptive first: detectUnverifiedFunctionality reads the capability findings they produce.
+  detectArchitecture(files, contents, run);
+  detectCapabilities(files, contents, run);
+  detectApis(files, contents, run);
+  detectJobs(files, contents, run);
+  detectIntegrations(files, contents, run);
+  detectAiInterfaces(files, contents, run);
 
-if (JSON_OUT) {
-  // Standard 25's envelope. `findings` is additive detail beyond the contract Standard 31 R2
-  // guarantees — a consumer joins on results[].ruleId, never on a finding category.
-  process.stdout.write(JSON.stringify({ ...report, findings }, null, 2) + "\n");
-} else {
-  process.stdout.write(renderVerdict(report, policy) + "\n");
-  // Report the current digest for any attestation that lacks one, so it can be recorded rather
-  // than computed by hand (ADR 0005). A digest is offered ONLY where none is recorded: computing a
-  // replacement for a record that already carries one would invite exactly the substitution this
-  // mechanism forbids — a legacy value swapped for a reproducible one without a new review.
-  for (const [ruleId, state] of freshness) {
-    if (state.state !== FRESHNESS.unrecorded) continue;
-    const against = currentReview(ruleId, policy.document?.attestations?.[ruleId])?.reviewedAgainst;
-    const current = repositoryDigest(root, against?.paths ?? []);
-    if (!current.ok) {
-      process.stdout.write(
-        `\n  attestation ${ruleId}: no digest can be offered — ${current.missing.join(", ")} ` +
-          `has no committed identity.\n`,
+  detectMissingDocs(files, contents, run);
+  detectArchitectureArtifacts(run);
+  detectMissingPlanningArtifacts(files, contents, run);
+  detectMissingAuditInfrastructure(files, run);
+  detectUnverifiedFunctionality(files, run);
+  detectUnfinished(files, run);
+  detectDeadCode(files, contents, run);
+  detectOpenQuestions(files, contents, run);
+  await detectPlanDiscrepancies(files, contents, run);
+  detectDocDiscrepancies(files, contents, run);
+  detectStandardsViolations(files, contents, run);
+
+  // Availability is probed once and shared: the env detector and attestation freshness both need the
+  // repository, and asking twice would spend a second subprocess to learn the same thing.
+  const repoAvailability = repositoryAvailable(root);
+  const envCheck = detectCommittedEnvFiles(files, root, repoAvailability, run);
+  detectSecretsInArtifacts(files, contents, run);
+  detectSwallowedExceptions(files, contents, run);
+  detectCertBypass(files, run);
+  detectSqlConcat(files, run);
+
+  // ---------------------------------------------------------------------------
+  // Verdict — catalog + policy + findings (Standards 25, 27, 30)
+  //
+  // The three-way separation is deliberate and must not be violated here: the catalog defines rule
+  // identity and metadata, project-policy.yml defines what applies to THIS project, and everything
+  // above produces evidence. Nothing in this section redefines a rule or invents applicability.
+
+  const catalog = await loadCatalog();
+  assertBindings(
+    catalog,
+    findings.map((f) => f.rule).filter(Boolean),
+  );
+
+  if (!validating) {
+    // audit: evidence only. No status, no score, no policy required — ADR 0004.
+    if (cli.json) {
+      emit(
+        JSON.stringify(
+          {
+            schemaVersion: SCHEMA_VERSION,
+            repo: root.split(path.sep).join("/"),
+            auditedAt: new Date().toISOString(),
+            // What the run could not search. Additive field: a consumer that ignores it reads the
+            // findings exactly as before, and one that reads it can tell a clean result from an
+            // unexamined one.
+            evidenceSurface,
+            findings,
+          },
+          null,
+          2,
+        ) + "\n",
       );
-      continue;
+    } else {
+      emit(renderHuman(files.length, evidenceSurface, run) + "\n");
+      emit(
+        "\nThis is evidence, not a verdict. Run `standards validate` for a compliance status.\n",
+      );
     }
-    process.stdout.write(`\n  attestation ${ruleId}: current digest is ${current.digest}\n`);
-    process.stdout.write(
-      `  Record it as reviewedAgainst.digest with digestAlgorithm: ${DIGEST_ALGORITHM}.\n`,
-    );
+    return done(cli.strict && findings.some((f) => f.severity !== "info") ? EXIT_FINDINGS : EXIT_OK);
   }
+
+  // ---------------------------------------------------------------------------
+  // validate — the verdict (Standards 25, 27, 30)
+  //
+  // The three-way separation must not be violated here: the catalog defines rule identity and
+  // metadata, project-policy.yml defines what applies to THIS project, and everything above produces
+  // evidence. Nothing in this section redefines a rule or invents applicability.
+
+  const policy = await loadProjectPolicy(root);
+
+  /**
+   * The version-identity guard — a verdict may not be reported for version X unless the framework
+   * executing the run identifies itself as X.
+   *
+   * `standardVersion` declares which framework version governs a project, and nothing resolves that
+   * declaration: every run evaluates against the catalog on disk, whichever version that happens to
+   * be. While this repository was the framework's only consumer the two were the same working tree
+   * and could not disagree, so the gap was recorded and deferred (Standard 21 R5).
+   *
+   * Distribution ends that. Once a project pins a version and a workflow checks out a ref, the pin
+   * and the ref are independent sources of truth: a policy declaring 2.0.0 can be evaluated by 2.1.0,
+   * and the envelope would carry `standardVersion: "2.0.0"` beside a verdict the 2.0.0 rule set never
+   * produced. That is not a compliance failure — it is a provenance lie, and a verdict that misstates
+   * which rules produced it is the false green this tool exists to refuse.
+   *
+   * This is an honesty guard, NOT historical rule-set resolution. It detects the disagreement and
+   * stops; it cannot evaluate the declared version, and does not pretend to. Standard 21 R5 remains
+   * unimplemented and this narrows rather than closes it.
+   *
+   * Exit 2, beside the unreadable-policy case below: the policy and the framework disagree about what
+   * is being evaluated, which is a configuration error. Exit 1 would assert the project failed a
+   * rule, and no rule was reached. No envelope is emitted in either output mode — an envelope carries
+   * a `status`, and that status is precisely the claim that must not be made. The JSON branch emits a
+   * typed error instead of nothing, so a consumer parsing stdout gets a loud object rather than a
+   * parse failure it might mistake for an empty result.
+   *
+   * A missing or malformed `standardVersion` cannot reach here: the schema makes it required and pins
+   * it to a full semver triple, so loadProjectPolicy() has already returned `document: null` and the
+   * configuration path below owns that case. The guard is deliberately confined to `validate` —
+   * `audit` reports evidence and claims no standards version, so widening it there would attach a
+   * version precondition to a command whose contract does not depend on one.
+   */
+  const FRAMEWORK_VERSION = (
+    await readFile(path.join(path.dirname(SELF), "..", "VERSION"), "utf8")
+  ).trim();
+  const declaredVersion = policy.document?.standardVersion;
+
+  if (declaredVersion && declaredVersion !== FRAMEWORK_VERSION) {
+    const message =
+      `project-policy.yml declares standardVersion ${declaredVersion}, but the framework executing ` +
+      `this run is ${FRAMEWORK_VERSION}. No verdict was produced: a compliance status reported under ` +
+      `a version that did not evaluate it would misstate its own provenance.`;
+    if (cli.json) {
+      emit(
+        JSON.stringify(
+          {
+            error: "VERSION_MISMATCH",
+            policyStandardVersion: declaredVersion,
+            frameworkVersion: FRAMEWORK_VERSION,
+            message,
+            historicalResolution: "not implemented (Standard 21 R5)",
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+    } else {
+      process.stderr.write(
+        `VERSION_MISMATCH\n  ${message}\n\n` +
+          `  Resolving a historical rule set is not implemented (Standard 21 R5), so this run cannot\n` +
+          `  evaluate ${declaredVersion}. Either execute the framework at ${declaredVersion}, or update\n` +
+          `  project-policy.yml to ${FRAMEWORK_VERSION} deliberately and review the failures the newer\n` +
+          `  rule set reports. Upgrading the governing version is an engineering event, not a default.\n`,
+      );
+    }
+    return done(EXIT_INVOCATION);
+  }
+
+  /**
+   * Digest the paths each attestation says it reviewed, so a material change to them makes the
+   * attestation stale (ADR 0005 rule 4).
+   *
+   * Content-based rather than revision-based on purpose: invalidating every attestation on every
+   * commit would make the mechanism unusable, and it would be abandoned. Digesting what was actually
+   * reviewed invalidates on material change, which is the real requirement.
+   */
+  function attestationFreshness(document, repoRoot, repo) {
+    const out = new Map();
+    for (const [ruleId, record] of Object.entries(document?.attestations ?? {})) {
+      // Freshness describes what may establish the rule now, so it is computed for the newest review
+      // event. Earlier events keep their own recorded provenance and are reported by
+      // `npm run attestations`; they are history, and history does not go stale.
+      const against = currentReview(ruleId, record)?.reviewedAgainst;
+      if (!against?.paths?.length) continue;
+      out.set(ruleId, classifyFreshness(repoRoot, against, repo));
+    }
+    return { states: out, repo };
+  }
+
+  const { states: freshness, repo } = attestationFreshness(policy.document, root, repoAvailability);
+
+  // Repository content is the source of truth for attestation freshness, and its absence is a fact
+  // about the search mechanism rather than about the project (Standard 44 R12). It is reported as an
+  // infrastructure finding carrying no rule, exactly as evidence-surface loss is, so that it can never
+  // become a second compliance owner — the affected attestations independently fail to establish their
+  // rules, and that is where the compliance consequence lives. It does not exit 2: one unavailable
+  // provenance source must not discard every other result the run established.
+  if (!repo.available && freshness.size > 0) {
+    addFinding({
+      id: "repository-evidence-unavailable",
+      category: "evidence-surface",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: [...freshness.keys()],
+      message:
+        `Attestation freshness could not be established for ${freshness.size} rule(s): ${repo.reason}. ` +
+        `Repository content identifies what was reviewed; without it, no approval establishes a rule.`,
+      standardRef: R.search,
+    });
+  }
+  // A rule whose evidence could not be obtained was not evaluated this run, whatever the static set
+  // says. Withdrawing it here rather than letting it report a clean pass is what keeps `nobody could
+  // look` distinct from `nobody found anything` — a distinction that matters most for a `forbidden`
+  // rule, which is satisfied by absence and would otherwise pass precisely when it knows least
+  // (Standard 45 R6).
+  const evaluatedThisRun = EVALUATED_RULES.filter(
+    (id) => !(id === "scm.no-committed-env-files" && envCheck.evaluated === false),
+  );
+
+  const verdict = evaluate({
+    catalog,
+    policy: policy.document,
+    findings,
+    evaluated: evaluatedThisRun,
+    today: new Date().toISOString().slice(0, 10),
+    freshness,
+  });
+
+  // Framework maturity, read from this framework's own inventory rather than the target repository.
+  // It travels beside the verdict and never inside it: a coverage improvement must never be able to
+  // look like a compliance improvement.
+  const totalStandards = await (async () => {
+    try {
+      const inventoryPath = path.join(path.dirname(SELF), "..", "artifacts/standards-source-inventory.json");
+      const inv = JSON.parse(await readFile(inventoryPath, "utf8"));
+      return inv.expectedCount ?? inv.standards?.length ?? null;
+    } catch {
+      return null;
+    }
+  })();
+
+  const report = envelope({
+    verdict,
+    project: policy.document?.project,
+    standardVersion: policy.document?.standardVersion,
+    auditedAt: new Date().toISOString(),
+    repo: root.split(path.sep).join("/"),
+    frameworkCoverage: coverage(catalog, { evaluated: EVALUATED_RULES, totalStandards }),
+  });
+
+  if (cli.json) {
+    // Standard 25's envelope. `findings` is additive detail beyond the contract Standard 31 R2
+    // guarantees — a consumer joins on results[].ruleId, never on a finding category.
+    emit(JSON.stringify({ ...report, findings }, null, 2) + "\n");
+  } else {
+    emit(renderVerdict(report, policy) + "\n");
+    // Report the current digest for any attestation that lacks one, so it can be recorded rather
+    // than computed by hand (ADR 0005). A digest is offered ONLY where none is recorded: computing a
+    // replacement for a record that already carries one would invite exactly the substitution this
+    // mechanism forbids — a legacy value swapped for a reproducible one without a new review.
+    for (const [ruleId, state] of freshness) {
+      if (state.state !== FRESHNESS.unrecorded) continue;
+      const against = currentReview(ruleId, policy.document?.attestations?.[ruleId])?.reviewedAgainst;
+      const current = repositoryDigest(root, against?.paths ?? []);
+      if (!current.ok) {
+        emit(
+          `\n  attestation ${ruleId}: no digest can be offered — ${current.missing.join(", ")} ` +
+            `has no committed identity.\n`,
+        );
+        continue;
+      }
+      emit(`\n  attestation ${ruleId}: current digest is ${current.digest}\n`);
+      emit(
+        `  Record it as reviewedAgainst.digest with digestAlgorithm: ${DIGEST_ALGORITHM}.\n`,
+      );
+    }
+  }
+
+  // A policy that could not be read, or none at all, is exit 2: a verdict was requested and there is
+  // nothing to evaluate against. That is a configuration problem, not a compliance failure
+  // (Standard 30 R1, ADR 0004). A required-level failure is exit 1 regardless of score.
+  if (policy.error || !policy.document) return done(EXIT_INVOCATION);
+  if (report.status === "NON_COMPLIANT") return done(EXIT_FINDINGS);
+  // Standard 45 R6: a must-never rule nobody examined must not gate-pass CI. This is exit 1 rather
+  // than exit 2 because it is a statement about the project, not about the configuration — the policy
+  // read fine, and what it says is that a prohibition went unexamined.
+  if (report.unestablishedProhibitions?.length) return done(EXIT_FINDINGS);
+  return done(EXIT_OK);
 }
 
-// A policy that could not be read, or none at all, is exit 2: a verdict was requested and there is
-// nothing to evaluate against. That is a configuration problem, not a compliance failure
-// (Standard 30 R1, ADR 0004). A required-level failure is exit 1 regardless of score.
-if (policy.error || !policy.document) process.exit(EXIT_INVOCATION);
-if (report.status === "NON_COMPLIANT") process.exit(EXIT_FINDINGS);
-// Standard 45 R6: a must-never rule nobody examined must not gate-pass CI. This is exit 1 rather
-// than exit 2 because it is a statement about the project, not about the configuration — the policy
-// read fine, and what it says is that a prohibition went unexamined.
-if (report.unestablishedProhibitions?.length) process.exit(EXIT_FINDINGS);
-process.exit(EXIT_OK);
+// ---------------------------------------------------------------------------
+// The CLI boundary — the only place in this file that terminates the process.
+//
+// Importing this module runs nothing: no walk, no output, no exit. That is what makes `main`
+// testable against a fresh-process oracle, and it is the property ADR 0014 turns into a test.
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = (await main(process.argv.slice(2))).exitCode;
+}

--- a/standards/51-architecture-integrity.md
+++ b/standards/51-architecture-integrity.md
@@ -169,8 +169,11 @@ whether or not it crosses a network boundary.
 [Standard 1](01-human-and-ai-operability.md) R1 owns UI-only capabilities.
 [Standard 11](11-architecture-decision-records.md) is where every justification in this standard
 lives.
-[ADR 0007](../artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md)
-is this repository's own R1 record, and the worked example of what one looks like. [Standard 15](15-ai-tool-contracts.md) and [Standard 21](21-versioning.md) are what R5 routes
+[ADR 0014](../artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md)
+is this repository's own R1 record, and the worked example of what one looks like. It replaced
+[ADR 0007](../artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md),
+which is kept as the evidence for why: naming state by enumeration failed at five consecutive
+reviews, so the record now constrains lifetime instead. [Standard 15](15-ai-tool-contracts.md) and [Standard 21](21-versioning.md) are what R5 routes
 to. [Standard 48](48-error-handling-and-observability.md) R2 owns the source's HTTP-status
 prohibition. [Standard 22](22-adoption-and-migration.md) R6 is R3's principle stated for standards
 rather than code. [Standard 32](32-documentation-standards.md) is why a bypassed boundary is also a
@@ -183,7 +186,7 @@ exception discipline.
 
 | Requirement | Rule | State |
 | --- | --- | --- |
-| R1 | `architecture.no-hidden-global-state` | `manual-review`. A module-level mutable binding is trivial to find and says nothing about whether the state is hidden or owned. **This repository has a real subject for it** — twenty module-level bindings across `scripts/standards.mjs`, `scripts/inventory.mjs` and `scripts/fidelity.mjs` — and discharges R1 the way R1 asks, with [ADR 0007](../artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md) naming the state, its owner, and its reset boundary. That record governs by categorical rule rather than by its list, because two successive reviews found the list incomplete |
+| R1 | `architecture.no-hidden-global-state` | `manual-review`. A module-level mutable binding is trivial to find and says nothing about whether the state is hidden or owned. **This repository has a real subject for it**, and discharges R1 the way R1 asks, with [ADR 0014](../artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md) naming the state, its owner, and its reset boundary: run state is constructed by the invocation that uses it and cannot outlive it, so the owner is the invocation and the reset is its return. Enumeration was tried first and abandoned — [ADR 0007](../artifacts/adr/0007-cli-scripts-are-single-run-programs-with-module-scoped-state.md) records five consecutive reviews at which the list of governed bindings was incomplete, and is kept unrepaired as the evidence for the change |
 | R2 | `architecture.no-boundary-bypass` | `manual-review`. Requires knowing where the boundaries are, which is a project-specific fact no scan has |
 | R3 | `architecture.no-duplicate-implementations` | `manual-review`. Similar code is not duplicated logic, and duplicated logic is often not similar code |
 | R4 | `architecture.dependency-evaluation` | `manual-review`, `required`/`warning`. A manifest shows which dependencies exist, never which were evaluated |

--- a/test/invocation-ownership.test.mjs
+++ b/test/invocation-ownership.test.mjs
@@ -1,0 +1,206 @@
+/**
+ * ADR 0014 — execution-specific mutable state is owned by an invocation.
+ *
+ * These are the falsifiers the decision rests on, not illustrations of it. Each one compares an
+ * in-process run against a **fresh-process oracle** — a separate `node` invocation of the same
+ * command — because a contaminated in-process run agrees with itself.
+ *
+ * Two rules govern how they are written, and both were learned the hard way:
+ *
+ * 1. **Never compare against a globally patched `process.stdout.write`.** Two concurrent runs
+ *    interleave into one buffer, and a comparison against that buffer cannot tell independence from
+ *    interleaving. Every assertion below reads `result.stdout` — the bytes that invocation itself
+ *    rendered.
+ * 2. **Output equality is not sufficient.** The negative control at the foot of this file restores
+ *    the pre-refactor lifetime for one object and still passes every behavioural check. Only the
+ *    identity assertion catches it. That is why the identity assertion exists and why it may not be
+ *    removed as redundant.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { main } from "../scripts/standards.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..");
+const CLI = path.join(ROOT, "scripts/standards.mjs");
+
+// Two distinct targets. Same-root concurrency proves no shared cache; different-root proves no
+// cross-target leakage. Fixtures rather than the repository itself, so the suite stays quick.
+const A = path.join(HERE, "fixtures/compliant");
+const B = path.join(HERE, "fixtures/never-clean");
+
+/** Only `auditedAt` is normalised, by explicit allowlist. Stripping every volatile-looking field
+ *  would normalise away exactly the contamination these tests exist to find. */
+const norm = (text) => JSON.stringify(JSON.parse(text), (k, v) => (k === "auditedAt" ? "<volatile>" : v));
+
+function freshProcess(args) {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8", maxBuffer: 1 << 28 });
+  return { stdout: r.stdout, exitCode: r.status };
+}
+
+/**
+ * An in-process run writes its report to the real stdout, exactly as the CLI does, so this suite is
+ * noisy. It is left noisy deliberately.
+ *
+ * Patching `process.stdout.write` to quieten it was tried and reverted: the test runner reports over
+ * that same stream, so silencing it swallowed the runner's own results and turned twelve reported
+ * tests into one. The assertions never read the stream in any case — every one of them reads
+ * `result.stdout`, the bytes that invocation returned.
+ */
+const audit = (dir) => main(["audit", `--dir=${dir}`, "--json"]);
+const oracleA = freshProcess(["audit", `--dir=${A}`, "--json"]);
+const oracleB = freshProcess(["audit", `--dir=${B}`, "--json"]);
+
+test("importing the module runs nothing", () => {
+  // If importing performed the audit, this file could not have reached here without output, and the
+  // oracles above would be comparing against a module that had already run.
+  const r = spawnSync(
+    process.execPath,
+    ["--input-type=module", "-e", `await import(${JSON.stringify(pathToFileURL(CLI).href)});`],
+    { encoding: "utf8" },
+  );
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout, "");
+});
+
+test("a sequential run does not inherit the previous target's state", async () => {
+  await audit(A);
+  const second = await audit(B);
+  assert.equal(norm(second.stdout), norm(oracleB.stdout));
+
+  await audit(B);
+  const third = await audit(A);
+  assert.equal(norm(third.stdout), norm(oracleA.stdout));
+});
+
+test("the same target twice produces the same result", async () => {
+  const first = await audit(A);
+  const second = await audit(A);
+  assert.equal(norm(first.stdout), norm(second.stdout));
+});
+
+test("a failed run does not contaminate the next one", async () => {
+  const missing = await main(["audit", `--dir=${path.join(HERE, "fixtures/does-not-exist")}`, "--json"]);
+  assert.equal(missing.exitCode, 2);
+  const after = await audit(B);
+  assert.equal(norm(after.stdout), norm(oracleB.stdout));
+});
+
+test("concurrent runs over the same target are independent", async () => {
+  const [first, second] = await Promise.all([audit(A), audit(A)]);
+  assert.equal(norm(first.stdout), norm(oracleA.stdout));
+  assert.equal(norm(second.stdout), norm(oracleA.stdout));
+});
+
+test("concurrent runs over different targets do not leak across", async () => {
+  const [ra, rb] = await Promise.all([audit(A), audit(B)]);
+  assert.equal(norm(ra.stdout), norm(oracleA.stdout));
+  assert.equal(norm(rb.stdout), norm(oracleB.stdout));
+});
+
+test("no invocation-owned object is shared between two runs", async () => {
+  const [first, second] = await Promise.all([audit(A), audit(A)]);
+  // Equal CONTENT is expected and is not what is asserted. Shared IDENTITY is the defect: two
+  // invocations holding one object cannot be independent however similar their output looks.
+  assert.notEqual(first.run.findings, second.run.findings);
+  assert.notEqual(first.run.sources, second.run.sources);
+  assert.notEqual(first.surface.files, second.surface.files);
+  assert.notEqual(first.surface.contents, second.surface.contents);
+  assert.notEqual(first.surface.surfaceLoss, second.surface.surfaceLoss);
+});
+
+test("mutating a completed result cannot affect a later run", async () => {
+  const completed = await audit(A);
+  completed.run.sources.set("poison", { code: "x", structure: "x", comments: "" });
+  completed.run.findings.push({ id: "poison" });
+  completed.surface.files.push("poison");
+
+  const after = await audit(A);
+  assert.equal(norm(after.stdout), norm(oracleA.stdout));
+});
+
+test("the rendered bytes match a fresh process, timestamp aside", async () => {
+  // Stronger than the JSON comparisons above: those tolerate any reordering that survives
+  // re-serialisation, this compares the emitted text itself. The timestamp is the one line that
+  // legitimately differs between two runs, so it is blanked rather than the whole value normalised.
+  const blank = (s) => s.replace(/"auditedAt": "[^"]*"/, '"auditedAt": ""');
+  for (const [dir, oracle] of [[A, oracleA], [B, oracleB]]) {
+    const inProcess = await audit(dir);
+    assert.equal(blank(inProcess.stdout), blank(oracle.stdout));
+  }
+});
+
+test("the three exit codes survive the refactor", () => {
+  assert.equal(freshProcess(["audit", `--dir=${A}`, "--json"]).exitCode, 0);
+  assert.equal(freshProcess(["validate", `--dir=${ROOT}`, "--json"]).exitCode, 1);
+  assert.equal(freshProcess(["nonsense"]).exitCode, 2);
+});
+
+test("only the CLI boundary terminates the process", () => {
+  const src = readFileSync(CLI, "utf8");
+  const marker = "if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {";
+  const boundary = src.indexOf(marker);
+  assert.ok(boundary > 0, "the CLI boundary must be recognisable for this check to mean anything");
+
+  // Comments are excluded: this file discusses `process.exit` at length, and a check that could not
+  // tell discussion from use would be the very mention-versus-use defect the detectors exist to
+  // avoid.
+  const above = src
+    .slice(0, boundary)
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+    .join("\n");
+  const hits = [...above.matchAll(/process\.(exit|exitCode)\b/g)];
+  assert.deepEqual(hits.map((h) => h[0]), [], "no helper below the CLI boundary may terminate the process");
+});
+
+/**
+ * The negative control, and the reason the identity assertion is not redundant.
+ *
+ * A copy of the evaluator is patched so one object — the source cache — regains its pre-refactor
+ * lifetime: created once at module scope and reused by every invocation. That is the exact defect
+ * ADR 0014 removes.
+ *
+ * The measured result, which is the point: the patched module still produces correct output for
+ * both targets, so every behavioural check above passes against it. Only the identity assertion
+ * fails. A suite that tested output alone would have reported this defect as absent.
+ */
+test("the identity assertion detects a shared cache that output comparison cannot", async () => {
+  const src = readFileSync(CLI, "utf8");
+  const anchor = "  const findings = [];\n  const sources = new Map();";
+  assert.ok(
+    src.includes(anchor),
+    "the control must patch real construction code; if this anchor moves, fix the control rather than deleting it",
+  );
+
+  const patched = src
+    .replace("function createRun({ root, strict, json }) {", "const SHARED = new Map();\nfunction createRun({ root, strict, json }) {")
+    .replace(anchor, "  const findings = [];\n  const sources = SHARED;");
+
+  // Beside the real module, because it imports its siblings by relative path. Dot-prefixed and
+  // removed in `finally`, so it is never a file the repository audits.
+  const copy = path.join(ROOT, "scripts", ".shared-cache-control.mjs");
+  writeFileSync(copy, patched);
+
+  try {
+    const control = await import(pathToFileURL(copy).href);
+    const [first, second] = await Promise.all([
+      control.main(["audit", `--dir=${A}`, "--json"]),
+      control.main(["audit", `--dir=${A}`, "--json"]),
+    ]);
+
+    // Behaviourally indistinguishable from the real thing.
+    assert.equal(norm(first.stdout), norm(oracleA.stdout));
+    assert.equal(norm(second.stdout), norm(oracleA.stdout));
+
+    // And yet the two runs share one cache.
+    assert.equal(first.run.sources, second.run.sources);
+  } finally {
+    rmSync(copy, { force: true });
+  }
+});

--- a/test/invocation-ownership.test.mjs
+++ b/test/invocation-ownership.test.mjs
@@ -19,7 +19,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, rmSync, mkdirSync, mkdtempSync, symlinkSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -143,7 +144,7 @@ test("the three exit codes survive the refactor", () => {
 
 test("only the CLI boundary terminates the process", () => {
   const src = readFileSync(CLI, "utf8");
-  const marker = "if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {";
+  const marker = "if (invokedDirectly(process.argv[1])) {";
   const boundary = src.indexOf(marker);
   assert.ok(boundary > 0, "the CLI boundary must be recognisable for this check to mean anything");
 
@@ -157,6 +158,99 @@ test("only the CLI boundary terminates the process", () => {
     .join("\n");
   const hits = [...above.matchAll(/process\.(exit|exitCode)\b/g)];
   assert.deepEqual(hits.map((h) => h[0]), [], "no helper below the CLI boundary may terminate the process");
+});
+
+/**
+ * The installed shape of this package, which is the shape consumers actually gate their builds on.
+ *
+ * `package.json` declares `bin: { standards: "scripts/standards.mjs" }`, so `npm install` links
+ * `node_modules/.bin/standards` at this file. Node follows that symlink when it resolves the module,
+ * so `import.meta.url` names the real file while `process.argv[1]` still names the link — and the
+ * original guard compared those two strings. It answered "not invoked directly", the CLI ran nothing,
+ * and the process exited 0.
+ *
+ * The failure mode is the worst available one: silence that reads as success. `standards validate`
+ * is what ADR 0004 tells consuming projects to gate on, and a gate that exits 0 without looking is
+ * indistinguishable from a clean repository. Measured before the fix — direct invocation exited 1
+ * with a 2914-byte verdict, invocation through the link exited 0 with zero bytes.
+ *
+ * The assertion is equality with the direct invocation rather than "exit 0", because exit 0 is
+ * exactly what the defect produced.
+ */
+function withBinLink(fn) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "standards-bin-"));
+  try {
+    const bin = path.join(dir, "node_modules/.bin");
+    mkdirSync(bin, { recursive: true });
+    const link = path.join(bin, "standards");
+    try {
+      symlinkSync(CLI, link, "file");
+    } catch (error) {
+      // Windows refuses symlinks without Developer Mode or elevation. Reported rather than passed
+      // quietly: the gating pipeline runs this on Linux, where the branch below always executes, and
+      // a skip that looked like a pass is the same class of defect this test exists to catch.
+      if (["EPERM", "EACCES"].includes(error.code)) return { skipped: error.code };
+      throw error;
+    }
+    return { skipped: null, result: fn(link) };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("invoking through the installed bin symlink runs the CLI, not a silent exit 0", (t) => {
+  const outcome = withBinLink((link) => {
+    const viaLink = (args) => {
+      const r = spawnSync(process.execPath, [link, ...args], { encoding: "utf8", maxBuffer: 1 << 28 });
+      return { stdout: r.stdout, exitCode: r.status };
+    };
+    return {
+      audit: viaLink(["audit", `--dir=${A}`, "--json"]),
+      bad: viaLink(["nonsense"]),
+    };
+  });
+
+  if (outcome.skipped) {
+    t.skip(`symlink creation refused (${outcome.skipped}); this runs on the Linux CI image`);
+    return;
+  }
+
+  const direct = freshProcess(["audit", `--dir=${A}`, "--json"]);
+  assert.notEqual(outcome.result.audit.stdout, "", "the symlinked CLI produced no output at all");
+  assert.equal(norm(outcome.result.audit.stdout), norm(direct.stdout), "the symlinked CLI reported something else");
+  assert.equal(outcome.result.audit.exitCode, direct.exitCode);
+  // A distinguishing exit code, so the check cannot be satisfied by a process that exits 0 blindly.
+  assert.equal(outcome.result.bad.exitCode, 2, "the symlinked CLI did not reach argument handling");
+});
+
+test("importing the module still runs nothing, by either of its two paths", (t) => {
+  // The other half of the fix. Canonicalising the guard makes two spellings of one path comparable;
+  // it must not widen what counts as invocation. An imported module's argv[1] is the *importing*
+  // entry point — a different real file — so both the real path and the bin link must stay inert.
+  // Asserted because the natural over-correction (comparing realpaths of the module against the
+  // module) would make every import execute the CLI, which is the property ADR 0014 rests on.
+  const outcome = withBinLink((link) => {
+    const dir = path.dirname(path.dirname(path.dirname(link)));
+    const entry = path.join(dir, "entry.mjs");
+    writeFileSync(
+      entry,
+      `import ${JSON.stringify(pathToFileURL(CLI).href)};\n` +
+        `import ${JSON.stringify(pathToFileURL(link).href)};\n` +
+        `process.stdout.write("IMPORTED-AND-NOTHING-ELSE");\n`,
+    );
+    const r = spawnSync(process.execPath, [entry, "validate"], { encoding: "utf8", maxBuffer: 1 << 28 });
+    return { stdout: r.stdout, stderr: r.stderr, exitCode: r.status };
+  });
+
+  if (outcome.skipped) {
+    t.skip(`symlink creation refused (${outcome.skipped}); this runs on the Linux CI image`);
+    return;
+  }
+
+  // `validate` is passed as an argument on purpose: if importing were to execute, it would have a
+  // command to run and would print a verdict rather than failing on a missing one.
+  assert.equal(outcome.result.stdout, "IMPORTED-AND-NOTHING-ELSE", "importing the module executed the CLI");
+  assert.equal(outcome.result.exitCode, 0, "importing the module set an exit code");
 });
 
 /**


### PR DESCRIPTION
Implements [ADR 0014](artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md). Owner-directed, after a two-candidate experiment run outside the repository.

## Why enumeration was retired rather than repaired

ADR 0007 governed `architecture.no-hidden-global-state` by naming the module-level bindings that held run state. The categorical rule never failed; the table was incomplete at **five consecutive reviews**, and mechanising it did no better — a declaration scan could not see the alias-mediated write to `surfaceLoss`, and a full AST analysis produced confident, plausible, materially wrong measurements twice without failing.

| Candidate | Result |
| --- | --- |
| **A — recognition** (derive scope, find every representation) | scope derivation worked; **1 of 6** adversarial state representations caught. Every miss was a valid execution carrying wrong assurance. |
| **B — construction** (constrain lifetime) | representation stops mattering. Its four transformation defects all crashed. |

The decisive argument is failure-mode asymmetry, not tidiness.

## What changed

`scripts/standards.mjs` no longer works at module load. Importing it runs nothing; `main(args)` returns an exit code; only the CLI boundary terminates the process. The findings sink, repository surface, and source cache are constructed per invocation — **by construction, never by a reset**, because clearing a shared object makes sequential runs look independent while leaving concurrent runs sharing it.

Detectors take the run object and destructure what they use. Frozen tables and matching configuration stay at module scope: the invariant is that no *execution-specific* mutable state outlives its invocation, not that module scope is empty.

## Evidence

`test/invocation-ownership.test.mjs` — twelve falsifiers against fresh-process oracles: import inertness, sequential independence both directions, failed-run isolation, same-root and different-root concurrency, object identity, completed-result inertness, byte parity for `audit --json` and `validate --json`, exit codes 0/1/2, and the static check that only the CLI boundary terminates the process.

**The negative control is the most important test.** It restores the old lifetime for one object and still passes every behavioural check — only the identity assertion catches it. Output equality is not sufficient evidence of independence.

Full gate green; 245 tests pass.

## What this does not claim

- Not arbitrary concurrent safety — two concurrent invocations under the tested paths.
- The prototypes were mechanical transforms used to choose a design. This implementation is hand-written and re-earns every property on its own terms.

## For the owner

`architecture.no-hidden-global-state` **goes stale** here. That is expected and correct — its evidence changed. It has not been refreshed or recomputed, and it returns for review with this ADR and implementation as its subject.

ADR 0007 is kept **unrepaired**: its eight missing rows are the evidence for retiring enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)