### PR TITLE
Local Docker CI, and a pull request that names the commit it verified

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the previous run's evidence out of the next run's image.
+#
+# If artifacts/local-ci were copied in, a container could find a `latest.json` it did not write and
+# a reader could not tell which run produced it. The report this run produces is extracted from the
+# container afterwards, never mounted in.
+artifacts/local-ci/
+
+# Nothing else is excluded, and the omissions are deliberate:
+#   * `.git` is required — the audit asks the repository which paths it ignores, and attestation
+#     freshness is computed from committed blob identity.
+#   * there is no node_modules to exclude; this repository has no dependencies.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Line endings for files that are executed by a Linux shell.
+#
+# The developer platform here is Windows, so a fresh checkout converts to CRLF. That is harmless for
+# most of this repository and fatal for two kinds of file: a script whose first line becomes
+# `#!/usr/bin/env bash\r` is not executable, and a Dockerfile whose `RUN` lines carry carriage
+# returns passes them to `sh`. Both fail in the container, on someone else's machine, for a reason
+# that does not appear in the diff.
+#
+# git already stores LF for these — it is the checkout that would change them — so this only
+# constrains what lands on disk.
+*.sh text eol=lf
+ci/Dockerfile text eol=lf
+
+# PowerShell is only ever run on the host, where CRLF is native. Left alone deliberately rather than
+# normalised for symmetry.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   # can only be observed by merging toward the branch it protects is a check nobody can test.
   workflow_dispatch:
 
+# The step list below is not the definition of what CI covers. `scripts/pipeline.mjs` is, and the
+# same list is executed by `scripts/ci.ps1` / `scripts/ci.sh` inside a container before a branch is
+# ever pushed (docs/local-ci.md). The steps here stay spelled out one per line because each carries a
+# reason worth reading and because GitHub's UI reports them individually — but they run the same
+# `npm run …` commands, and `test/local-ci.test.mjs` fails if the two ever name different sets, in
+# either direction. Adding a check here without adding a stage there is a caught error, not a drift.
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Local CI verification records.
+#
+# `artifacts/local-ci/latest.json` is evidence about one run on one machine: it names a commit, a
+# result, and the container that produced it. Committing it would make one developer's run part of
+# the repository's history, where a reader could not tell it from a reviewed artifact — and it would
+# be stale the moment the next commit landed.
+#
+# This repository does retain evidence on purpose elsewhere (attestations in project-policy.yml,
+# reviews under artifacts/), and the difference is that those are reviewed and owned. A transient
+# verification record is neither, so it stays out.
+#
+# The audit reads this file to decide what the repository treats as not-its-own, so an entry here
+# also removes the path from the evidence surface — which is correct: nothing in it is the project's
+# code.
+artifacts/local-ci/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ All notable changes to this framework. Versioning follows
 | Output schema | The validator's JSON envelope | `schemaVersion` in every report |
 | Package | The npm package | `package.json` |
 
+## Unreleased
+
+**No change to the framework, the rule catalog, the policy schema, or any published contract.** This
+is repository tooling: nothing an adopting project consumes is affected, and `VERSION` is unchanged.
+
+Added the complete CI pipeline as a containerized local run, and made pull request submission depend
+on it:
+
+- `scripts/pipeline.mjs` — the stage list, now stated once. `.github/workflows/ci.yml` and the local
+  container both execute it, and `test/local-ci.test.mjs` fails while the two name different sets,
+  in either direction. The workflows are unchanged in what they run and were not deleted.
+- `ci/Dockerfile` + `compose.ci.yml` — Node 20 pinned by image digest, matching the runner. No
+  network, no bind mounts, no Docker socket, non-root. The repository is copied into the image
+  rather than mounted, so the suite — which does write files — cannot reach the working tree.
+- `scripts/ci.ps1`, `scripts/ci.sh` — the authoritative CI command. Unique compose project per run;
+  teardown on every exit path and scoped to what the run created.
+- `scripts/submit-pr.ps1` + `scripts/submit-gate.mjs` — submission refuses a dirty tree, a protected
+  branch, a failed run, a HEAD that moved during verification, and a verification record naming a
+  different commit, a partial run, or a run outside the container. The push names the verified SHA
+  explicitly rather than the branch.
+- `artifacts/local-ci/latest.json` — the machine-readable record, git-ignored as transient evidence.
+
+`validate` remains advisory rather than gating in the local pipeline, exactly as it is a separate,
+non-required job on GitHub, and for the same reason: this repository is intentionally
+`NON_COMPLIANT` while recorded rejections stand. Its real exit code is recorded and printed, never
+suppressed. See [docs/local-ci.md](docs/local-ci.md).
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/README.md
+++ b/README.md
@@ -154,8 +154,10 @@ templates/          What an adopting project copies.
 design/             Forward-looking designs, not yet implemented.
 schemas/            JSON Schemas for the structured contracts (Standard 19).
 project-policy.yml  This repository's own policy (Standard 18), the first dogfooded instance.
-scripts/            The audit CLI and the invariant checks CI runs.
+scripts/            The audit CLI, the invariant checks CI runs, and the local CI entry points.
 test/               Tests and fixture repositories, including known-negative policies.
+ci/Dockerfile       The containerized CI environment, pinned by image digest.
+compose.ci.yml      The ephemeral CI environment local runs are executed in.
 artifacts/
   prompts/          Source spec material the standards were written from.
   adr/              Accepted decision records.
@@ -164,6 +166,18 @@ artifacts/
 **Commands.** `npm test` · `npm run audit` (evidence) · `npm run validate` (verdict) ·
 `npm run policy` · `npm run diagrams` · `npm run inventory` · `npm run fidelity`. CI runs all seven.
 `standards init` bootstraps another project — see [INSTRUCTIONS.md](INSTRUCTIONS.md).
+
+**Contributing.** The complete pipeline runs locally in Docker, and a pull request may only be
+submitted for a commit that passed it:
+
+```text
+.\scripts\ci.ps1        run the full pipeline in an ephemeral container (proves nothing else)
+.\scripts\submit-pr.ps1 verify this exact commit, then push it and open the pull request
+```
+
+See [docs/local-ci.md](docs/local-ci.md) for prerequisites, the check list, the isolation model, how
+to debug a failed container, and how local CI relates to the GitHub workflows — which still exist
+and still run the same commands.
 
 **Version 1.1.0** — see [CHANGELOG.md](CHANGELOG.md). 1.0.0 froze the public surface; 1.1.0 adds
 attestations as the fourth policy mechanism.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,59 @@
+# The CI environment, pinned by digest.
+#
+# The tag is `node:20-bookworm`; the digest is what actually resolves. This repository already
+# refuses a mutable reference for the framework revision its reusable workflow executes — "a
+# mandatory check pinned to a moving ref can change what it enforces without anyone deciding to" —
+# and a base image tag is the same hazard wearing different clothes. `node:20-bookworm` is rebuilt
+# regularly; two runs of the same commit a month apart would not be the same run.
+#
+# To move to a newer base: pull the tag, read `docker image inspect --format '{{index .RepoDigests 0}}'`,
+# and change the digest here in its own commit so the change is reviewable as a change.
+#
+#   Node 20 matches `.github/workflows/ci.yml`, deliberately. package.json declares engines >=18 and
+#   the developer's host runs 24; the version that must be reproduced is the one the gate uses. This
+#   repository has already shipped a suite that ran on the author's Node and died on the runner's.
+FROM node:20-bookworm@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5
+
+# git is required, not incidental. The audit asks the repository which paths it ignores rather than
+# reimplementing .gitignore semantics, and attestation freshness is computed from committed blob
+# identity — both are `git` calls (scripts/repository.mjs). Without git the run would still produce a
+# verdict, and it would be a different verdict than CI's. `node:20-bookworm` ships git 2.39; the
+# slim variant does not ship it at all, which is why this is not the slim variant.
+#
+# There is no package installation step here and no `npm ci`. This repository has zero third-party
+# dependencies (design/standards-audit-cli.md) and CI having no install step is what enforces that
+# decision structurally. If a RUN apt-get or npm install ever appears below, the decision changed.
+
+# /work is created owned by the user that will run in it, before WORKDIR touches it.
+#
+# This is not tidiness. `WORKDIR` creates a missing directory as root; `COPY --chown` then fixes the
+# contents and not the directory itself. git compares the *repository directory's* owner against the
+# current uid and refuses a mismatch with "detected dubious ownership", so every `git` call in the
+# audit failed — and the repository seam it feeds has no filesystem fallback by design, so the
+# must-never fixtures stopped being detectable and one test went red. The failure was loud, which is
+# the only reason this was a five-minute problem; the alternative design, where a missing repository
+# silently degrades to a filesystem guess, would have produced a green run covering less than it
+# claimed. `git config --global --add safe.directory` would also silence the error, and is refused:
+# it tells git to stop asking the question rather than making the answer correct.
+RUN mkdir -p /work && chown node:node /work
+WORKDIR /work
+
+# The repository is COPIED, not bind-mounted, and that is the isolation boundary.
+#
+# A bind mount would put the developer's working tree inside a container that runs the repository's
+# own test suite — and that suite writes files (test/invocation-ownership.test.mjs materialises a
+# patched copy of the evaluator to run its negative control). Copying means the container cannot
+# touch the host tree at all: there is nothing mounted to touch. It also means the run is repeatable
+# from the image alone, which is what makes "re-run CI from clean state" a real operation rather
+# than a re-read of whatever the host happens to hold now.
+#
+# `.git` is copied on purpose — see the git note above. `.dockerignore` keeps out only the
+# verification artifacts, so a previous run's report can never be mistaken for this run's.
+COPY --chown=node:node . /work
+
+# Non-root. CI executes whatever is in the branch under test, which is untrusted by construction:
+# the whole point of running it is that nobody has verified it yet.
+USER node
+
+# Overridden by compose; stated here so `docker run` on the image alone does the same thing.
+CMD ["node", "scripts/pipeline.mjs", "run"]

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -44,8 +44,10 @@ services:
     build:
       context: .
       dockerfile: ci/Dockerfile
-    # Named per run by the invoking script, so a rebuild for one project cannot replace the image
-    # another run is still using.
+    # Named per run by the invoking script — `<slug>-ci:<project>`, where the project is unique per
+    # invocation — so a rebuild for one checkout cannot replace the image another run is about to
+    # execute. The literal below is only the fallback for a hand-run debug session, where a single
+    # operator is watching one container and collision is not a risk.
     image: ${CI_IMAGE:-engineeringstandards-ci:local}
 
     # No network. The pipeline resolves nothing, downloads nothing, and installs nothing — that is

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -1,0 +1,84 @@
+# The containerized CI environment.
+#
+# Invoked only through `scripts/ci.ps1` / `scripts/ci.sh`, which supply a unique `-p <project>` per
+# run so that two repositories — or two runs of this one — cannot collide on container, network, or
+# volume names, and so teardown can remove exactly what this run created and nothing else.
+#
+# Run it by hand only when debugging:
+#   docker compose -p engstd-ci-debug -f compose.ci.yml up --build --abort-on-container-exit
+#
+# ## Services
+#
+# There is one, and the absence of the others is a fact about this repository rather than an
+# omission. It has no database, no cache, no message broker, and no external service of any kind:
+# the checks read files, run `git`, and compare text. The user's standing preference — T-SQL on
+# localhost — is a preference for *if* a database is needed, and one is not; adding a SQL Server
+# container to satisfy a template would be a service nothing connects to.
+#
+# **Adding a dependency later.** Declare it as a sibling service with a real `healthcheck`, and
+# depend on it by condition:
+#
+#   services:
+#     db:
+#       image: <pinned by digest>
+#       healthcheck:
+#         test: ["CMD", "<a command that fails until the service can actually serve>"]
+#         interval: 2s
+#         timeout: 5s
+#         retries: 30
+#         start_period: 10s
+#     ci:
+#       depends_on:
+#         db:
+#           condition: service_healthy
+#
+# `scripts/ci.*` already brings up every non-`ci` service with `docker compose up --wait`, which
+# blocks on those healthchecks and fails the run if one never becomes healthy. No sleep is involved
+# now and none would be then. The database would be a container created and destroyed with the run's
+# unique project name, so a developer's own SQL Server is never the thing the tests write to, and
+# credentials would arrive as environment variables from the invoking script rather than from a
+# committed file.
+
+services:
+  ci:
+    build:
+      context: .
+      dockerfile: ci/Dockerfile
+    # Named per run by the invoking script, so a rebuild for one project cannot replace the image
+    # another run is still using.
+    image: ${CI_IMAGE:-engineeringstandards-ci:local}
+
+    # No network. The pipeline resolves nothing, downloads nothing, and installs nothing — that is
+    # what zero third-party dependencies buys — so the strongest available setting is also the
+    # correct one. It is a check as much as a hardening: if a step ever starts needing the network,
+    # this run fails rather than quietly depending on the developer's connectivity.
+    network_mode: none
+
+    # PID 1 that reaps children and forwards signals, so a cancelled run does not leave a container
+    # holding a defunct `npm` process.
+    init: true
+
+    # No volumes and no bind mounts, deliberately. The repository is baked into the image; the
+    # verification record is copied out of the stopped container by the invoking script. Nothing on
+    # the host is reachable from inside this container, so no test can modify the developer's tree,
+    # and no `latest.json` from an earlier run can be read as this one's.
+    #
+    # The Docker socket is not mounted either. Nothing in this pipeline starts a container.
+
+    # Read-only root would be the next hardening step and is not enabled: `npm` writes to a cache
+    # directory and the suite materialises a file under scripts/ for its negative control. Both write
+    # inside the container's own layer, which is discarded with the container.
+
+    # Two facts the run records about itself. `submit-pr` refuses a verification record that was not
+    # produced in here, so this is what separates "the pipeline passed" from "it passed on the
+    # developer's machine" — the distinction containerising CI exists to make.
+    environment:
+      LOCAL_CI_CONTAINER: "1"
+      CI_IMAGE: ${CI_IMAGE:-engineeringstandards-ci:local}
+
+    working_dir: /work
+    command:
+      - node
+      - scripts/pipeline.mjs
+      - run
+      - --report=/work/artifacts/local-ci/latest.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,8 @@ recorded in [`design/standards-audit-cli.md`](../design/standards-audit-cli.md),
 | `artifacts/adr/` | Accepted decision records |
 | `artifacts/standards-source-inventory.json` | The canonical, human-reviewed enumeration of the 53 standards |
 | `artifacts/project-plan-breakdown/` | The plan, one file per section |
-| `docs/` | This document and its diagram source |
+| `docs/` | This document, its diagram source, and the local CI guide |
+| `ci/Dockerfile`, `compose.ci.yml` | The containerized CI environment. The image is pinned by digest, has no network, and holds a copy of the repository rather than a mount of it — see [local-ci.md](local-ci.md) |
 
 ## Commands
 
@@ -277,6 +278,8 @@ error-severity findings, which is the gate CI relies on — the audit step itsel
 | Add a policy rule check | `complianceFindings` in `scripts/policy.mjs`, plus a fixture in `test/fixtures/policies/` |
 | Change the diagram | `docs/architecture.mmd`, then re-embed it here. Never edit a render |
 | Record a decision | `artifacts/adr/000N-<slug>.md`, and link it from the README |
+| Add or change a CI check | `STAGES` in `scripts/pipeline.mjs`, then the matching step in `.github/workflows/ci.yml`. `test/local-ci.test.mjs` fails while the two disagree, in either direction |
+| Submit a pull request | `.\scripts\submit-pr.ps1` — verifies this exact commit in Docker, then pushes that SHA and opens the PR |
 
 ## Known Gaps
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -135,7 +135,7 @@ lives elsewhere (attestations in `project-policy.yml`, reviews under `artifacts/
   "commit": "9cb5376f397ca2bab4631363d8718f8826f02ca1",
   "branch": "chore/local-docker-ci",
   "repository": "https://github.com/mikeycdavis/EngineeringStandards.git",
-  "environment": { "node": "v20.20.2", "image": "engineeringstandards-ci:local", "containerized": true },
+  "environment": { "node": "v20.20.2", "image": "engineeringstandards-ci:engineeringstandards-ci-1755300000000-4812", "containerized": true },
   "scope": "complete",
   "startedAt": "…",
   "completedAt": "…",
@@ -148,6 +148,28 @@ container, so a stale image announces itself rather than passing under the curre
 `scope` is `partial` when only some stages ran, and the gate refuses anything but `complete`.
 `containerized` is false for a host run, and the gate refuses those too — a pass on the developer's
 machine proves the developer's machine.
+
+### What the record is not
+
+It is not tamper-evident, and nothing here should be read as claiming otherwise. The file is plain
+JSON in the developer's own working tree; anyone who can run `submit-pr` can also write
+`latest.json` by hand, and no signature, digest, or sealed channel stands between the two. The three
+fields above defend against a record being *wrong* — stale, partial, produced outside the container
+— not against one being *forged*.
+
+That is a deliberate scope, not an unexamined gap. The threat model here is developer error and
+drift: the run that quietly verified a different commit, the record left over from an earlier
+branch, the pipeline that only got halfway. Against an author who has decided to fabricate a pass,
+a local file offers no defence and cannot be made to — they already hold the push credential and the
+working tree, and any secret the check could consult, they could read. Making the record
+cryptographically self-certifying would move the problem to where the key lives, not solve it.
+
+The control that survives a hostile author is not this file. It is that the pushed commit is public
+and re-verifiable by anyone: the pipeline is deterministic, the base image is digest-pinned, and a
+reviewer — or a runner that is not the author's machine — can run the same stages against the same
+SHA and compare. Local verification is a claim the author makes; reproducibility is what makes the
+claim checkable. Treat `latest.json` as the author's signed statement in the informal sense, and
+weigh it accordingly.
 
 ## What the pull request claims
 
@@ -251,10 +273,40 @@ in either direction, so a step added to the workflow by hand is caught as readil
 | `standards-dogfood.yml` | It exercises GitHub's `workflow_call` resolution — checking out the framework from GitHub at a pinned SHA and invoking a reusable workflow. That *is* the thing under test (ADR 0013, distribution fidelity); running it locally would test something else. Its local equivalent is the `validate` stage, which produces the verdict the distributed check must reproduce. |
 | Branch protection and required-check status | A property of the GitHub repository, not of any pipeline. Note that `gh api …/branches/develop/protection` currently returns 404 — protection is not configured. |
 | `actions/upload-artifact`, job summaries | Runner-hosted presentation. The equivalent evidence is `artifacts/local-ci/latest.json` and the printed summary. |
-| Multi-OS or multi-Node matrices | Neither workflow declares one today. The image pins Node 20 to match the runner; `package.json` declares `engines: >=18`, so an 18 floor check is an available follow-up rather than lost coverage. |
+| Multi-OS or multi-Node matrices | Neither workflow declares one today. See the Node disposition below. |
+| A linked `git worktree` checkout | `.git` there is a file pointing at an absolute host path outside the build context, so the copied pointer resolves to nothing and every `git` call in the container fails. Both entry points detect this and refuse by name. Supporting it would mean copying an arbitrary host path into the image — the broad host reach this environment exists to avoid — to serve a checkout shape one `cd` steps out of. |
 
 Nothing from the existing pipeline was dropped. Every `run:` step in the required `test` job maps to
 a gating stage, and the `validate` job maps to the advisory stage — asserted by test, both ways.
+
+### Which Node this pipeline speaks for
+
+The image pins Node 20 by digest, and Node 20 is the version this pipeline makes claims about. A
+green run says the checks pass on Node 20 — not that they pass on every Node the package permits.
+
+`package.json` declares `engines: ">=18"`, and that is a **package compatibility floor**, not a
+statement that CI verified 18. The two are deliberately different things and the difference is
+recorded rather than reconciled: nothing here has ever run on 18, so raising the floor to 20 would
+discard a compatibility claim that may well be true, while adding an 18 stage would double the
+runtime of every local run to defend a version no consumer has reported using. If a consumer ever
+does, the resolution is a matrix in `scripts/pipeline.mjs` — one entry, both executors inherit it —
+and not a change to how verification works.
+
+### Supported submission entry point
+
+Verification is cross-platform; **submission is Windows-first, and deliberately so.**
+
+`scripts/ci.sh` is a complete equivalent of `scripts/ci.ps1`: Linux and macOS developers can run the
+full pipeline and get the same record. There is no `submit-pr.sh`, so the `verified SHA → push → PR`
+workflow has one supported entry point, `scripts/submit-pr.ps1`, which needs PowerShell 7 (available
+on Linux and macOS, and how a POSIX developer would drive it today).
+
+The asymmetry is not an oversight and `ci.sh` should not be read as implying parity. The decision
+that matters — every refusal, in order — lives in `scripts/submit-gate.mjs`, a pure function tested
+directly and executed inside the container. A second shell implementation would not add a platform;
+it would add a second paraphrase of the invariant, and a paraphrase is exactly the thing that drifts
+from the rule it restates. If a native POSIX submitter is ever wanted, it should call the same gate
+module rather than re-derive its logic.
 
 ## Self-hosted runner, later
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -1,0 +1,272 @@
+# Local Docker CI, and verified pull request submission
+
+GitHub remains the source-control, pull-request and review system. What it is no longer required to
+do is *prove that a branch works*. That proof is produced here, in an ephemeral Docker container, on
+the developer's machine, before the branch is pushed.
+
+The invariant this exists to enforce is one sentence:
+
+> **A pull request may only be submitted if the exact commit SHA being pushed has successfully
+> passed the repository's complete containerized CI pipeline.**
+
+Everything below is in service of that sentence being true rather than aspirational.
+
+## Why this repository in particular
+
+GitHub-hosted Actions have been unreliable for this account since the repository's first day: thirty
+consecutive red runs said nothing about the code because no runner could start, and the required
+check went unexercised until 2026-08-11. A gate that cannot be observed is not a gate. Local CI is
+independently usable and does not care whether Actions can run.
+
+## Prerequisites
+
+| Command | Needed for | Notes |
+| --- | --- | --- |
+| **Docker** | `ci`, `submit-pr` | Engine plus Compose v2 (`docker compose`, not `docker-compose`). |
+| **git** | `ci`, `submit-pr` | The audit resolves repository membership and ignore rules through git. |
+| **gh** | the pull request only | Your existing authenticated session. No token is read, written, or stored. |
+
+**Node is not a prerequisite.** The checks run against a Node baked into the CI image at a pinned
+digest; even the submission gate is evaluated inside that image. A green run therefore says nothing
+about what happens to be installed on the machine that produced it, which is the point.
+
+## Running CI
+
+```bash
+.\scripts\ci.ps1
+```
+
+On Linux or macOS, and on a future self-hosted runner:
+
+```bash
+./scripts/ci.sh
+```
+
+Exit `0` means every gating check passed. Anything else means it did not. Options:
+
+| Option | Effect |
+| --- | --- |
+| `-KeepOnFailure` / `--keep-on-failure` | Leave the container in place when the run fails, and print the commands to inspect it. |
+| `-Verbose` / `--verbose` | Print each stage's rationale before it runs. Stage output is always shown. |
+| `-Project` / `--project` | Reuse a specific compose project name; only useful when re-attaching to a kept run. |
+
+Run it as often as you like — it submits nothing and pushes nothing.
+
+## What CI performs
+
+The stage list lives in one place, [`scripts/pipeline.mjs`](../scripts/pipeline.mjs), and both
+executors read it: the container here, and `.github/workflows/ci.yml` on a runner. `npm run pipeline`
+prints it.
+
+| Stage | Command | Gating | What it establishes |
+| --- | --- | --- | --- |
+| `inventory` | `npm run inventory` | yes | The standards series has not silently changed shape. |
+| `fidelity` | `npm run fidelity` | yes | Every block claiming to be verbatim source is verbatim, against that standard's own declared source sections. |
+| `policy` | `npm run policy` | yes | `project-policy.yml` validates against its schema, and no compliance condition such as an expired exception is outstanding. |
+| `diagrams` | `npm run diagrams` | yes | Mermaid source and its embedded copies have not drifted (Standard 39 R4). |
+| `test` | `npm test` | yes | The full `node:test` suite, including the assertion that this repository's own audit produces no error-severity finding. |
+| `audit` | `npm run audit` | yes | The audit tool run against the repository that defines it. Deliberately not `--strict`. |
+| `validate` | `npm run validate` | **no** | The authoritative compliance verdict (ADR 0004). See below. |
+
+**There is no dependency-installation stage, and its absence is a decision.** This repository has
+zero third-party dependencies, recorded in [`design/standards-audit-cli.md`](../design/standards-audit-cli.md)
+and enforced structurally by CI having no install step. An `npm ci` appearing in the pipeline or an
+`apt-get` in the image would mean that decision changed.
+
+### Why `validate` does not gate
+
+`validate` is the authoritative verdict and **this repository is intentionally `NON_COMPLIANT`** —
+rules carry recorded human rejections, so exit 1 is the correct answer and will stay the correct
+answer until those rejections are withdrawn. `.github/workflows/ci.yml` already separates it into
+its own non-required job for exactly this reason: while it lived in the required job, the required
+check could never pass, and with PR-only protection that left no legal path to change `develop`.
+
+Local CI reproduces that boundary rather than inventing one. `validate` runs on every local run, its
+real exit code is recorded in the verification record and printed in the summary, and it is never
+suppressed or reported as a pass. What it does not do is decide whether a pull request may be
+opened — because on GitHub it does not decide that either. This is the one place where a check's
+failure does not block, and it is documented here, in the pipeline manifest, and in a test that
+fails if the two executors ever disagree about it.
+
+## Submitting a verified pull request
+
+```bash
+.\scripts\submit-pr.ps1
+```
+
+The sequence, in order, and each step is a refusal point:
+
+1. Verify this is a Git repository, on a branch, and not on `master`, `main`, or `develop`.
+2. Refuse a dirty working tree. CI verifies a *commit*; an uncommitted change is not in one.
+3. Record `git rev-parse HEAD`.
+4. Run the complete containerized pipeline.
+5. Stop if it failed — `CI failed. No branch was pushed and no PR was created.`
+6. Resolve `HEAD` again and refuse if it moved — `HEAD changed after CI verification. The current commit has not been verified. Re-run CI before submitting.`
+7. Check the pipeline's own record names that same commit, a complete run, and a containerized one.
+8. Push **`<sha>:refs/heads/<branch>`** — the verified SHA explicitly, not the branch name, so a
+   commit landing between the check and the push still cannot be what reaches the remote.
+9. Create the pull request with `gh`, appending the verification block to your body.
+
+Options: `-Base develop` (default), `-Title`, `-Body` / `-BodyFile`, `-Draft`, `-SkipPr`.
+
+The script never commits, never amends, never stashes, never force-pushes, and never pushes when
+verification failed. If CI is red the answer is to fix the code.
+
+> **`submit-pr` is PowerShell only.** There is no `.sh` twin, deliberately: this repository's
+> developer platform is Windows, and shipping a second untested implementation of the submission
+> sequence would be the duplication the gate design exists to avoid. The *decision* is already
+> platform-neutral — [`scripts/submit-gate.mjs`](../scripts/submit-gate.mjs) — so a POSIX twin would
+> be plumbing only, and is a small, deliberate follow-up rather than an accident.
+
+## Verification evidence
+
+Every run prints repository, branch, verified commit, scope, environment, the stages executed with
+their outcomes, the result, and a completion timestamp. The block is rendered inside the container,
+because the container is the only party that knows what it actually ran.
+
+It also writes `artifacts/local-ci/latest.json`, which is git-ignored — it is one machine's
+transient record, not a reviewed artifact, and this repository's intentional evidence-retention
+lives elsewhere (attestations in `project-policy.yml`, reviews under `artifacts/`).
+
+```json
+{
+  "result": "passed",
+  "failedStage": null,
+  "commit": "9cb5376f397ca2bab4631363d8718f8826f02ca1",
+  "branch": "chore/local-docker-ci",
+  "repository": "https://github.com/mikeycdavis/EngineeringStandards.git",
+  "environment": { "node": "v20.20.2", "image": "engineeringstandards-ci:local", "containerized": true },
+  "scope": "complete",
+  "startedAt": "…",
+  "completedAt": "…",
+  "checks": [{ "id": "test", "outcome": "passed", "exitCode": 0, "gating": true }]
+}
+```
+
+Three fields exist to stop a record being read as more than it is. `commit` is resolved *inside* the
+container, so a stale image announces itself rather than passing under the current commit's name.
+`scope` is `partial` when only some stages ran, and the gate refuses anything but `complete`.
+`containerized` is false for a host run, and the gate refuses those too — a pass on the developer's
+machine proves the developer's machine.
+
+## What the pull request claims
+
+```markdown
+## Local CI
+
+This pipeline ran in an ephemeral Docker container on the author's machine.
+It is **not** a GitHub-hosted Actions run and makes no claim about one.
+
+- Verified commit: `<full sha>`
+- Result: **PASS**
+- Environment: Docker (…)
+```
+
+Your body is never replaced; the block is appended below a rule. The wording is asserted by a test:
+reporting a GitHub-hosted success that did not happen would be `errors.no-false-success` reasoning
+applied one level up from the code.
+
+## Isolation
+
+**Containers and networks.** Each run gets a unique compose project name derived from the repository
+directory plus a timestamp and PID, so two concurrent runs — of this repository or any other — cannot
+share a container, a network, or a teardown. Teardown removes exactly what the run created. There is
+no `docker system prune` anywhere in these scripts and a test asserts there never is one: a CI script
+that garbage-collects the host is a CI script that deletes someone's work.
+
+**The host filesystem.** The repository is *copied into the image*, not bind-mounted. Nothing on the
+host is reachable from inside the container, so a failing test cannot touch the working tree even if
+it tries — which matters here, because the suite genuinely writes files (the invocation-ownership
+negative control materialises a patched copy of the evaluator). The verification record is copied
+*out* of the stopped container afterwards.
+
+**The network.** `network_mode: none`. The pipeline resolves nothing and installs nothing, so the
+strongest setting is also the correct one — and it is a check as much as a hardening: if a stage ever
+starts needing the network, the run fails rather than quietly depending on the developer's
+connectivity.
+
+**Privileges.** The pipeline runs as the non-root `node` user. The Docker socket is not mounted;
+nothing in this pipeline starts a container.
+
+**Databases.** There are none. This repository has no database, cache, or message broker: the checks
+read files, run `git`, and compare text. No developer database is touched because no database is
+involved at all. The standing preference — T-SQL on `localhost` — is a preference for *if* one is
+needed, and one is not; adding a SQL Server container to satisfy a template would be a service
+nothing connects to. [`compose.ci.yml`](../compose.ci.yml) documents exactly how a dependency would
+be added when that changes: a sibling service with a real `healthcheck`, depended on by
+`condition: service_healthy`. `scripts/ci.*` already brings up every non-`ci` service with
+`docker compose up --wait`, which blocks on those healthchecks and fails when one never becomes
+healthy. No sleep is involved now and none would be then.
+
+## Failures and debugging
+
+Cleanup runs on every exit path — success, failure, and interruption — because cleanup that only
+happens on success is cleanup that never happens when it matters.
+
+To keep the container for inspection:
+
+```bash
+.\scripts\ci.ps1 -KeepOnFailure
+```
+
+It prints the exact commands, which are:
+
+```bash
+docker logs <project>-ci
+```
+
+```bash
+docker compose -p <project> -f compose.ci.yml run --rm --entrypoint bash ci
+```
+
+That second one drops you into the same image, at `/work`, with the same tree CI saw. Individual
+stages can be run there: `node scripts/pipeline.mjs run audit`. Remember that a partial run's record
+is marked `partial` and cannot be used to submit.
+
+Remove a kept run:
+
+```bash
+docker rm -f <project>-ci && docker compose -p <project> -f compose.ci.yml down --volumes --remove-orphans
+```
+
+## Local CI versus GitHub Actions
+
+They are not the same thing and the documentation does not pretend otherwise.
+
+| | Local Docker CI | GitHub Actions |
+| --- | --- | --- |
+| Runs | Before push, on the developer's machine | On push and pull request, if a runner is available |
+| Proves | This commit passed the gating checks in a pinned container | The same, on GitHub's infrastructure |
+| Required for a PR | **Yes**, by `scripts/submit-pr.ps1` | No |
+| Check list | `scripts/pipeline.mjs` | `.github/workflows/ci.yml`, running the same commands |
+
+The workflows were **not** deleted. `ci.yml` still runs the same `npm run …` commands, and a test
+(`test/local-ci.test.mjs`) fails if the workflow and the pipeline manifest ever name different sets —
+in either direction, so a step added to the workflow by hand is caught as readily as one removed.
+
+### What cannot be reproduced locally
+
+| Not reproduced | Why |
+| --- | --- |
+| `standards-dogfood.yml` | It exercises GitHub's `workflow_call` resolution — checking out the framework from GitHub at a pinned SHA and invoking a reusable workflow. That *is* the thing under test (ADR 0013, distribution fidelity); running it locally would test something else. Its local equivalent is the `validate` stage, which produces the verdict the distributed check must reproduce. |
+| Branch protection and required-check status | A property of the GitHub repository, not of any pipeline. Note that `gh api …/branches/develop/protection` currently returns 404 — protection is not configured. |
+| `actions/upload-artifact`, job summaries | Runner-hosted presentation. The equivalent evidence is `artifacts/local-ci/latest.json` and the printed summary. |
+| Multi-OS or multi-Node matrices | Neither workflow declares one today. The image pins Node 20 to match the runner; `package.json` declares `engines: >=18`, so an 18 floor check is an available follow-up rather than lost coverage. |
+
+Nothing from the existing pipeline was dropped. Every `run:` step in the required `test` job maps to
+a gating stage, and the `validate` job maps to the advisory stage — asserted by test, both ways.
+
+## Self-hosted runner, later
+
+Nothing needs redesigning to add one. A self-hosted runner would invoke `./scripts/ci.sh` and nothing
+else; the stage list, the image, the isolation and the evidence record are all already inside that
+call. No runner is configured today and none is required.
+
+## Reusing this in another repository
+
+Copy `compose.ci.yml`, `ci/Dockerfile`, `.dockerignore`, `scripts/ci.ps1`, `scripts/ci.sh`,
+`scripts/pipeline.mjs`, `scripts/submit-gate.mjs`, `scripts/submit-decide.ps1`,
+`scripts/submit-pr.ps1`, and the `artifacts/local-ci/` line from `.gitignore`. Then change two
+things: the `STAGES` list in `scripts/pipeline.mjs`, and the base image in `ci/Dockerfile` if the
+project is not Node. Container, image, and project names are derived from the repository directory,
+so nothing else is repository-specific.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "fidelity": "node scripts/fidelity.mjs",
     "policy": "node scripts/policy.mjs",
     "diagrams": "node scripts/diagrams.mjs",
-    "audit:strict": "node scripts/standards.mjs audit . --strict"
+    "audit:strict": "node scripts/standards.mjs audit . --strict",
+    "pipeline": "node scripts/pipeline.mjs list"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -1,0 +1,180 @@
+<#
+.SYNOPSIS
+    Run this repository's complete CI pipeline in an ephemeral Docker container.
+
+.DESCRIPTION
+    The authoritative local CI command. Exit 0 means every gating check passed on the tree in this
+    working directory; anything else means it did not.
+
+    What this script does and does not decide: it owns the *environment* — building the image,
+    starting dependencies, waiting on their health, extracting the verification record, tearing
+    everything down. It owns none of the *checks*. Those are listed in scripts/pipeline.mjs, which
+    .github/workflows/ci.yml runs as well, so there is one statement of what CI covers rather than
+    one per executor.
+
+    Host requirements: Docker and git. Nothing else — no Node, no npm, no globally installed
+    anything. The checks run against a Node baked into the image at a pinned digest, which is the
+    point: a green run here says nothing about what the developer happens to have installed.
+
+.PARAMETER KeepOnFailure
+    Leave the container and network in place when the run fails, so it can be inspected. The script
+    prints the exact commands to use. Without this, teardown happens on every path including failure.
+
+.PARAMETER Verbose
+    Print each stage's rationale before running it. Stage output is always shown.
+
+.PARAMETER Project
+    Override the generated compose project name. Only useful when reproducing a kept-on-failure run.
+
+.EXAMPLE
+    .\scripts\ci.ps1
+.EXAMPLE
+    .\scripts\ci.ps1 -KeepOnFailure
+#>
+[CmdletBinding()]
+param(
+    [switch] $KeepOnFailure,
+    [string] $Project
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ComposeFile = Join-Path $RepoRoot 'compose.ci.yml'
+$ReportDir = Join-Path $RepoRoot 'artifacts/local-ci'
+$ReportPath = Join-Path $ReportDir 'latest.json'
+
+# Names derived from the directory rather than hardcoded, so this file can be copied into another
+# repository unchanged. The image is stable per repository (layer cache); the project is unique per
+# run, so two concurrent runs — of this repository or of any other — cannot share a container, a
+# network, or a teardown.
+$RepoSlug = ((Split-Path -Leaf $RepoRoot) -replace '[^A-Za-z0-9]', '-').ToLowerInvariant()
+$Image = "$RepoSlug-ci:local"
+if (-not $Project) {
+    $Project = "$RepoSlug-ci-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())-$PID"
+}
+
+$CiContainer = "$Project-ci"
+
+$env:CI_IMAGE = $Image
+$env:LOCAL_CI_VERBOSE = if ($PSBoundParameters.ContainsKey('Verbose')) { '1' } else { '0' }
+
+# Streams the command's output to the console and returns only its exit code.
+#
+# `Out-Host` is load-bearing. Without it the native command's stdout becomes part of the function's
+# return value, so `(Invoke-Compose build) -ne 0` compares an array of log lines against 0 and is
+# always true — a successful build reported as a failed one, which is exactly what happened the
+# first time this script ran.
+function Invoke-Compose {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $ComposeArgs)
+    & docker compose -p $Project -f $ComposeFile @ComposeArgs 2>&1 | Out-Host
+    return $LASTEXITCODE
+}
+
+# The reading counterpart, for commands whose output is data rather than a log.
+function Get-ComposeOutput {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $ComposeArgs)
+    return (& docker compose -p $Project -f $ComposeFile @ComposeArgs 2>$null)
+}
+
+function Write-Stage([string] $Text) {
+    Write-Host ""
+    Write-Host "==> $Text" -ForegroundColor Cyan
+}
+
+# Teardown removes exactly what this run created: containers, the run's network, and volumes
+# attached to this compose project. It is scoped by the unique project name, so it can never reach a
+# developer's own containers, volumes, or databases. There is no `docker system prune` here and
+# there must never be one — a CI script that garbage-collects the host is a CI script that deletes
+# someone's work.
+function Remove-CiEnvironment {
+    Write-Stage "Tearing down project '$Project'"
+    # The one-off `run` container is named, so it is removed by name; `down` then removes the
+    # project's network and any volumes it created. Both are scoped to this run's project.
+    & docker rm --force --volumes $CiContainer 2>&1 | Out-Null
+    & docker compose -p $Project -f $ComposeFile down --volumes --remove-orphans --timeout 10 2>&1 |
+        Write-Host
+}
+
+$exitCode = 1
+try {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw "docker was not found on PATH. Docker is the only required host dependency besides git."
+    }
+    & docker info --format '{{.ServerVersion}}' > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "the Docker daemon is not reachable. Start Docker Desktop (or dockerd) and retry."
+    }
+    if (-not (Test-Path $ComposeFile)) { throw "compose file not found: $ComposeFile" }
+
+    Write-Host "repository : $RepoRoot"
+    Write-Host "image      : $Image"
+    Write-Host "project    : $Project"
+
+    Write-Stage "Building the CI image"
+    if ((Invoke-Compose build) -ne 0) { throw "the CI image failed to build." }
+
+    # Dependencies, if this repository ever grows any. `--wait` blocks on each service's declared
+    # healthcheck and fails when one never becomes healthy; no sleep is involved. Today the list is
+    # empty — there is no database, cache, or broker — so this is a no-op that costs one command and
+    # means adding a service later requires no change to this script.
+    $services = (Get-ComposeOutput config --services) | Where-Object { $_ -and $_.Trim() -ne 'ci' }
+    if ($services) {
+        Write-Stage "Starting dependencies and waiting for health: $($services -join ', ')"
+        if ((Invoke-Compose up --detach --wait @services) -ne 0) {
+            throw "a dependency never became healthy."
+        }
+    }
+
+    Write-Stage "Running the pipeline"
+    # `run --name` rather than `run --rm`: the container must outlive its own exit long enough for
+    # the verification record to be copied out of it. `run` also propagates the pipeline's exit code
+    # directly and leaves its output unprefixed, which `up` does not.
+    $pipelineExit = Invoke-Compose run --name $CiContainer ci
+
+    Write-Stage "Extracting the verification record"
+    New-Item -ItemType Directory -Force -Path $ReportDir | Out-Null
+    if (Test-Path $ReportPath) { Remove-Item $ReportPath -Force }
+    # Copied out of the stopped container rather than written through a bind mount. Nothing on the
+    # host was reachable from inside the container, so a failing test could not have touched the
+    # developer's tree even if it tried.
+    & docker cp "${CiContainer}:/work/artifacts/local-ci/latest.json" $ReportPath 2>&1 | Out-Null
+
+    if (Test-Path $ReportPath) {
+        Write-Host "record          : $ReportPath"
+    }
+    elseif ($pipelineExit -eq 0) {
+        # A pass with no record is not a pass anyone can act on: submit-pr has nothing to check the
+        # commit against, and a reader has nothing to read.
+        throw "the pipeline reported success but produced no verification record."
+    }
+
+    $exitCode = $pipelineExit
+}
+catch {
+    Write-Host ""
+    Write-Host "CI could not complete: $($_.Exception.Message)" -ForegroundColor Red
+    $exitCode = 2
+}
+finally {
+    if ($KeepOnFailure -and $exitCode -ne 0) {
+        Write-Host ""
+        Write-Host "Containers kept for inspection (-KeepOnFailure)." -ForegroundColor Yellow
+        Write-Host "  docker logs $CiContainer"
+        Write-Host "  docker compose -p $Project -f compose.ci.yml run --rm --entrypoint bash ci"
+        Write-Host "  docker rm -f $CiContainer; docker compose -p $Project -f compose.ci.yml down --volumes --remove-orphans"
+    }
+    else {
+        Remove-CiEnvironment
+    }
+}
+
+Write-Host ""
+if ($exitCode -eq 0) {
+    Write-Host "LOCAL CI PASSED" -ForegroundColor Green
+}
+else {
+    Write-Host "LOCAL CI FAILED (exit $exitCode)" -ForegroundColor Red
+}
+exit $exitCode

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -46,14 +46,23 @@ $ReportDir = Join-Path $RepoRoot 'artifacts/local-ci'
 $ReportPath = Join-Path $ReportDir 'latest.json'
 
 # Names derived from the directory rather than hardcoded, so this file can be copied into another
-# repository unchanged. The image is stable per repository (layer cache); the project is unique per
-# run, so two concurrent runs — of this repository or of any other — cannot share a container, a
-# network, or a teardown.
+# repository unchanged. The project is unique per run, so two concurrent runs — of this repository or
+# of any other — cannot share a container, a network, or a teardown.
 $RepoSlug = ((Split-Path -Leaf $RepoRoot) -replace '[^A-Za-z0-9]', '-').ToLowerInvariant()
-$Image = "$RepoSlug-ci:local"
 if (-not $Project) {
     $Project = "$RepoSlug-ci-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())-$PID"
 }
+
+# The image tag is unique per run, not stable per repository, and the difference is a correctness
+# one rather than a tidiness one. A stable `<slug>-ci:local` is derived from the directory *basename*,
+# so two clones of this repository — a worktree, a second checkout, a colleague's copy under the same
+# folder name — resolve to the same tag. If one run's build finishes while the other is between its
+# own build and its `compose run`, the second container executes the first checkout's code, and the
+# run reports a result for a tree nobody asked about. Submission still refuses that result, because
+# the record names a commit that is not HEAD, but `ci.ps1` on its own would have printed a green pass
+# for the wrong source. Tagging per run removes the window instead of relying on the later check to
+# catch it. Layers are shared, so the rebuild is a cache hit and costs no meaningful time.
+$Image = "$RepoSlug-ci:$Project"
 
 $CiContainer = "$Project-ci"
 
@@ -95,6 +104,10 @@ function Remove-CiEnvironment {
     & docker rm --force --volumes $CiContainer 2>&1 | Out-Null
     & docker compose -p $Project -f $ComposeFile down --volumes --remove-orphans --timeout 10 2>&1 |
         Write-Host
+    # The run's own image tag, removed by that exact name. Untagging this run's build cannot affect
+    # another run, because no other run shares the tag — that is the point of naming it per project.
+    # The layers stay in the builder cache, so the next run is still fast.
+    & docker image rm $Image 2>&1 | Out-Null
 }
 
 $exitCode = 1
@@ -107,6 +120,19 @@ try {
         throw "the Docker daemon is not reachable. Start Docker Desktop (or dockerd) and retry."
     }
     if (-not (Test-Path $ComposeFile)) { throw "compose file not found: $ComposeFile" }
+
+    # A linked worktree's `.git` is a *file* holding `gitdir: <absolute host path>` pointing into the
+    # main checkout's .git/worktrees/. The build context copies that pointer faithfully and its target
+    # does not exist in the image, so every `git` call inside the container fails and the pipeline
+    # aborts in preflight with exit 2. Refused here, by name, rather than left to surface as an
+    # unexplained failure several minutes into a run.
+    #
+    # Not worked around: the fix would mean copying an absolute path from outside the build context
+    # into the image, which is exactly the broad host reach this environment is built to avoid, to
+    # support a checkout shape the developer can step out of with one `cd`.
+    if (Test-Path (Join-Path $RepoRoot '.git') -PathType Leaf) {
+        throw "this is a linked git worktree, whose .git points outside the build context. Run CI from the main working tree."
+    }
 
     Write-Host "repository : $RepoRoot"
     Write-Host "image      : $Image"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Run this repository's complete CI pipeline in an ephemeral Docker container.
+#
+# The POSIX twin of scripts/ci.ps1, for Linux and macOS developers and for a future GitHub
+# self-hosted runner, which would invoke this file and nothing else. The two scripts own the
+# environment; neither owns the check list. That lives in scripts/pipeline.mjs, which
+# .github/workflows/ci.yml also runs, so adding a check means editing one file rather than three.
+#
+# Host requirements: Docker and git. No Node, no npm, no globally installed anything — the checks
+# run against a Node baked into the image at a pinned digest.
+#
+# Usage:
+#   ./scripts/ci.sh [--keep-on-failure] [--verbose] [--project NAME]
+set -euo pipefail
+
+keep_on_failure=0
+verbose=0
+project=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-on-failure) keep_on_failure=1 ;;
+    --verbose) verbose=1 ;;
+    --project) project="${2:?--project needs a name}"; shift ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+compose_file="$repo_root/compose.ci.yml"
+report_dir="$repo_root/artifacts/local-ci"
+report_path="$report_dir/latest.json"
+
+# Derived from the directory rather than hardcoded, so this file can be copied into another
+# repository unchanged. Stable image name for the layer cache; unique project name per run, so two
+# concurrent runs cannot share a container, a network, or a teardown.
+repo_slug="$(basename "$repo_root" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+image="${repo_slug}-ci:local"
+[ -n "$project" ] || project="${repo_slug}-ci-$(date -u +%s)-$$"
+ci_container="${project}-ci"
+export CI_IMAGE="$image"
+export LOCAL_CI_VERBOSE="$verbose"
+
+compose() { docker compose -p "$project" -f "$compose_file" "$@"; }
+stage() { printf '\n==> %s\n' "$1"; }
+
+# Teardown removes exactly what this run created, scoped by the unique project name. It can never
+# reach a developer's own containers, volumes, or databases. There is deliberately no
+# `docker system prune` anywhere in this file: a CI script that garbage-collects the host is a CI
+# script that deletes someone's work.
+teardown() {
+  stage "Tearing down project '$project'"
+  # The one-off `run` container is named, so it is removed by name; `down` then removes the
+  # project's network and any volumes it created. Both are scoped to this run's project.
+  docker rm --force --volumes "$ci_container" >/dev/null 2>&1 || true
+  compose down --volumes --remove-orphans --timeout 10 || true
+}
+
+exit_code=1
+finish() {
+  if [ "$keep_on_failure" -eq 1 ] && [ "$exit_code" -ne 0 ]; then
+    printf '\nContainers kept for inspection (--keep-on-failure).\n'
+    printf '  docker logs %s\n' "$ci_container"
+    printf '  docker compose -p %s -f compose.ci.yml run --rm --entrypoint bash ci\n' "$project"
+    printf '  docker rm -f %s && docker compose -p %s -f compose.ci.yml down --volumes --remove-orphans\n' "$ci_container" "$project"
+  else
+    teardown
+  fi
+  printf '\n'
+  if [ "$exit_code" -eq 0 ]; then echo "LOCAL CI PASSED"; else echo "LOCAL CI FAILED (exit $exit_code)"; fi
+}
+# Runs on every exit path, including an interrupted run. Cleanup that only happens on success is
+# cleanup that never happens when it matters.
+trap finish EXIT
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker was not found on PATH. Docker is the only required host dependency besides git." >&2
+  exit_code=2; exit 2
+}
+docker info --format '{{.ServerVersion}}' >/dev/null 2>&1 || {
+  echo "the Docker daemon is not reachable. Start Docker and retry." >&2
+  exit_code=2; exit 2
+}
+
+echo "repository : $repo_root"
+echo "image      : $image"
+echo "project    : $project"
+
+stage "Building the CI image"
+compose build
+
+# Dependencies, if this repository ever grows any. `--wait` blocks on each declared healthcheck and
+# fails when a service never becomes healthy; no sleep is involved. The list is empty today — no
+# database, cache, or broker — so this costs one command and means adding a service later needs no
+# change here.
+services="$(compose config --services | grep -v '^ci$' || true)"
+if [ -n "$services" ]; then
+  stage "Starting dependencies and waiting for health: $(echo "$services" | tr '\n' ' ')"
+  # shellcheck disable=SC2086
+  compose up --detach --wait $services
+fi
+
+stage "Running the pipeline"
+# `run --name` rather than `run --rm`: the container must outlive its own exit long enough for the
+# verification record to be copied out. `run` also propagates the pipeline's exit code directly and
+# leaves its output unprefixed, which `up` does not. The summary block the pipeline prints is
+# rendered inside the container, so this script formats nothing and cannot drift from its twin.
+pipeline_exit=0
+compose run --name "$ci_container" ci || pipeline_exit=$?
+
+stage "Extracting the verification record"
+mkdir -p "$report_dir"
+rm -f "$report_path"
+# Copied out of the stopped container rather than written through a bind mount. Nothing on the host
+# was reachable from inside the container.
+docker cp "${ci_container}:/work/artifacts/local-ci/latest.json" "$report_path" >/dev/null 2>&1 || true
+
+if [ -f "$report_path" ]; then
+  echo "record          : $report_path"
+elif [ "$pipeline_exit" -eq 0 ]; then
+  # A pass with no record is not a pass anyone can act on: submit-pr has nothing to check the commit
+  # against, and a reader has nothing to read.
+  echo "the pipeline reported success but produced no verification record." >&2
+  pipeline_exit=2
+fi
+
+exit_code="$pipeline_exit"
+exit "$exit_code"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,11 +34,16 @@ report_dir="$repo_root/artifacts/local-ci"
 report_path="$report_dir/latest.json"
 
 # Derived from the directory rather than hardcoded, so this file can be copied into another
-# repository unchanged. Stable image name for the layer cache; unique project name per run, so two
-# concurrent runs cannot share a container, a network, or a teardown.
+# repository unchanged. Unique project name per run, so two concurrent runs cannot share a container,
+# a network, or a teardown.
 repo_slug="$(basename "$repo_root" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
-image="${repo_slug}-ci:local"
 [ -n "$project" ] || project="${repo_slug}-ci-$(date -u +%s)-$$"
+
+# Unique per run, for the reason spelled out in scripts/ci.ps1: a tag derived from the directory
+# basename is shared by every clone with that name, so one run's build can replace the image another
+# run is about to execute, and the result would describe the wrong tree. Layers are shared; the
+# rebuild is a cache hit.
+image="${repo_slug}-ci:${project}"
 ci_container="${project}-ci"
 export CI_IMAGE="$image"
 export LOCAL_CI_VERBOSE="$verbose"
@@ -56,6 +61,8 @@ teardown() {
   # project's network and any volumes it created. Both are scoped to this run's project.
   docker rm --force --volumes "$ci_container" >/dev/null 2>&1 || true
   compose down --volumes --remove-orphans --timeout 10 || true
+  # This run's own image tag, removed by that exact name. No other run shares it.
+  docker image rm "$image" >/dev/null 2>&1 || true
 }
 
 exit_code=1
@@ -83,6 +90,16 @@ docker info --format '{{.ServerVersion}}' >/dev/null 2>&1 || {
   echo "the Docker daemon is not reachable. Start Docker and retry." >&2
   exit_code=2; exit 2
 }
+
+# A linked worktree's `.git` is a file holding `gitdir: <absolute host path>`. The build context
+# copies the pointer and not its target, so every `git` call in the container fails and the pipeline
+# aborts in preflight. Named here rather than left to surface as an unexplained exit 2. Deliberately
+# not worked around: the fix means copying an absolute path from outside the build context into the
+# image, which is the broad host reach this environment exists to avoid.
+if [ -f "$repo_root/.git" ]; then
+  echo "this is a linked git worktree, whose .git points outside the build context. Run CI from the main working tree." >&2
+  exit_code=2; exit 2
+fi
 
 echo "repository : $repo_root"
 echo "image      : $image"

--- a/scripts/pipeline.mjs
+++ b/scripts/pipeline.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+/**
+ * The pipeline definition — one place that says what "this repository's CI" means.
+ *
+ * Two things execute this repository's checks: `.github/workflows/ci.yml` on a GitHub runner, and
+ * `compose.ci.yml` in a local container. Before this file existed there was one of those, and its
+ * step list was the only statement of what CI covered. A second executor written independently
+ * would have been a second definition, and the two would have agreed right up until someone added a
+ * check to one of them — which is the failure mode this repository already documents for standards
+ * copied between projects (Standard 22 R6) and for domain logic duplicated across layers
+ * (Standard 51 R3). So the list lives here, both executors read it, and `test/local-ci.test.mjs`
+ * fails when the workflow and this file disagree.
+ *
+ * **Commands are `npm run <script>` on purpose.** package.json already names the authoritative
+ * invocation of each check; restating `node scripts/inventory.mjs` here would be a third definition
+ * of the same thing. This file decides *which* checks run and *what their failure means* — not how
+ * a check is spelled.
+ *
+ * ## Gating versus advisory, and why the distinction is not a softening
+ *
+ * `validate` is the authoritative verdict (ADR 0004) and this repository is *intentionally*
+ * `NON_COMPLIANT`: rules carry recorded human rejections, so exit 1 is the correct answer and will
+ * stay the correct answer until those rejections are withdrawn. `ci.yml` already separates it into
+ * its own job for exactly this reason — a required check that can never pass leaves no legal path to
+ * change `develop`, which this repository learned by making `develop` unmergeable.
+ *
+ * This file reproduces that boundary rather than inventing one. The gating set is precisely what
+ * branch protection requires on GitHub; `validate` runs on every local run, its exit code is
+ * recorded, and it is never suppressed, hidden, or reported as a pass. What it does not do is decide
+ * whether a pull request may be opened, because on GitHub it does not decide that either.
+ *
+ * Holds no module-level run state: every mutable value is local to a call.
+ */
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXIT_FAILED = 1;
+const EXIT_INVOCATION = 2;
+
+/**
+ * Every check this repository runs, in execution order.
+ *
+ * `gating: true` means a failure blocks a pull request. It must match, exactly, the step list of the
+ * `test` job in `.github/workflows/ci.yml` — the job branch protection names.
+ *
+ * `gating: false` means the stage runs and reports and cannot block. There is one, and adding a
+ * second should be an argued decision rather than a convenience: an advisory stage is a check whose
+ * failure nobody has to answer for.
+ */
+export const STAGES = [
+  {
+    id: "inventory",
+    command: "npm run inventory",
+    gating: true,
+    title: "Source inventory",
+    why: "The standards series has not silently changed shape; extraction is compared against the reviewed, committed inventory rather than re-derived.",
+  },
+  {
+    id: "fidelity",
+    command: "npm run fidelity",
+    gating: true,
+    title: "Source fidelity",
+    why: "Every block claiming to be verbatim source is verified against that standard's own declared source sections.",
+  },
+  {
+    id: "policy",
+    command: "npm run policy",
+    gating: true,
+    title: "Project policy",
+    why: "This repository's project-policy.yml validates against its schema. An unreadable policy (exit 2) and a compliance condition such as an expired exception (exit 1) are both failures here.",
+  },
+  {
+    id: "diagrams",
+    command: "npm run diagrams",
+    gating: true,
+    title: "Diagram freshness",
+    why: "Standard 39 R4: Mermaid source and its embedded copies must not drift. Text comparison, not rendering — which is what lets a zero-dependency repository enforce the rule at all.",
+  },
+  {
+    id: "test",
+    command: "npm test",
+    gating: true,
+    title: "Test suite",
+    why: "The full node:test suite, including the assertion that this repository's own audit produces no error-severity finding.",
+  },
+  {
+    id: "audit",
+    command: "npm run audit",
+    gating: true,
+    title: "Self-audit",
+    why: "The audit tool is run against the repository that defines it. Deliberately not --strict: that flag fails on warnings, which turns every advisory heuristic into a broken build and gets the step disabled.",
+  },
+  {
+    id: "validate",
+    command: "npm run validate",
+    gating: false,
+    title: "Compliance verdict (advisory — reported, never gating)",
+    why: "ADR 0004's authoritative verdict. Expected to exit 1: this repository is intentionally NON_COMPLIANT while recorded human rejections stand. Non-gating here for the same reason it is a separate, non-required job in ci.yml — not because a failure is acceptable, but because this failure is the honest answer and gating on it would leave no legal path to change develop.",
+  },
+];
+
+/** The gating set, as the workflow's required job must also run it. */
+export const gatingStages = () => STAGES.filter((s) => s.gating);
+
+/**
+ * Restore/install, stated rather than omitted.
+ *
+ * There is no dependency-installation stage and its absence is a decision, not an oversight: this
+ * repository has zero third-party dependencies, recorded in design/standards-audit-cli.md and
+ * enforced structurally by CI having no install step. An `npm ci` appearing in this pipeline would
+ * mean that decision changed. A reader comparing this pipeline against a conventional one should
+ * find the answer here rather than concluding a step was forgotten.
+ */
+export const RESTORE = {
+  stage: "none",
+  reason:
+    "Zero third-party dependencies by decision (design/standards-audit-cli.md). No install step exists, in this pipeline or in ci.yml, and its absence is what enforces the decision.",
+};
+
+function runStage(stage, cwd, verbose) {
+  const started = new Date();
+  process.stdout.write(`\n=== ${stage.id} :: ${stage.command}${stage.gating ? "" : "  [advisory]"}\n`);
+  // `--verbose` adds the rationale, not the output. Stage output is always inherited: a CI log that
+  // hides what a check said until someone remembers a flag is a log nobody reads when it matters.
+  if (verbose) process.stdout.write(`    ${stage.why}\n`);
+  const result = spawnSync(stage.command, { cwd, shell: true, stdio: "inherit" });
+  // A signal death carries no exit status. Treating it as 0 would report a killed stage as a passing
+  // one, which is the false green the whole framework exists to refuse.
+  const code = result.error ? EXIT_INVOCATION : (result.status ?? EXIT_INVOCATION);
+  const outcome = code === 0 ? "passed" : stage.gating ? "failed" : "advisory-failed";
+  process.stdout.write(`--- ${stage.id}: ${outcome} (exit ${code})\n`);
+  return {
+    id: stage.id,
+    command: stage.command,
+    gating: stage.gating,
+    exitCode: code,
+    outcome,
+    startedAt: started.toISOString(),
+    completedAt: new Date().toISOString(),
+    ...(result.error ? { error: result.error.message } : {}),
+  };
+}
+
+/**
+ * Run stages and produce the machine-readable record.
+ *
+ * The record reports every stage including the advisory one, with its real exit code. That is
+ * deliberate: a report that listed only gating stages would let a reader conclude the compliance
+ * verdict passed, and this repository's verdict does not pass.
+ */
+/**
+ * What this run was run *against*, established by the runner rather than asserted by its caller.
+ *
+ * The commit is read from the repository the pipeline is executing on — inside the container, that
+ * is the copy baked into the image. This matters for the submission invariant: `submit-pr` compares
+ * the host's HEAD against *this* value, so a stale image announces itself instead of passing under
+ * the current commit's name. A host-supplied commit would have been the host describing itself, and
+ * would agree with the host no matter what the container actually checked.
+ */
+function provenance(cwd) {
+  const git = (args) => {
+    const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+    return r.status === 0 ? r.stdout.trim() : null;
+  };
+  return {
+    commit: git(["rev-parse", "HEAD"]),
+    branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    repository: git(["config", "--get", "remote.origin.url"]),
+    environment: {
+      node: process.version,
+      platform: `${process.platform}/${process.arch}`,
+      // Set by compose from the image it built, so the record names the environment that produced it.
+      image: process.env.CI_IMAGE ?? null,
+      containerized: process.env.LOCAL_CI_CONTAINER === "1",
+    },
+  };
+}
+
+export function runPipeline({ cwd, only = null, verbose = false } = {}) {
+  const selected = only ? STAGES.filter((s) => only.includes(s.id)) : STAGES;
+  if (only) {
+    const unknown = only.filter((id) => !STAGES.some((s) => s.id === id));
+    if (unknown.length) throw new Error(`unknown stage(s): ${unknown.join(", ")}`);
+  }
+
+  const startedAt = new Date().toISOString();
+  const checks = [];
+  let firstFailure = null;
+  for (const stage of selected) {
+    const record = runStage(stage, cwd, verbose);
+    checks.push(record);
+    // Fail fast, but only on a gating stage. An advisory failure is recorded and the run continues,
+    // because stopping there would make the advisory stage gating by another name.
+    if (record.outcome === "failed") {
+      firstFailure = record.id;
+      break;
+    }
+  }
+
+  const ranEveryGatingStage = gatingStages()
+    .filter((s) => !only || only.includes(s.id))
+    .every((s) => checks.some((c) => c.id === s.id && c.outcome === "passed"));
+
+  return {
+    result: firstFailure === null && ranEveryGatingStage ? "passed" : "failed",
+    failedStage: firstFailure,
+    ...provenance(cwd),
+    // A partial run must never look like a full one. `submit-pr` refuses anything but "complete",
+    // so `pipeline.mjs run audit` cannot be used to manufacture a passing record for one stage.
+    scope: only ? "partial" : "complete",
+    startedAt,
+    completedAt: new Date().toISOString(),
+    restore: RESTORE,
+    checks,
+  };
+}
+
+/**
+ * Refuse to run at all if the repository seam is unavailable.
+ *
+ * The audit asks `git` which paths this repository ignores and which are tracked, and the tracked
+ * half has no filesystem fallback: without git it reports evidence unavailability rather than
+ * guessing. That is the right behaviour and it is also why a run with a broken git is not a weaker
+ * run — it is a run answering a different question, and the exit code cannot tell you which one you
+ * got. Containerising this pipeline broke exactly this on the first attempt (the copied tree was
+ * owned by root while the process ran as `node`, and git refused it), so the condition is checked
+ * once, up front, with a message that names the cause.
+ */
+function preflight(cwd) {
+  const r = spawnSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" });
+  if (r.error) return { ok: false, message: `git is not available: ${r.error.message}` };
+  if (r.status !== 0) return { ok: false, message: `git could not read this repository:\n${(r.stderr ?? "").trim()}` };
+  return { ok: true, commit: r.stdout.trim() };
+}
+
+function usage() {
+  process.stderr.write(
+    "usage: node scripts/pipeline.mjs <list|run> [--json] [--verbose] [--report=PATH] [stage ...]\n",
+  );
+}
+
+function main(argv) {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const mode = argv[0];
+  const flags = argv.filter((a) => a.startsWith("--"));
+  const stages = argv.slice(1).filter((a) => !a.startsWith("--"));
+  const reportPath = flags.find((f) => f.startsWith("--report="))?.slice("--report=".length);
+
+  if (mode === "list") {
+    if (flags.includes("--json")) {
+      process.stdout.write(`${JSON.stringify({ stages: STAGES, restore: RESTORE }, null, 2)}\n`);
+    } else {
+      for (const s of STAGES) {
+        process.stdout.write(`${s.gating ? "gate    " : "advisory"}  ${s.id.padEnd(10)} ${s.command}\n`);
+      }
+    }
+    return 0;
+  }
+
+  if (mode !== "run") {
+    usage();
+    return EXIT_INVOCATION;
+  }
+
+  const ready = preflight(root);
+  if (!ready.ok) {
+    process.stderr.write(
+      `pipeline: ${ready.message}\n` +
+        "The audit resolves repository membership and ignore rules through git, so a run without it\n" +
+        "covers a different surface than CI does. Refusing to report a result for it.\n",
+    );
+    return EXIT_INVOCATION;
+  }
+
+  let report;
+  try {
+    report = runPipeline({
+      cwd: root,
+      only: stages.length ? stages : null,
+      // The environment variable exists because the command line is fixed in compose.ci.yml; the
+      // host scripts pass `--verbose` through as an env var rather than rewriting the command.
+      verbose: flags.includes("--verbose") || process.env.LOCAL_CI_VERBOSE === "1",
+    });
+  } catch (err) {
+    process.stderr.write(`pipeline: ${err.message}\n`);
+    return EXIT_INVOCATION;
+  }
+
+  if (reportPath) {
+    mkdirSync(path.dirname(reportPath), { recursive: true });
+    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  // The human-readable verification evidence, rendered here rather than in the host scripts. Two
+  // shells formatting the same record would be two renderings that drift, and the container is the
+  // only party that actually knows what it ran.
+  const field = (k) => `${k}`.padEnd(17);
+  process.stdout.write("\n");
+  process.stdout.write(`${field("repository")}: ${report.repository ?? "(no origin remote)"}\n`);
+  process.stdout.write(`${field("branch")}: ${report.branch}\n`);
+  process.stdout.write(`${field("verified commit")}: ${report.commit}\n`);
+  process.stdout.write(`${field("scope")}: ${report.scope}\n`);
+  process.stdout.write(
+    `${field("environment")}: ${report.environment.containerized ? "Docker" : "host"} ` +
+      `${report.environment.image ?? ""} Node ${report.environment.node}\n`,
+  );
+  process.stdout.write(`${field("stages")}:\n`);
+  for (const c of report.checks) {
+    process.stdout.write(`  ${c.outcome.padEnd(16)} ${c.id}${c.gating ? "" : "  [advisory]"}\n`);
+  }
+  process.stdout.write(`${field("result")}: ${report.result.toUpperCase()}\n`);
+  process.stdout.write(`${field("completed")}: ${report.completedAt}\n`);
+  return report.result === "passed" ? 0 : EXIT_FAILED;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/submit-decide.ps1
+++ b/scripts/submit-decide.ps1
@@ -11,8 +11,16 @@
     decides whether a pull request may be opened is evaluated in the same pinned environment that
     decided whether the code passes. There is no network: the decision reads nothing but its input.
 
-    The image is built if it is not already present, because the first decision happens before the
-    CI run that would otherwise have built it. The build is layer-cached and costs seconds.
+    The image is built on every invocation, from the current working tree, and removed afterwards.
+    Not an oversight, and not free: the build is layer-cached and costs seconds. What it buys is that
+    the gate evaluating this submission is the gate belonging to the commit being submitted.
+
+    Reusing a predictable tag if one already existed would mean the rule that decides whether a pull
+    request may be opened comes from whichever checkout last built that tag. When the gate's rules or
+    its input shape have changed since, the failures are quiet and asymmetric: a valid submission can
+    be refused by a rule that no longer exists, and a refusal added in this very commit is skipped
+    until the CI run rebuilds. Neither announces itself. The image is therefore identified per
+    invocation and never inherited.
 #>
 [CmdletBinding()]
 param(
@@ -24,30 +32,36 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-# Derived exactly as scripts/ci.ps1 derives it, so both refer to the same image.
+# Unique per invocation. A predictable tag would be shared with every other checkout of a directory
+# by this name, which is how a stale gate gets executed against a current submission.
 $RepoSlug = ((Split-Path -Leaf $RepoRoot) -replace '[^A-Za-z0-9]', '-').ToLowerInvariant()
-$Image = "$RepoSlug-ci:local"
+$Project = "$RepoSlug-ci-gate-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())-$PID"
+$Image = "${RepoSlug}-ci:$Project"
 
-& docker image inspect $Image > $null 2>&1
-if ($LASTEXITCODE -ne 0) {
+try {
     $env:CI_IMAGE = $Image
-    & docker compose -p "$RepoSlug-ci-gate" -f (Join-Path $RepoRoot 'compose.ci.yml') build 2>&1 | Out-Null
+    & docker compose -p $Project -f (Join-Path $RepoRoot 'compose.ci.yml') build 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "could not build the CI image, so no decision can be made." }
+
+    $mode = if ($PrBody) { 'pr-body' } else { 'decide' }
+    $json = $Facts | ConvertTo-Json -Depth 12 -Compress
+
+    # stdin carries the facts; stdout carries the answer. Nothing is written anywhere.
+    $output = $json | & docker run --rm --interactive --network none $Image node scripts/submit-gate.mjs $mode
+    $code = $LASTEXITCODE
+
+    if ($PrBody) {
+        if ($code -ne 0) { throw "the gate could not render the verification block (exit $code)." }
+        return ($output | Out-String)
+    }
+
+    # Exit 2 means the question was malformed, which is not the same as a refusal and must not be
+    # reported as one.
+    if ($code -eq 2) { throw "the gate could not evaluate the submission (exit 2): $($output | Out-String)" }
+    return ($output | Out-String | ConvertFrom-Json)
 }
-
-$mode = if ($PrBody) { 'pr-body' } else { 'decide' }
-$json = $Facts | ConvertTo-Json -Depth 12 -Compress
-
-# stdin carries the facts; stdout carries the answer. Nothing is written anywhere.
-$output = $json | & docker run --rm --interactive --network none $Image node scripts/submit-gate.mjs $mode
-$code = $LASTEXITCODE
-
-if ($PrBody) {
-    if ($code -ne 0) { throw "the gate could not render the verification block (exit $code)." }
-    return ($output | Out-String)
+finally {
+    # Removed by the exact name this invocation created, on every path including a thrown decision.
+    # No other invocation shares the tag, so this can remove nothing but its own.
+    & docker image rm $Image 2>&1 | Out-Null
 }
-
-# Exit 2 means the question was malformed, which is not the same as a refusal and must not be
-# reported as one.
-if ($code -eq 2) { throw "the gate could not evaluate the submission (exit 2): $($output | Out-String)" }
-return ($output | Out-String | ConvertFrom-Json)

--- a/scripts/submit-decide.ps1
+++ b/scripts/submit-decide.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Ask scripts/submit-gate.mjs for a verdict, or for the pull request's verification block.
+
+.DESCRIPTION
+    A shim, and deliberately nothing more. It serialises the facts, runs the gate inside the CI
+    image, and returns what the gate said.
+
+    The gate runs in the container rather than on the host for two reasons. It removes Node from
+    this workflow's host requirements — Docker and git are enough — and it means the rule that
+    decides whether a pull request may be opened is evaluated in the same pinned environment that
+    decided whether the code passes. There is no network: the decision reads nothing but its input.
+
+    The image is built if it is not already present, because the first decision happens before the
+    CI run that would otherwise have built it. The build is layer-cached and costs seconds.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] $Facts,
+    [Parameter(Mandatory = $true)] [string] $RepoRoot,
+    [switch] $PrBody
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Derived exactly as scripts/ci.ps1 derives it, so both refer to the same image.
+$RepoSlug = ((Split-Path -Leaf $RepoRoot) -replace '[^A-Za-z0-9]', '-').ToLowerInvariant()
+$Image = "$RepoSlug-ci:local"
+
+& docker image inspect $Image > $null 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $env:CI_IMAGE = $Image
+    & docker compose -p "$RepoSlug-ci-gate" -f (Join-Path $RepoRoot 'compose.ci.yml') build 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "could not build the CI image, so no decision can be made." }
+}
+
+$mode = if ($PrBody) { 'pr-body' } else { 'decide' }
+$json = $Facts | ConvertTo-Json -Depth 12 -Compress
+
+# stdin carries the facts; stdout carries the answer. Nothing is written anywhere.
+$output = $json | & docker run --rm --interactive --network none $Image node scripts/submit-gate.mjs $mode
+$code = $LASTEXITCODE
+
+if ($PrBody) {
+    if ($code -ne 0) { throw "the gate could not render the verification block (exit $code)." }
+    return ($output | Out-String)
+}
+
+# Exit 2 means the question was malformed, which is not the same as a refusal and must not be
+# reported as one.
+if ($code -eq 2) { throw "the gate could not evaluate the submission (exit 2): $($output | Out-String)" }
+return ($output | Out-String | ConvertFrom-Json)

--- a/scripts/submit-gate.mjs
+++ b/scripts/submit-gate.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * The exact-commit invariant, as a decision function.
+ *
+ *   A pull request may only be submitted if the exact commit SHA being pushed has successfully
+ *   passed the repository's complete containerized CI pipeline.
+ *
+ * This lives in Node rather than inside `submit-pr.ps1` and `submit-pr.sh` for one reason: the
+ * invariant has to be *tested*, and a rule implemented twice in two shells is two rules that agree
+ * until one of them is edited. The shell scripts gather facts — is this a repository, what branch,
+ * is the tree dirty, what was HEAD before and after — and this decides. `test/local-ci.test.mjs`
+ * drives every refusal path through this function without touching a real branch, a real remote, or
+ * real history.
+ *
+ * A refusal is not an error condition to be recovered from. Every branch below returns a reason and
+ * a message, and the caller's only permitted response is to print it and stop.
+ *
+ * Holds no module-level run state: `evaluateSubmission` is pure, and every value it reads arrives as
+ * an argument (ADR 0014).
+ */
+
+import { pathToFileURL } from "node:url";
+
+const EXIT_REFUSED = 1;
+const EXIT_INVOCATION = 2;
+
+/**
+ * Branches a pull request may not be *submitted from*.
+ *
+ * `master` and `develop` are integration branches in this repository, and the standing instruction
+ * is that neither is pushed to directly. `main` is included because this pattern is meant to be
+ * copied into repositories that use it, and a guard that silently does nothing in the next
+ * repository is worse than no guard.
+ */
+export const PROTECTED_BRANCHES = ["master", "main", "develop"];
+
+/** The two messages the task specifies verbatim, kept where both callers read the same string. */
+export const MESSAGES = {
+  ciFailed: "CI failed. No branch was pushed and no PR was created.",
+  headMoved:
+    "HEAD changed after CI verification. The current commit has not been verified. " +
+    "Re-run CI before submitting.",
+};
+
+const isSha = (v) => typeof v === "string" && /^[0-9a-f]{40}$/.test(v);
+
+/**
+ * Decide whether this submission may proceed.
+ *
+ * Checks are ordered cheapest-and-most-fundamental first, and the order is part of the contract:
+ * a dirty tree is reported before CI runs, so a developer is not made to wait ten minutes to be
+ * told something visible in the first second.
+ *
+ * @param {object} facts
+ * @param {boolean} facts.isRepository   `git rev-parse --git-dir` succeeded.
+ * @param {string}  facts.branch         Current branch name, or "HEAD" when detached.
+ * @param {string}  facts.base           The pull request's base branch.
+ * @param {string[]} facts.dirty         `git status --porcelain` lines. Empty means clean.
+ * @param {string}  facts.shaBefore      `git rev-parse HEAD` captured *before* CI ran.
+ * @param {string}  facts.shaAfter       `git rev-parse HEAD` captured *after* CI finished.
+ * @param {number}  facts.ciExitCode     Exit status of the containerized pipeline.
+ * @param {object|null} facts.evidence   Parsed artifacts/local-ci/latest.json, or null if absent.
+ * @returns {{allowed: boolean, reason: string, message: string}}
+ */
+export function evaluateSubmission(facts) {
+  const {
+    isRepository,
+    branch,
+    base,
+    dirty = [],
+    shaBefore,
+    shaAfter,
+    ciExitCode,
+    evidence = null,
+  } = facts ?? {};
+
+  if (!isRepository) {
+    return refuse("not-a-repository", "Not a Git repository. Run this from inside the repository.");
+  }
+
+  if (!branch || branch === "HEAD") {
+    return refuse(
+      "detached-head",
+      "HEAD is detached. A pull request is opened from a branch; check one out before submitting.",
+    );
+  }
+
+  if (PROTECTED_BRANCHES.includes(branch)) {
+    return refuse(
+      "protected-branch",
+      `Refusing to submit from '${branch}'. It is an integration branch, not a feature branch; ` +
+        "the workflow never pushes directly to one.",
+    );
+  }
+
+  if (branch === base) {
+    return refuse("branch-is-base", `The branch and the base are both '${branch}'. There is nothing to compare.`);
+  }
+
+  if (dirty.length > 0) {
+    // Refused rather than stashed. The commit that gets verified must be the commit that gets
+    // pushed, and any uncommitted change means the tree CI sees is not a commit at all — so there
+    // would be no SHA to hold the invariant against.
+    return refuse(
+      "dirty-tree",
+      `The working tree has ${dirty.length} uncommitted change(s). Commit or stash them: CI verifies a ` +
+        "commit, and an uncommitted change is not in one.\n  " +
+        dirty.slice(0, 20).join("\n  "),
+    );
+  }
+
+  if (!isSha(shaBefore)) {
+    return refuse("no-pre-sha", `Could not resolve HEAD before CI (got ${JSON.stringify(shaBefore)}).`);
+  }
+
+  if (ciExitCode !== 0) {
+    return refuse("ci-failed", MESSAGES.ciFailed);
+  }
+
+  if (!isSha(shaAfter)) {
+    return refuse("no-post-sha", `Could not resolve HEAD after CI (got ${JSON.stringify(shaAfter)}).`);
+  }
+
+  if (shaAfter !== shaBefore) {
+    return refuse("head-moved", `${MESSAGES.headMoved}\n  verified: ${shaBefore}\n  current:  ${shaAfter}`);
+  }
+
+  // The evidence cross-check, and the reason it is not redundant with the comparison above.
+  //
+  // `shaBefore === shaAfter` proves HEAD did not move around the CI run. It does not prove the run
+  // that produced a pass was *this* run: a stale artifacts/local-ci/latest.json from an earlier
+  // commit satisfies the SHA comparison entirely, because the comparison never reads it. So the
+  // pipeline's own record of which commit it verified is checked against the commit being pushed.
+  if (!evidence) {
+    return refuse(
+      "no-evidence",
+      "The pipeline produced no verification record. Nothing establishes which commit was checked.",
+    );
+  }
+  if (evidence.scope !== "complete") {
+    return refuse(
+      "evidence-partial",
+      `The verification record covers scope '${evidence.scope}', not the complete pipeline. ` +
+        "A subset of stages passing is not the pipeline passing.",
+    );
+  }
+  if (evidence.environment?.containerized !== true) {
+    return refuse(
+      "evidence-not-containerized",
+      "The verification record was not produced inside the CI container. A run on the developer's " +
+        "host proves the developer's host, which is the thing containerizing CI exists to stop relying on.",
+    );
+  }
+  if (evidence.result !== "passed") {
+    return refuse(
+      "evidence-not-passed",
+      `The verification record reports '${evidence.result}', not 'passed'. ${MESSAGES.ciFailed}`,
+    );
+  }
+  if (evidence.commit !== shaBefore) {
+    return refuse(
+      "evidence-commit-mismatch",
+      "The verification record names a different commit than the one being pushed. " +
+        `${MESSAGES.headMoved}\n  record:   ${evidence.commit}\n  pushing:  ${shaBefore}`,
+    );
+  }
+
+  return {
+    allowed: true,
+    reason: "verified",
+    message: `Verified commit ${shaBefore} on '${branch}' passed the complete local Docker CI pipeline.`,
+  };
+}
+
+function refuse(reason, message) {
+  return { allowed: false, reason, message };
+}
+
+/**
+ * The PR body's verification block.
+ *
+ * Deliberately says *local Docker* and names no GitHub-hosted run, because none happened. Claiming
+ * otherwise would be `errors.no-false-success` reasoning applied to a pull request: reporting a
+ * success semantics for something that did not occur.
+ */
+export function evidenceBlock(evidence) {
+  const stages = (evidence.checks ?? [])
+    .map((c) => `- \`${c.id}\` — ${c.outcome} (exit ${c.exitCode})${c.gating ? "" : " _[advisory, non-gating]_"}`)
+    .join("\n");
+  return [
+    "## Local CI",
+    "",
+    "This pipeline ran in an ephemeral Docker container on the author's machine.",
+    "It is **not** a GitHub-hosted Actions run and makes no claim about one.",
+    "",
+    `- Verified commit: \`${evidence.commit}\``,
+    `- Branch: \`${evidence.branch}\``,
+    "- Result: **PASS**",
+    `- Environment: Docker (\`${evidence.environment?.image ?? "unknown image"}\`, Node ${evidence.environment?.node ?? "unknown"})`,
+    `- Completed: ${evidence.completedAt}`,
+    "",
+    "<details><summary>Stages executed</summary>",
+    "",
+    stages,
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+/**
+ * CLI shim, so a shell script can ask the question without reimplementing the answer.
+ *
+ * Facts arrive as one JSON object on stdin; the verdict leaves as one JSON object on stdout. Exit 0
+ * means allowed, 1 means refused, 2 means the question itself was malformed — the same three-way
+ * split the validator uses, for the same reason: "refused" and "could not decide" are different
+ * answers and flattening them would hide the second.
+ */
+async function main(argv) {
+  const mode = argv[0] ?? "decide";
+  if (!["decide", "pr-body"].includes(mode)) {
+    process.stderr.write("usage: node scripts/submit-gate.mjs <decide|pr-body>  (JSON on stdin)\n");
+    return EXIT_INVOCATION;
+  }
+
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  let input;
+  try {
+    input = JSON.parse(Buffer.concat(chunks).toString("utf8") || "null");
+  } catch (err) {
+    process.stderr.write(`submit-gate: could not parse stdin as JSON: ${err.message}\n`);
+    return EXIT_INVOCATION;
+  }
+  if (!input || typeof input !== "object") {
+    process.stderr.write("submit-gate: expected a JSON object on stdin.\n");
+    return EXIT_INVOCATION;
+  }
+
+  if (mode === "pr-body") {
+    process.stdout.write(`${evidenceBlock(input)}\n`);
+    return 0;
+  }
+
+  const verdict = evaluateSubmission(input);
+  process.stdout.write(`${JSON.stringify(verdict)}\n`);
+  return verdict.allowed ? 0 : EXIT_REFUSED;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/scripts/submit-pr.ps1
+++ b/scripts/submit-pr.ps1
@@ -1,0 +1,202 @@
+<#
+.SYNOPSIS
+    Verify the current commit in Docker, then push exactly that commit and open a pull request.
+
+.DESCRIPTION
+    Enforces one invariant:
+
+        A pull request may only be submitted if the exact commit SHA being pushed has successfully
+        passed the repository's complete containerized CI pipeline.
+
+    The sequence is: refuse a dirty tree or a protected branch, record HEAD, run scripts/ci.ps1,
+    record HEAD again, and refuse if it moved. The push then names that SHA explicitly rather than
+    pushing whatever the branch currently points at, so even a commit landing between the check and
+    the push cannot be the thing that reaches the remote.
+
+    Nothing here decides anything. The decision is scripts/submit-gate.mjs, executed inside the CI
+    image so that this script needs no Node on the host, and so that the rule is one testable
+    function rather than a paraphrase in each shell — see test/local-ci.test.mjs, which drives every
+    refusal path.
+
+    This script never commits, never amends, never stashes, and never pushes when verification
+    failed. If CI is red the answer is to fix the code, not to change what CI checks.
+
+    Host requirements: Docker, git, and — for the pull request itself — an authenticated `gh`. No
+    token is read, stored, or written by this script; it uses the developer's existing gh session.
+
+.PARAMETER Base
+    Base branch for the pull request. Defaults to 'develop', this repository's integration branch.
+
+.PARAMETER Title
+    Pull request title. Defaults to the subject of the branch's most recent commit.
+
+.PARAMETER Body
+    Pull request body. The local-CI verification block is appended to it; it never replaces it.
+
+.PARAMETER BodyFile
+    Read the body from a file instead. Ignored when -Body is given.
+
+.PARAMETER Draft
+    Open the pull request as a draft.
+
+.PARAMETER SkipPr
+    Verify and push, but stop before creating the pull request. For when the PR already exists.
+
+.EXAMPLE
+    .\scripts\submit-pr.ps1
+.EXAMPLE
+    .\scripts\submit-pr.ps1 -Draft -Base develop -Title "Local Docker CI"
+#>
+[CmdletBinding()]
+param(
+    [string] $Base = 'develop',
+    [string] $Title,
+    [string] $Body,
+    [string] $BodyFile,
+    [switch] $Draft,
+    [switch] $SkipPr
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ReportPath = Join-Path $RepoRoot 'artifacts/local-ci/latest.json'
+Push-Location $RepoRoot
+
+function Fail([string] $Message, [int] $Code = 1) {
+    Write-Host ""
+    Write-Host $Message -ForegroundColor Red
+    Pop-Location
+    exit $Code
+}
+
+function Git-Out {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $GitArgs)
+    $out = & git @GitArgs 2>$null
+    if ($LASTEXITCODE -ne 0) { return $null }
+    return ($out | Out-String).Trim()
+}
+
+try {
+    # --- Facts, gathered before anything expensive runs -------------------------------------------
+    $isRepo = $null -ne (Git-Out rev-parse --git-dir)
+    $branch = if ($isRepo) { Git-Out rev-parse --abbrev-ref HEAD } else { $null }
+    $dirty = if ($isRepo) { @(& git status --porcelain) | Where-Object { $_ } } else { @() }
+    $shaBefore = if ($isRepo) { Git-Out rev-parse HEAD } else { $null }
+
+    # The pre-CI decision. Every refusal that does not depend on CI's result is made here, so a
+    # developer on a dirty tree is told in the first second rather than after a full pipeline.
+    $preFacts = @{
+        isRepository = $isRepo
+        branch       = $branch
+        base         = $Base
+        dirty        = @($dirty)
+        shaBefore    = $shaBefore
+        shaAfter     = $shaBefore
+        ciExitCode   = 0
+        evidence     = $null
+    }
+    $pre = & "$PSScriptRoot\submit-decide.ps1" -Facts $preFacts -RepoRoot $RepoRoot
+    # 'no-evidence' is the only refusal expected at this point: CI has not run yet. Anything else is
+    # a real refusal and stops the run before the container is even built.
+    if (-not $pre.allowed -and $pre.reason -ne 'no-evidence') { Fail $pre.message }
+
+    Write-Host "repository : $(Git-Out config --get remote.origin.url)"
+    Write-Host "branch     : $branch  ->  $Base"
+    Write-Host "commit     : $shaBefore"
+
+    # --- Verification ------------------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "==> Verifying $shaBefore in Docker" -ForegroundColor Cyan
+    if (Test-Path $ReportPath) { Remove-Item $ReportPath -Force }
+    & "$PSScriptRoot\ci.ps1"
+    $ciExit = $LASTEXITCODE
+
+    $shaAfter = Git-Out rev-parse HEAD
+    $evidence = if (Test-Path $ReportPath) { Get-Content $ReportPath -Raw | ConvertFrom-Json } else { $null }
+
+    $facts = @{
+        isRepository = $isRepo
+        branch       = $branch
+        base         = $Base
+        dirty        = @(@(& git status --porcelain) | Where-Object { $_ })
+        shaBefore    = $shaBefore
+        shaAfter     = $shaAfter
+        ciExitCode   = $ciExit
+        evidence     = $evidence
+    }
+    $verdict = & "$PSScriptRoot\submit-decide.ps1" -Facts $facts -RepoRoot $RepoRoot
+    if (-not $verdict.allowed) { Fail $verdict.message }
+
+    Write-Host ""
+    Write-Host $verdict.message -ForegroundColor Green
+
+    # --- Push the exact verified commit ------------------------------------------------------------
+    Write-Host ""
+    Write-Host "==> Pushing $shaBefore to origin/$branch" -ForegroundColor Cyan
+    # `<sha>:refs/heads/<branch>` rather than the branch name. Pushing by name would send whatever
+    # the branch points at when git runs, and the whole point of this script is that the thing which
+    # reaches the remote is the thing that was verified.
+    & git push origin "${shaBefore}:refs/heads/$branch"
+    if ($LASTEXITCODE -ne 0) { Fail "The push failed. No pull request was created." }
+    & git branch --set-upstream-to "origin/$branch" $branch 2>&1 | Out-Null
+
+    if ($SkipPr) {
+        Write-Host ""
+        Write-Host "Pushed. Pull request creation skipped (-SkipPr)." -ForegroundColor Yellow
+        Pop-Location
+        exit 0
+    }
+
+    # --- Pull request ------------------------------------------------------------------------------
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Host ""
+        Write-Host "gh is not installed, so no pull request was created. The verified commit is pushed." -ForegroundColor Yellow
+        Write-Host "Open it manually, or install GitHub CLI and re-run with the branch already pushed."
+        Pop-Location
+        exit 0
+    }
+    & gh auth status 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ""
+        Write-Host "gh is not authenticated, so no pull request was created. The verified commit is pushed." -ForegroundColor Yellow
+        Write-Host "Run 'gh auth login' and retry. This script never stores a token."
+        Pop-Location
+        exit 0
+    }
+
+    if (-not $Title) { $Title = Git-Out log -1 --pretty=%s }
+    if (-not $Body -and $BodyFile) { $Body = Get-Content $BodyFile -Raw }
+    if (-not $Body) {
+        # Not empty, and not a summary this script invented: the commits being proposed.
+        $Body = "## Commits`n`n" + (Git-Out log --reverse --pretty='- %s' "origin/$Base..$shaBefore")
+    }
+
+    # The verification block is generated by the same module that made the decision, so the PR can
+    # never claim something the gate did not establish. It is appended — user content is never
+    # replaced — and it says "local Docker", never "CI passed", because GitHub-hosted Actions did
+    # not run. Reporting otherwise would be a false success at the pull-request level.
+    $block = & "$PSScriptRoot\submit-decide.ps1" -Facts $evidence -RepoRoot $RepoRoot -PrBody
+    $fullBody = "$Body`n`n---`n`n$block"
+
+    $bodyFile = New-TemporaryFile
+    Set-Content -Path $bodyFile -Value $fullBody -Encoding utf8
+
+    Write-Host ""
+    Write-Host "==> Creating the pull request" -ForegroundColor Cyan
+    $ghArgs = @('pr', 'create', '--base', $Base, '--head', $branch, '--title', $Title, '--body-file', $bodyFile)
+    if ($Draft) { $ghArgs += '--draft' }
+    & gh @ghArgs
+    $ghExit = $LASTEXITCODE
+    Remove-Item $bodyFile -Force -ErrorAction SilentlyContinue
+    if ($ghExit -ne 0) { Fail "gh pr create failed. The verified commit is pushed; open the pull request manually." }
+
+    Write-Host ""
+    Write-Host "Submitted $shaBefore." -ForegroundColor Green
+    Pop-Location
+    exit 0
+}
+catch {
+    Fail "submit-pr could not complete: $($_.Exception.Message)" 2
+}

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -152,6 +152,48 @@ test("both entry points derive their names from the repository rather than hardc
   assert.match(read("scripts/ci.sh"), /repo_slug/, "ci.sh hardcodes its resource names");
 });
 
+test("the image a run executes is the image that run built", () => {
+  // A tag derived from the directory basename is shared by every clone with that name. If one run's
+  // build lands between another run's build and its `compose run`, the second container executes the
+  // first checkout's code and reports a result for a tree nobody asked about. Submission would still
+  // refuse it — the record names the wrong commit — but `ci.*` alone would have printed a pass.
+  // The tag therefore carries the per-run project, and no `:local` tag is used by either entry point.
+  const ps = withoutComments(read("scripts/ci.ps1"));
+  const sh = withoutComments(read("scripts/ci.sh"));
+  assert.match(ps, /\$Image\s*=\s*"\$RepoSlug-ci:\$Project"/, "ci.ps1 does not tag the image per run");
+  assert.match(sh, /image="\$\{repo_slug\}-ci:\$\{project\}"/, "ci.sh does not tag the image per run");
+  for (const [file, text] of [["scripts/ci.ps1", ps], ["scripts/ci.sh", sh]]) {
+    assert.doesNotMatch(text, /-ci:local/, `${file} still uses a tag shared across checkouts`);
+    // Removed by that exact name — never by a filter, a dangling sweep, or a prune.
+    assert.match(text, /docker image rm/, `${file} leaves its run tag behind`);
+  }
+});
+
+test("the gate is built from the tree being submitted, never inherited from an earlier one", () => {
+  // The gate decides whether a pull request may be opened. Executing a previously built image means
+  // that decision comes from whichever checkout last built the tag: a rule deleted in this commit
+  // still refuses, and a refusal added in this commit does not fire. Both are silent.
+  const text = withoutComments(read("scripts/submit-decide.ps1"));
+  assert.doesNotMatch(text, /docker image inspect/, "submit-decide reuses an existing image if it finds one");
+  assert.match(text, /compose -p \$Project[^\n]*build/, "submit-decide does not build the current context");
+  assert.match(text, /\$Image\s*=\s*"\$\{RepoSlug\}-ci:\$Project"/, "the gate image tag is not per invocation");
+  assert.match(text, /finally\s*\{[\s\S]*docker image rm \$Image/, "the gate image is not removed on every path");
+});
+
+test("a linked worktree is refused by name rather than failing inside the container", () => {
+  // `.git` in a linked worktree is a file holding `gitdir: <absolute host path>`. The build context
+  // copies the pointer, not its target, so every `git` call in the container fails and the pipeline
+  // aborts in preflight with an exit code that explains nothing about the cause.
+  for (const [file, pattern] of [
+    ["scripts/ci.ps1", /Test-Path \(Join-Path \$RepoRoot '\.git'\) -PathType Leaf/],
+    ["scripts/ci.sh", /if \[ -f "\$repo_root\/\.git" \]/],
+  ]) {
+    const text = withoutComments(read(file));
+    assert.match(text, pattern, `${file} does not detect a linked worktree`);
+    assert.match(text, /linked git worktree/, `${file} does not name the cause`);
+  }
+});
+
 // --- The submission gate -----------------------------------------------------------------------
 
 const SHA_A = "a".repeat(40);

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -1,0 +1,326 @@
+/**
+ * The local Docker CI workflow, and the invariant it exists to enforce:
+ *
+ *   A pull request may only be submitted if the exact commit SHA being pushed has successfully
+ *   passed the repository's complete containerized CI pipeline.
+ *
+ * Two kinds of assertion live here, and the split is deliberate.
+ *
+ * **The decision is tested directly.** `evaluateSubmission` is a pure function precisely so that
+ * every refusal — dirty tree, protected branch, red CI, and above all a HEAD that moved between
+ * verification and push — can be driven without a remote, without a real branch, and without
+ * mutating history to demonstrate a guard. The SHA-mismatch case is the one this whole workflow is
+ * built around, so it is tested from both directions: a moved HEAD, and a stale verification record
+ * that names a different commit while HEAD sat still.
+ *
+ * **The environment is tested as text**, the same limitation `test/workflow.test.mjs` already
+ * records for GitHub's YAML: these checks confirm that a line is present or absent, and they cannot
+ * confirm that Docker behaves as intended. Only running the pipeline establishes that, which is
+ * what `scripts/ci.ps1` is for.
+ *
+ * Nothing here starts a container. A test suite that required Docker could not run inside the
+ * container that runs the test suite.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { STAGES, gatingStages, RESTORE } from "../scripts/pipeline.mjs";
+import { evaluateSubmission, evidenceBlock, MESSAGES, PROTECTED_BRANCHES } from "../scripts/submit-gate.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(path.join(ROOT, p), "utf8");
+
+/**
+ * A script with its comments removed, for checks that must distinguish use from mention.
+ *
+ * This exists because the first version of the prune check below failed against `scripts/ci.ps1` —
+ * on the sentence *"There is no `docker system prune` here and there must never be one"*. A check
+ * that cannot tell a prohibition from its violation is the use-versus-mention defect this tool has
+ * now produced six times, and there is no reason a test should be exempt from the rule its
+ * detectors follow.
+ *
+ * Handles `#` line comments (both shells) and PowerShell `<# … #>` blocks. It is not a parser and
+ * does not need to be: a `#` inside a string would be over-stripped, which can only make these
+ * assertions blinder, never falsely confident.
+ */
+const withoutComments = (text) =>
+  text
+    .replace(/<#[\s\S]*?#>/g, "")
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
+// --- One definition of what CI runs ------------------------------------------------------------
+
+/** The body of one top-level job in ci.yml, from its key to the next one or the end of the file. */
+function jobBody(text, name) {
+  const at = text.search(new RegExp(`^  ${name}:$`, "m"));
+  if (at === -1) return "";
+  const after = text.slice(at + 1).search(/^  [a-z][\w-]*:$/m);
+  return after === -1 ? text.slice(at) : text.slice(at, at + 1 + after);
+}
+
+test("every gating stage is a step of the required GitHub job", () => {
+  // The drift guard. Two executors run this repository's checks — a GitHub runner and a local
+  // container — and before scripts/pipeline.mjs existed, adding a check to one of them was a silent
+  // way to have two different definitions of CI. This fails the moment they disagree.
+  const testJob = jobBody(read(".github/workflows/ci.yml"), "test");
+  assert.ok(testJob.length > 0, "ci.yml no longer declares a test job");
+  for (const stage of gatingStages()) {
+    assert.ok(
+      testJob.includes(stage.command),
+      `pipeline.mjs gates on '${stage.command}' and the required GitHub job does not run it`,
+    );
+  }
+});
+
+test("the required GitHub job runs nothing the pipeline does not know about", () => {
+  // The other direction, and the one that actually catches drift in practice: a step added to the
+  // workflow by hand would pass the test above and still mean local CI covers less than GitHub does.
+  const testJob = jobBody(read(".github/workflows/ci.yml"), "test");
+  const commands = [...testJob.matchAll(/^\s+run:\s*(npm .+)$/gm)].map((m) => m[1].trim());
+  assert.ok(commands.length > 0, "the required job runs no npm command — has its shape changed?");
+  const known = new Set(STAGES.map((s) => s.command));
+  for (const command of commands) {
+    assert.ok(known.has(command), `ci.yml runs '${command}', which is in no pipeline stage`);
+  }
+});
+
+test("the advisory stage is the one GitHub also keeps out of the required job", () => {
+  // `validate` is non-gating here for the same reason it is a separate, non-required job there: this
+  // repository is intentionally NON_COMPLIANT, so exit 1 is the honest answer and gating on it would
+  // leave no legal path to change develop. If that ever stops being true in one place it must stop
+  // being true in both.
+  const ci = read(".github/workflows/ci.yml");
+  const advisory = STAGES.filter((s) => !s.gating);
+  assert.deepEqual(advisory.map((s) => s.id), ["validate"], "the advisory set changed without an argument");
+  assert.ok(jobBody(ci, "validate").includes("npm run validate"));
+  assert.ok(!jobBody(ci, "test").includes("npm run validate"), "the required job runs the validator");
+});
+
+test("the pipeline still has no dependency-installation stage", () => {
+  // Zero third-party dependencies is enforced structurally by CI having no install step. A stage
+  // appearing here, or an install command in the image, would mean that decision changed.
+  assert.equal(RESTORE.stage, "none");
+  for (const stage of STAGES) {
+    assert.doesNotMatch(stage.command, /npm (ci|install|i)\b/, `${stage.id} installs dependencies`);
+  }
+  const dockerfile = read("ci/Dockerfile");
+  assert.doesNotMatch(dockerfile, /^\s*RUN\s+(apt-get|npm|yarn|pnpm)\b/m, "the CI image installs packages");
+});
+
+// --- The container is the isolation boundary ---------------------------------------------------
+
+test("the CI image is pinned by digest, not by a moving tag", () => {
+  // The same rule the reusable workflow applies to the framework revision it executes. A tag is
+  // rebuilt; two runs of the same commit a month apart would not be the same run.
+  const dockerfile = read("ci/Dockerfile");
+  const from = dockerfile.match(/^FROM\s+(\S+)/m);
+  assert.ok(from, "the CI image declares no base");
+  assert.match(from[1], /@sha256:[0-9a-f]{64}$/, `the base image '${from[1]}' is not pinned by digest`);
+});
+
+test("the CI container reaches nothing on the host", () => {
+  // Comments stripped for the same reason as everywhere else here: compose.ci.yml documents, at
+  // length, the volume and healthcheck shape a future dependency would use.
+  const active = withoutComments(read("compose.ci.yml"));
+  assert.match(active, /network_mode:\s*none/, "the CI container has network access");
+  assert.doesNotMatch(active, /^\s*volumes:/m, "the CI service declares a volume or bind mount");
+  assert.doesNotMatch(active, /docker\.sock/, "the Docker socket is exposed to the CI container");
+  assert.doesNotMatch(active, /privileged:\s*true/, "the CI container runs privileged");
+  assert.match(read("ci/Dockerfile"), /^USER node$/m, "the pipeline runs as root");
+});
+
+test("teardown can only remove what the run created", () => {
+  // A CI script that garbage-collects the host is a CI script that deletes someone's work. Every
+  // teardown in both entry points is scoped to the run's unique compose project.
+  for (const file of ["scripts/ci.ps1", "scripts/ci.sh"]) {
+    const text = withoutComments(read(file));
+    assert.doesNotMatch(text, /docker\s+system\s+prune/, `${file} prunes the host`);
+    assert.doesNotMatch(text, /docker\s+(volume|image|container|network)\s+prune/, `${file} prunes shared resources`);
+    assert.match(text, /down --volumes --remove-orphans/, `${file} does not tear its project down`);
+  }
+});
+
+test("both entry points derive their names from the repository rather than hardcoding them", () => {
+  // The pattern is meant to be copied into other repositories unchanged; a hardcoded project name
+  // would collide the moment two of them ran at once.
+  assert.match(read("scripts/ci.ps1"), /RepoSlug/, "ci.ps1 hardcodes its resource names");
+  assert.match(read("scripts/ci.sh"), /repo_slug/, "ci.sh hardcodes its resource names");
+});
+
+// --- The submission gate -----------------------------------------------------------------------
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+
+/** A verification record that would be accepted, so each test can spoil exactly one thing. */
+const passingEvidence = (commit = SHA_A) => ({
+  result: "passed",
+  scope: "complete",
+  commit,
+  branch: "feature/x",
+  completedAt: "2026-08-15T00:00:00.000Z",
+  environment: { containerized: true, image: "x-ci:local", node: "v20.20.2" },
+  checks: [{ id: "test", outcome: "passed", exitCode: 0, gating: true }],
+});
+
+/** Facts that would be accepted, so each test can spoil exactly one thing. */
+const goodFacts = (over = {}) => ({
+  isRepository: true,
+  branch: "feature/x",
+  base: "develop",
+  dirty: [],
+  shaBefore: SHA_A,
+  shaAfter: SHA_A,
+  ciExitCode: 0,
+  evidence: passingEvidence(),
+  ...over,
+});
+
+test("a clean, verified, unchanged commit is allowed", () => {
+  const verdict = evaluateSubmission(goodFacts());
+  assert.equal(verdict.allowed, true, verdict.message);
+  assert.equal(verdict.reason, "verified");
+  assert.match(verdict.message, new RegExp(SHA_A));
+});
+
+test("submission is refused when HEAD moved after verification", () => {
+  // THE test. Everything else in this workflow exists to make this comparison meaningful.
+  const verdict = evaluateSubmission(goodFacts({ shaAfter: SHA_B }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "head-moved");
+  assert.ok(verdict.message.startsWith(MESSAGES.headMoved), "the specified message is not the one produced");
+  assert.match(verdict.message, new RegExp(SHA_A), "the refusal does not name the verified commit");
+  assert.match(verdict.message, new RegExp(SHA_B), "the refusal does not name the current commit");
+});
+
+test("submission is refused when the record names a commit other than the one being pushed", () => {
+  // The subtler half of the same invariant, and the reason the SHA comparison alone is not enough:
+  // HEAD never moved here, so shaBefore === shaAfter and that check passes cleanly. What is wrong is
+  // that the run which produced the pass was a different commit's run — a stale latest.json left by
+  // an earlier verification. Comparing HEAD against itself can never detect that.
+  const verdict = evaluateSubmission(goodFacts({ evidence: passingEvidence(SHA_B) }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "evidence-commit-mismatch");
+  assert.match(verdict.message, /record:\s+b{40}/);
+  assert.match(verdict.message, /pushing:\s+a{40}/);
+});
+
+test("submission is refused when CI failed, with the specified message", () => {
+  const verdict = evaluateSubmission(goodFacts({ ciExitCode: 1, evidence: null }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "ci-failed");
+  assert.equal(verdict.message, MESSAGES.ciFailed);
+});
+
+test("CI failure is decided before the record is consulted", () => {
+  // Ordering matters: a red run that still produced a record must be reported as a failed run, not
+  // as a record problem. The reason string is what a developer acts on.
+  const verdict = evaluateSubmission(goodFacts({ ciExitCode: 2 }));
+  assert.equal(verdict.reason, "ci-failed");
+});
+
+test("submission is refused from every protected branch", () => {
+  for (const branch of PROTECTED_BRANCHES) {
+    const verdict = evaluateSubmission(goodFacts({ branch, base: "develop" }));
+    assert.equal(verdict.allowed, false, `${branch} was allowed`);
+    assert.ok(
+      ["protected-branch", "branch-is-base"].includes(verdict.reason),
+      `${branch} was refused for the wrong reason: ${verdict.reason}`,
+    );
+  }
+});
+
+test("submission is refused on a dirty tree, before CI is allowed to matter", () => {
+  const verdict = evaluateSubmission(goodFacts({ dirty: [" M scripts/pipeline.mjs", "?? scratch.txt"] }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "dirty-tree");
+  assert.match(verdict.message, /scratch\.txt/, "the refusal does not say what is uncommitted");
+});
+
+test("submission is refused outside a repository and on a detached HEAD", () => {
+  assert.equal(evaluateSubmission(goodFacts({ isRepository: false })).reason, "not-a-repository");
+  assert.equal(evaluateSubmission(goodFacts({ branch: "HEAD" })).reason, "detached-head");
+});
+
+test("submission is refused when the pipeline left no record at all", () => {
+  const verdict = evaluateSubmission(goodFacts({ evidence: null }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "no-evidence");
+});
+
+test("a partial pipeline run cannot be presented as a passing pipeline", () => {
+  // `pipeline.mjs run audit` produces a genuine record in which one stage genuinely passed. It is
+  // not a pipeline pass, and the scope field is what stops it being read as one.
+  const partial = { ...passingEvidence(), scope: "partial" };
+  const verdict = evaluateSubmission(goodFacts({ evidence: partial }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "evidence-partial");
+});
+
+test("a run on the developer's host cannot stand in for the containerized run", () => {
+  // `node scripts/pipeline.mjs run` works fine outside Docker and is useful while iterating. It does
+  // not verify anything for submission purposes: it proves the developer's machine, which is what
+  // containerizing CI exists to stop relying on.
+  const onHost = { ...passingEvidence(), environment: { containerized: false, node: "v24.15.0" } };
+  const verdict = evaluateSubmission(goodFacts({ evidence: onHost }));
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.reason, "evidence-not-containerized");
+});
+
+test("a record that does not say 'passed' is not a pass", () => {
+  const failed = { ...passingEvidence(), result: "failed" };
+  assert.equal(evaluateSubmission(goodFacts({ evidence: failed })).reason, "evidence-not-passed");
+});
+
+test("the gate is a pure function of its facts", () => {
+  // ADR 0014's property, applied to this module: no invocation may leave state behind for the next.
+  const facts = goodFacts();
+  const snapshot = JSON.stringify(facts);
+  evaluateSubmission(facts);
+  evaluateSubmission(goodFacts({ shaAfter: SHA_B }));
+  assert.equal(JSON.stringify(facts), snapshot, "evaluateSubmission mutated its argument");
+  assert.equal(evaluateSubmission(facts).allowed, true, "a later call changed an earlier answer");
+});
+
+// --- What the pull request is allowed to claim -------------------------------------------------
+
+test("the pull request block claims local Docker verification and never a GitHub run", () => {
+  const block = evidenceBlock(passingEvidence());
+  assert.match(block, /Local CI/);
+  assert.match(block, /ephemeral Docker container/);
+  assert.match(block, new RegExp(SHA_A), "the block does not name the verified commit");
+  assert.match(block, /\*\*PASS\*\*/);
+  // The prohibition, stated as a test: reporting a success semantics for something that did not
+  // happen is the same defect `errors.no-false-success` names, one level up from the code.
+  assert.match(block, /not\*{0,2} a GitHub-hosted Actions run/i, "the block does not disclaim GitHub Actions");
+  assert.doesNotMatch(block, /Actions passed|CI passed on GitHub|checks? passed on GitHub/i);
+});
+
+test("the pull request block marks an advisory stage as advisory", () => {
+  // A reader scanning the stage list must not read `validate` exiting 1 as a gating failure that
+  // somehow shipped, nor as a pass.
+  const evidence = passingEvidence();
+  evidence.checks.push({ id: "validate", outcome: "advisory-failed", exitCode: 1, gating: false });
+  const block = evidenceBlock(evidence);
+  assert.match(block, /`validate` — advisory-failed \(exit 1\).*advisory, non-gating/);
+});
+
+// --- The submission script may not take shortcuts ----------------------------------------------
+
+test("the submission script pushes an explicit SHA and never commits on the author's behalf", () => {
+  const text = withoutComments(read("scripts/submit-pr.ps1"));
+  // Pushing by branch name would send whatever the branch points at when git runs, which is exactly
+  // the window the SHA comparison exists to close.
+  assert.match(text, /git push origin "\$\{shaBefore\}:refs\/heads\/\$branch"/, "the push does not name the verified SHA");
+  for (const forbidden of [/git commit/, /git stash/, /--force/, /commit --amend/]) {
+    assert.doesNotMatch(text, forbidden, `submit-pr.ps1 contains ${forbidden}`);
+  }
+  // No token handling of any kind: the developer's existing gh session is used as-is.
+  assert.doesNotMatch(text, /GH_TOKEN|GITHUB_TOKEN|gh auth login --with-token/, "submit-pr.ps1 handles a token");
+  assert.match(text, /gh auth status/, "submit-pr.ps1 never checks that gh is authenticated");
+});


### PR DESCRIPTION
Local Docker CI, and pull request submission that depends on it.

GitHub stays the source-control, pull-request and review system. What it is no longer required to do is prove that a branch works — that proof is produced in an ephemeral container before the branch is pushed.

**The invariant:** a pull request may only be submitted if the exact commit SHA being pushed has successfully passed the complete containerized CI pipeline. This pull request was created by that workflow.

**What is here**

- `scripts/pipeline.mjs` — the stage list, stated once. This container and `.github/workflows/ci.yml` both run it, and `test/local-ci.test.mjs` fails while the two name different sets, in either direction.
- `ci/Dockerfile` + `compose.ci.yml` — Node 20 pinned by image digest, matching the runner. No network, no bind mounts, no Docker socket, non-root. The repository is copied into the image rather than mounted, because the suite writes files.
- `scripts/ci.ps1` / `scripts/ci.sh` — the authoritative CI command. Unique compose project per run, teardown on every exit path, scoped to what the run created.
- `scripts/submit-gate.mjs` + `scripts/submit-pr.ps1` — the decision as a pure, tested function; the plumbing in the shell.

**`validate` is advisory, not gating**, exactly as it is a separate non-required job in `ci.yml` today and for the same reason: this repository is intentionally `NON_COMPLIANT` while recorded rejections stand, so exit 1 is the honest answer and gating on it would leave no legal path to change `develop`. It runs on every local run and its real exit code is recorded and printed. Nothing was dropped from the existing pipeline.

**What cannot run locally**, stated rather than implied: `standards-dogfood.yml` exercises GitHub'"'"'s own `workflow_call` resolution, which is the thing under test in ADR 0013. Details in `docs/local-ci.md`.

**Validation performed**

- Full pipeline green, twice, the second time after deleting the image to force a rebuild from the pinned base.
- A planted verbatim-quote defect: `fidelity` failed, the run exited 1, it failed fast, teardown ran, and submission refused. Defect reverted, not committed.
- The SHA guard demonstrated on a real race in a throwaway clone with a local origin: a commit landed while the container was mid-pipeline, and submission refused with `HEAD changed after CI verification` and pushed nothing.
- Cleanup scoped: no container, network, or volume from any run survives, and no developer database was touched — the pipeline has no network and no mounts.


---

## Local CI

This pipeline ran in an ephemeral Docker container on the author's machine.
It is **not** a GitHub-hosted Actions run and makes no claim about one.

- Verified commit: `33ec10bab86789f61fb2ff2a6ed6cc2508df60bc`
- Branch: `chore/local-docker-ci`
- Result: **PASS**
- Environment: Docker (`engineeringstandards-ci:local`, Node v20.20.2)
- Completed: 2026-08-16T00:22:25.075Z

<details><summary>Stages executed</summary>

- `inventory` — passed (exit 0)
- `fidelity` — passed (exit 0)
- `policy` — passed (exit 0)
- `diagrams` — passed (exit 0)
- `test` — passed (exit 0)
- `audit` — passed (exit 0)
- `validate` — advisory-failed (exit 1) _[advisory, non-gating]_

</details>

