### PR TITLE
Verify the commit, not the checkout that happened to render it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,23 @@ runner passed. The gate produced a red the runner did not, and the mechanism is 
   linked worktree into a self-contained repository. The guard is left in place; lifting it is its own
   decision.
 
+Two defects found in review of the above, before it merged:
+
+- **What counts as a clean tree no longer depends on the reader's git config.** `git status
+  --porcelain` honours `status.showUntrackedFiles`, so under `no` a brand-new source file reported
+  nothing, the context clone omitted it because it was not committed, and the run would have passed
+  over a tree missing the file being worked on — the false success the clean-tree requirement exists
+  to prevent, arriving through the check itself. Every cleanliness question in the repository now
+  states `--untracked-files=normal` rather than inheriting an answer: both context builders,
+  `scripts/submit-pr.ps1`, `scripts/verify-materialisation.ps1`, and `scripts/repository.mjs`. Under
+  the usual configuration nothing changes.
+- **A project name can no longer choose what the context builder deletes.** `--project` is an
+  advertised option on both entry points, and its value named a temporary directory that the builder
+  removed recursively; a name carrying path components aimed that delete outside the temporary root.
+  Compose would have rejected such a name, but only after the context stage had run. Both twins now
+  refuse anything outside a plain Compose project name, before reading the repository at all. Driven
+  by a test that destroys a sentinel directory if the guard is removed.
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,31 @@ non-required job on GitHub, and for the same reason: this repository is intentio
 `NON_COMPLIANT` while recorded rejections stand. Its real exit code is recorded and printed, never
 suppressed. See [docs/local-ci.md](docs/local-ci.md).
 
+**The local gate now verifies committed content rather than the host checkout**
+([ADR 0015](artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md)).
+`COPY . /work` built the image from the developer's working directory, so what it verified was one
+platform's materialisation of the tree. Measured on `a373d4c` with committed content held constant:
+a CRLF checkout produced 273 pass / 1 fail and an LF checkout 274 pass / 0 fail, while the GitHub
+runner passed. The gate produced a red the runner did not, and the mechanism is symmetric.
+
+- `scripts/ci-context.ps1`, `scripts/ci-context.sh` — the build context is a temporary clone at the
+  exact commit `HEAD` names, with `core.autocrlf=false` and `core.eol=lf` written into its own
+  config, its materialised commit confirmed against the requested one, removed by exact path on every
+  exit path. A clone rather than a `git archive` export, because the audit resolves tracked and
+  ignored paths through git and attestation freshness reads committed blob identity — an export plus
+  a synthesised repository would trade this defect for ADR 0008's.
+- `scripts/ci.ps1`, `scripts/ci.sh`, `scripts/submit-decide.ps1` all build from that context.
+  **Local CI now requires a clean tree**: uncommitted work is absent from the run, so a pass would
+  describe a tree the developer is not looking at.
+- `scripts/verify-materialisation.ps1` — the falsifier. Runs the complete pipeline from an LF and a
+  CRLF checkout of one commit, having first confirmed their bytes differ, and requires the verified
+  SHA, every stage outcome, the verdict, and the repository's own freshness and tracked/ignored
+  answers to be identical. `-Mutate` restores the defect and requires the comparison to fail.
+- Isolation is unchanged: no bind mount, no Docker socket, no host path reachable from the run.
+- The linked-worktree refusal is now conservative rather than necessary — `git clone` resolves a
+  linked worktree into a self-contained repository. The guard is left in place; lifting it is its own
+  decision.
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
+++ b/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
@@ -1,0 +1,121 @@
+# ADR 0015 — Local CI verifies committed content, not the host checkout
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+- **Supersedes:** nothing. Corrects a repeatability claim `ci/Dockerfile` made in PR #27.
+- **Related:** [ADR 0008](0008-detectors-do-not-assert-repository-state-they-have-not-measured.md),
+  [ADR 0011](0011-attestation-freshness-is-repository-content-not-checkout-bytes.md),
+  [ADR 0013](0013-the-reusable-check-distributes-the-verdict-and-nothing-else.md)
+
+## Context
+
+PR #27 made the complete CI pipeline runnable in a local container and bound pull request submission
+to it: a pull request may only be opened for a commit that has passed that pipeline. The image was
+built with `COPY . /work` over the developer's working directory, and `ci/Dockerfile` claimed the
+result was "repeatable from the image alone".
+
+That claim was too strong, and the gap is not stylistic.
+
+Git stores normalised content and materialises it per platform. `.gitattributes` in this repository
+pins `*.sh` and `ci/Dockerfile` to LF — because a CRLF shebang is not executable — and deliberately
+leaves everything else to the checkout's own conventions. On a Windows checkout with
+`core.autocrlf=true`, that means every `.mjs`, `.json`, and `.md` file lands with CRLF. GitHub's
+`ubuntu-latest` checkout lands the same commit with LF. So `COPY .` copied *one platform's rendering
+of the tree*, not the tree.
+
+This was measured, not inferred. On commit `a373d4c`, with committed content held constant and only
+the checkout's line-ending conversion varied:
+
+| Materialisation | Pipeline result |
+| --- | --- |
+| CRLF (Windows default) | 273 pass, 1 fail |
+| LF (what git stores; what `ubuntu-latest` checks out) | 274 pass, 0 fail |
+| GitHub-hosted runner | pass |
+
+The failing test was `test/invocation-ownership.test.mjs`'s negative control, which patches evaluator
+source anchored on `\n`. The local gate produced a red the runner did not.
+
+The direction of that particular failure is the least important part of it. The mechanism is
+symmetric: a gate whose input is the host's byte representation can equally pass what the runner
+fails. It was being treated as equivalent to the hosted required gate, and it was not.
+
+## Decision
+
+**Local CI verifies a deterministic materialisation of the exact committed `HEAD`, never the host
+checkout's byte representation.**
+
+The Docker build context is constructed by `scripts/ci-context.ps1` and `scripts/ci-context.sh`: a
+temporary clone of the repository at the commit `HEAD` names, with `core.autocrlf=false` and
+`core.eol=lf` written into the context repository's own config, checked out from that config, its
+`origin` URL carried over, its materialised commit confirmed against the requested one, and the whole
+directory removed when the run ends. `compose.ci.yml` takes the context path from `CI_CONTEXT`, which
+both entry points and `scripts/submit-decide.ps1` set before building.
+
+Three consequences follow, and each is part of the decision rather than a side effect.
+
+**A clean working tree is required.** Once the context is committed content, an uncommitted edit is
+absent from the run. Showing a developer a green for `HEAD` while they are looking at unsaved work is
+a false success in the sense `errors.no-false-success` names, so the run refuses and names what is
+uncommitted. Submission already required this; the requirement moves to where it first matters.
+
+**The context is a clone, not an export.** `git archive HEAD` would have been simpler and would have
+produced committed file content. It would also have left the evaluator answering repository questions
+from something that is not a repository. `scripts/repository.mjs` asks git — with no fallback, by
+design (ADR 0008, ADR 0011) — which paths are tracked, which are ignored, what blob identity a
+reviewed path has at `HEAD`, and whether a reviewed path is dirty. `ci/Dockerfile` already recorded
+that git in the image is semantic rather than incidental. An export plus a synthesised repository
+would have traded a line-ending defect for a source-of-truth defect, which is a worse trade because
+the second one is quiet.
+
+**Isolation is unchanged.** The context is built on the host, copied into the image, and deleted.
+There is still no bind mount, no Docker socket, and no host path reachable from inside the run. The
+context builders touch git and nothing else — asserted by test, because the tempting shape of this
+fix is to punch a hole in the container and compensate inside it.
+
+## Alternatives considered
+
+**Add `text eol=lf` to every path in `.gitattributes`.** Rejected. It makes repository policy bend
+around the verifier: every future file has to be classified for the benefit of a CI script, and a
+missed classification is a silent hole. Worse, it fixes one transform. A checkout applies attributes,
+clean/smudge filters, `core.symlinks`, and platform conventions; each is another way for `COPY .` to
+ship something the commit does not determine. Constraining the input covers all of them with one
+decision, and leaves `.gitattributes` saying what it means — that two kinds of file must be LF because
+Linux executes them.
+
+**Normalise line endings inside the image after copying.** Rejected outright. It would mutate content
+after the point at which the run claims to be verifying a specific commit, so the image would no
+longer hold what its record names.
+
+**Keep `COPY .` and document the caveat.** Rejected. The gate is a precondition for opening a pull
+request; a documented caveat on a gate is a caveat nobody reads at the moment it matters.
+
+## Consequences
+
+- `ci/Dockerfile`'s repeatability claim is now true as stated, because what enters the image is
+  determined by the commit.
+- Running local CI on uncommitted work is no longer possible. This is a real workflow cost, accepted
+  deliberately: the alternative is a verdict whose subject is ambiguous.
+- The linked-worktree refusal in both entry points is now **conservative rather than necessary** —
+  `git clone` resolves a linked worktree into a self-contained repository, which was measured while
+  making this change. The guard is left in place; lifting it is a separate decision with its own
+  review, not a side effect of this one.
+- The property is falsifiable and is checked by a harness rather than asserted by structure.
+  `scripts/verify-materialisation.ps1` materialises one commit into an LF and a CRLF checkout,
+  confirms their bytes genuinely differ, runs the complete pipeline from each, and requires the
+  verified SHA, every stage outcome, the compliance verdict, and the repository's own freshness and
+  tracked/ignored answers to be identical. Its `-Mutate` mode restores the host-context behaviour and
+  requires the comparison to fail; agreement under the mutation is reported as the check being
+  incapable, not as a pass.
+- `test/local-ci.test.mjs` covers the structural half — that the context is parameterised, cloned
+  rather than exported, pinned rather than inherited, confirmed against the requested commit, removed
+  by exact path, and that no Docker capability was added to compensate. Those are text assertions and
+  carry the limitation the file already records for every other environment check: they confirm a
+  line is present or absent, not that Docker behaves as intended. The harness above is what
+  establishes the behaviour.
+
+## What this does not establish
+
+That local CI and the hosted required gate are equivalent in general. This removes one measured
+source of divergence — the input. Everything already listed under *What cannot be reproduced locally*
+in `docs/local-ci.md` remains unreproduced, and the two gates still run on different hardware, at
+different times, under different kernels.

--- a/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
+++ b/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
@@ -106,6 +106,14 @@ request; a documented caveat on a gate is a caveat nobody reads at the moment it
   tracked/ignored answers to be identical. Its `-Mutate` mode restores the host-context behaviour and
   requires the comparison to fail; agreement under the mutation is reported as the check being
   incapable, not as a pass.
+- One check asserts the invariant from *inside* the run rather than from the shape of the scripts
+  that set it up: every regular file on disk is compared, by raw byte identity, against its committed
+  blob at `HEAD`. It runs only when the run makes a verification claim — inside the container, or on
+  a GitHub runner — and skips with a stated reason otherwise, because on a Windows host the working
+  tree legitimately is not the committed bytes and failing there would report a checkout convention
+  as a defect. This is also what keeps the harness above from being vacuous: two checkouts agree
+  trivially when nothing in the suite can tell them apart, and this can. Under the restored defect a
+  CRLF checkout fails it and an LF checkout does not.
 - `test/local-ci.test.mjs` covers the structural half — that the context is parameterised, cloned
   rather than exported, pinned rather than inherited, confirmed against the requested commit, removed
   by exact path, and that no Docker capability was added to compensate. Those are text assertions and

--- a/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
+++ b/artifacts/adr/0015-local-ci-verifies-committed-content-not-the-host-checkout.md
@@ -58,6 +58,13 @@ absent from the run. Showing a developer a green for `HEAD` while they are looki
 a false success in the sense `errors.no-false-success` names, so the run refuses and names what is
 uncommitted. Submission already required this; the requirement moves to where it first matters.
 
+What counts as clean is stated rather than inherited. `git status --porcelain` honours
+`status.showUntrackedFiles`, a repository-local setting: under `no`, a new and uncommitted file
+reports nothing, the context omits it because it is not committed, and the run passes over a tree
+missing the file being worked on. A gate whose definition of "clean" is configurable exempts exactly
+what the configuration hides, so every cleanliness question in the repository states
+`--untracked-files=normal`. Found in review of this change rather than designed in.
+
 **The context is a clone, not an export.** `git archive HEAD` would have been simpler and would have
 produced committed file content. It would also have left the evaluator answering repository questions
 from something that is not a repository. `scripts/repository.mjs` asks git — with no fallback, by
@@ -95,6 +102,14 @@ request; a documented caveat on a gate is a caveat nobody reads at the moment it
   determined by the commit.
 - Running local CI on uncommitted work is no longer possible. This is a real workflow cost, accepted
   deliberately: the alternative is a verdict whose subject is ambiguous.
+- The context builders own a recursive delete, so they validate the name that chooses its target.
+  `--project` is an advertised option on both entry points and named the temporary directory being
+  removed; a value carrying path components aimed that delete outside the temporary root. Compose
+  would have rejected such a name, but only once the context stage had already run. Both twins now
+  refuse anything outside a plain Compose project name — every name the entry points derive already
+  satisfies it — and refuse it before reading the repository, so the check does not depend on the
+  tree being clean. The guard is what makes the constructed path safe rather than merely
+  conventional: a matching string contains no separator and no dot.
 - The linked-worktree refusal in both entry points is now **conservative rather than necessary** —
   `git clone` resolves a linked worktree into a self-contained repository, which was measured while
   making this change. The guard is left in place; lifting it is a separate decision with its own

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -43,12 +43,23 @@ WORKDIR /work
 # A bind mount would put the developer's working tree inside a container that runs the repository's
 # own test suite — and that suite writes files (test/invocation-ownership.test.mjs materialises a
 # patched copy of the evaluator to run its negative control). Copying means the container cannot
-# touch the host tree at all: there is nothing mounted to touch. It also means the run is repeatable
-# from the image alone, which is what makes "re-run CI from clean state" a real operation rather
-# than a re-read of whatever the host happens to hold now.
+# touch the host tree at all: there is nothing mounted to touch.
 #
-# `.git` is copied on purpose — see the git note above. `.dockerignore` keeps out only the
-# verification artifacts, so a previous run's report can never be mistaken for this run's.
+# **What is copied is not the working directory.** The context handed to Docker is built by
+# `scripts/ci-context.*`: a temporary clone of this repository at the exact commit HEAD names, with
+# `core.autocrlf=false` and `core.eol=lf` written into its own config so the files it materialises
+# are determined by the commit rather than by the host platform's checkout conventions. Building
+# from the working directory is what made the earlier claim on this line too strong — the image was
+# repeatable from itself, but what went into it was one platform's rendering of the tree, and the
+# CRLF/LF difference between a Windows checkout and `ubuntu-latest` was measurable as a different
+# test result for identical committed content.
+#
+# `.git` is copied on purpose — see the git note above, and note that this is why the context is a
+# clone rather than a `git archive` export. The audit resolves tracked and ignored paths through
+# git, and attestation freshness reads committed blob identity; an export plus a synthesised
+# repository would answer those questions from something that is not the repository, which is
+# ADR 0008's source-of-truth defect. `.dockerignore` keeps out only the verification artifacts, so a
+# previous run's report can never be mistaken for this run's.
 COPY --chown=node:node . /work
 
 # Non-root. CI executes whatever is in the branch under test, which is untrusted by construction:

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -42,7 +42,22 @@
 services:
   ci:
     build:
-      context: .
+      # NOT the working directory. `scripts/ci-context.*` materialises the exact committed HEAD into
+      # a temporary clone with pinned checkout attributes, and passes that path here; the invoking
+      # script deletes it on every exit path.
+      #
+      # `context: .` was the defect: it made the run verify one platform's materialisation of the
+      # tree rather than the tree. Git stores normalised content and materialises it per platform, so
+      # the same commit is CRLF on a Windows checkout and LF on `ubuntu-latest`. Measured on a373d4c,
+      # the two disagreed — 273 pass / 1 fail against 274 pass / 0 fail, identical committed content.
+      # A gate that verifies host bytes can fail what the runner passes, and pass what it fails.
+      #
+      # The fallback below is the *legacy* behaviour, and exists for exactly one caller: the
+      # cross-materialisation falsifier in `scripts/verify-materialisation.ps1`, which sets this to
+      # the working directory to prove the equivalence check can still fail. No entry point leaves it
+      # unset — both export it before building.
+      context: ${CI_CONTEXT:-.}
+      # Relative to the context, so the Dockerfile that builds the image is the committed one too.
       dockerfile: ci/Dockerfile
     # Named per run by the invoking script — `<slug>-ci:<project>`, where the project is unique per
     # invocation — so a rebuild for one checkout cannot replace the image another run is about to

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -52,6 +52,70 @@ Exit `0` means every gating check passed. Anything else means it did not. Option
 
 Run it as often as you like — it submits nothing and pushes nothing.
 
+**It does require a clean tree.** CI verifies committed content at `HEAD`, so an uncommitted edit is
+simply not in the run; showing you a green for `HEAD` while you are looking at unsaved work would be
+a pass describing a tree you cannot see. The run refuses and names what is uncommitted. Ignored
+files are not dirt — the run's own `artifacts/local-ci/` never blocks a run.
+
+## What Docker is actually given
+
+Not this directory. The build context is materialised by
+[`scripts/ci-context.ps1`](../scripts/ci-context.ps1) (and its POSIX twin): a temporary clone of this
+repository at the exact commit `HEAD` names, with `core.autocrlf=false` and `core.eol=lf` written
+into its own config, deleted when the run ends.
+
+The invariant, stated once:
+
+> Local CI verifies a deterministic materialisation of the exact committed `HEAD`, never the host
+> checkout's byte representation.
+
+The reason is measured rather than theoretical. Git stores normalised content and materialises it per
+platform; `.gitattributes` here pins only the files a Linux shell executes, so on a Windows checkout
+everything else lands as CRLF while `ubuntu-latest` lands the same commit as LF. Building the image
+with `COPY .` over the working directory therefore verified *one platform's rendering of the tree*.
+On commit `a373d4c` the two renderings disagreed:
+
+| Checkout | Result |
+| --- | --- |
+| CRLF (Windows default) | 273 pass, 1 fail |
+| LF (`ubuntu-latest`, and what git stores) | 274 pass, 0 fail |
+| GitHub-hosted runner, same commit | pass |
+
+The failing test patches evaluator source anchored on `\n`. The local gate produced a red the runner
+did not — and the mechanism is symmetric, which is the part that matters: a gate verifying host bytes
+can also pass what the runner fails.
+
+**Why not just add `eol=lf` to every path.** That bends repository policy around the verifier, and it
+closes only the transform someone happened to think of. A checkout applies attributes, filters, and
+platform conventions; each is a way for `COPY .` to ship something the commit does not determine.
+Fixing the input is one decision that covers all of them.
+
+**Why a clone and not `git archive`.** An export gives committed file content and no repository.
+[`scripts/repository.mjs`](../scripts/repository.mjs) asks git — with no fallback, deliberately —
+which paths are tracked, which are ignored, what blob identity a reviewed path has at `HEAD`, and
+whether a reviewed path is dirty. An export plus a synthesised repository would answer those from
+something that is not the repository, trading this defect for
+[ADR 0008](../artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)'s.
+
+**Isolation is unchanged.** The context is built on the host, copied into the image, and deleted.
+There is still no bind mount, no Docker socket, and no host path reachable from inside the run. The
+fix moved where the bytes come from; it did not open a channel for the container to compensate
+afterwards.
+
+To prove the property rather than assert it:
+
+```bash
+.\scripts\verify-materialisation.ps1
+```
+
+It materialises `HEAD` into an LF checkout and a CRLF checkout, confirms their bytes genuinely
+differ, runs the complete pipeline from each, and requires the verified SHA, every stage outcome, the
+compliance verdict, and the repository's own freshness and tracked/ignored answers to be identical.
+`-Mutate` restores the host-context defect and requires that comparison to **fail** — a falsifier
+that cannot be made to fail establishes nothing. Windows-only, for the reason in
+[Supported submission entry point](#supported-submission-entry-point); it runs the pipeline twice, so
+it takes a few minutes.
+
 ## What CI performs
 
 The stage list lives in one place, [`scripts/pipeline.mjs`](../scripts/pipeline.mjs), and both
@@ -274,7 +338,7 @@ in either direction, so a step added to the workflow by hand is caught as readil
 | Branch protection and required-check status | A property of the GitHub repository, not of any pipeline. Note that `gh api …/branches/develop/protection` currently returns 404 — protection is not configured. |
 | `actions/upload-artifact`, job summaries | Runner-hosted presentation. The equivalent evidence is `artifacts/local-ci/latest.json` and the printed summary. |
 | Multi-OS or multi-Node matrices | Neither workflow declares one today. See the Node disposition below. |
-| A linked `git worktree` checkout | `.git` there is a file pointing at an absolute host path outside the build context, so the copied pointer resolves to nothing and every `git` call in the container fails. Both entry points detect this and refuse by name. Supporting it would mean copying an arbitrary host path into the image — the broad host reach this environment exists to avoid — to serve a checkout shape one `cd` steps out of. |
+| A linked `git worktree` checkout | Both entry points detect this and refuse by name. The original reason was mechanical: `.git` there is a file pointing at an absolute host path outside the build context, so a copied working tree carried a pointer that resolved to nothing and every `git` call in the container failed. **That reason no longer applies** — the context is now a clone, and `git clone` resolves a linked worktree into a self-contained repository (measured, not assumed). The refusal is therefore conservative rather than necessary as of this change. Lifting it is a deliberate decision with its own review, not a side effect of fixing the context; until someone takes it, the guard stays and one `cd` steps out of the shape. |
 
 Nothing from the existing pipeline was dropped. Every `run:` step in the required `test` job maps to
 a gating stage, and the `validate` job maps to the advisory stage — asserted by test, both ways.

--- a/scripts/ci-context.ps1
+++ b/scripts/ci-context.ps1
@@ -78,6 +78,21 @@ function Invoke-Git {
     return ($output | Out-String).Trim()
 }
 
+<#
+    A git call run for its effect, whose output is discarded.
+
+    Not decoration. This script's contract is that stdout is the context path and nothing else, and
+    in PowerShell an un-consumed return value is stdout. Calling `Invoke-Git` bare for `clone` and
+    `checkout` emitted their empty results into the output stream, so the caller received an array
+    whose string form was the path with leading blanks — and handed Docker a build context that
+    could not exist. Effects go through here; only the values this script actually reads are
+    returned.
+#>
+function Invoke-GitEffect {
+    param([string[]] $GitArgs, [string] $What)
+    Invoke-Git -GitArgs $GitArgs -What $What | Out-Null
+}
+
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     throw "git was not found on PATH. It is required to materialise the CI context."
 }
@@ -126,7 +141,7 @@ if (Test-Path $contextRoot) { Remove-Item $contextRoot -Recurse -Force }
 # repository's own config. That matters twice: it decides what this checkout materialises, and it
 # travels into the container, so `git status` in there compares against the same rule rather than
 # re-deriving one from the container's defaults.
-Invoke-Git @(
+Invoke-GitEffect @(
     'clone', '--quiet', '--no-checkout', '--no-hardlinks',
     '-c', 'core.autocrlf=false',
     '-c', 'core.eol=lf',
@@ -137,14 +152,14 @@ Invoke-Git @(
 # record reading `branch: HEAD` names nothing a reader can act on. A genuinely detached HEAD on the
 # host stays detached here — the context reports the host's state, it does not improve it.
 if ($branch -eq 'HEAD') {
-    Invoke-Git @('-C', $contextRoot, 'checkout', '--quiet', '--detach', $sha) 'checking out the verified commit'
+    Invoke-GitEffect @('-C', $contextRoot, 'checkout', '--quiet', '--detach', $sha) 'checking out the verified commit'
 }
 else {
-    Invoke-Git @('-C', $contextRoot, 'checkout', '--quiet', '-B', $branch, $sha) 'checking out the verified commit'
+    Invoke-GitEffect @('-C', $contextRoot, 'checkout', '--quiet', '-B', $branch, $sha) 'checking out the verified commit'
 }
 
 if ($origin) {
-    Invoke-Git @('-C', $contextRoot, 'remote', 'set-url', 'origin', $origin) 'restoring the origin URL'
+    Invoke-GitEffect @('-C', $contextRoot, 'remote', 'set-url', 'origin', $origin) 'restoring the origin URL'
 }
 else {
     & git -C $contextRoot remote remove origin 2>&1 | Out-Null

--- a/scripts/ci-context.ps1
+++ b/scripts/ci-context.ps1
@@ -130,6 +130,14 @@ $status
 $contextRoot = Join-Path ([System.IO.Path]::GetTempPath()) "$Project-context"
 if (Test-Path $contextRoot) { Remove-Item $contextRoot -Recurse -Force }
 
+# Everything from here on is wrapped, because a half-built context must not survive.
+#
+# The caller only learns the path if this script returns it, so a failure between the clone and the
+# confirmation below would leave a directory nobody owns and nobody deletes — and, worse, a directory
+# holding a partial materialisation of a commit under a name that says it is that commit. It is
+# removed by the exact path this invocation created, never by a sweep of the temp directory.
+try {
+
 # `--no-checkout` first, so no file is materialised under whatever the host's defaults happen to be;
 # the working tree is then created by an explicit checkout under the config pinned below.
 #
@@ -171,6 +179,12 @@ else {
 $materialised = Invoke-Git @('-C', $contextRoot, 'rev-parse', 'HEAD') 'confirming the materialised commit'
 if ($materialised -ne $sha) {
     throw "the CI context materialised $materialised, not the requested $sha."
+}
+
+}
+catch {
+    if (Test-Path $contextRoot) { Remove-Item $contextRoot -Recurse -Force -ErrorAction SilentlyContinue }
+    throw
 }
 
 return $contextRoot

--- a/scripts/ci-context.ps1
+++ b/scripts/ci-context.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    Materialise the Docker build context for a local CI run from committed repository content.
+
+.DESCRIPTION
+    Prints one line on stdout: the absolute path of a temporary directory holding this repository at
+    the exact commit HEAD names, materialised deterministically. The caller passes that path to
+    Docker as the build context and deletes it when the run ends.
+
+    ## Why this exists
+
+    The container used to be built with `COPY . /work` over the developer's working directory, so
+    what it verified was *the host's materialisation of the tree* rather than the tree. Git stores
+    normalised content and materialises it per platform: `.gitattributes` here pins only the files a
+    Linux shell executes, `core.autocrlf` is true on a Windows checkout, and everything else lands
+    with CRLF. GitHub's `ubuntu-latest` checkout lands the same commit with LF.
+
+    That is not a theoretical gap. It was measured on commit a373d4c, where the two materialisations
+    disagreed: 273 pass / 1 fail from the CRLF checkout, 274 pass / 0 fail from the LF one, for
+    identical committed content. The failing test patches evaluator source anchored on `\n`. The
+    gate produced a red the runner did not — and the same mechanism runs the other way, which is the
+    part that matters: a local gate that verifies host bytes can pass something the runner fails.
+
+    The fix is not `eol=lf` on every path. That bends repository policy around the verifier and only
+    closes the one transform anybody thought of; a checkout applies filters, smudge rules, and
+    platform conventions, and every one of them is a way for `COPY .` to ship something the commit
+    does not determine. The invariant is stated once instead:
+
+        Local CI verifies a deterministic materialisation of the exact committed HEAD, never the
+        host checkout's byte representation.
+
+    ## Why a clone rather than `git archive`
+
+    `git archive HEAD` would produce committed file content and nothing else, and the evaluator
+    would then be lying about its own source of truth. `scripts/repository.mjs` asks git — with no
+    fallback, by design — which paths are tracked, which are ignored, what blob identity a reviewed
+    path has at HEAD, and whether a reviewed path is dirty. `ci/Dockerfile` already records that git
+    in the image is semantic rather than incidental. An archive plus a synthesised repository would
+    trade the CRLF mismatch for ADR 0008's source-of-truth defect: the audit would answer repository
+    questions from something that is not the repository.
+
+    So the context is a real clone of the real repository, with real history and real object
+    identity, whose checkout attributes are pinned rather than inherited from the host.
+
+    ## What this does not do
+
+    It does not punch a hole through the container. There is still no bind mount, no Docker socket,
+    and no host path reachable from inside the run: the context is constructed on the host, copied
+    into the image, and deleted. The isolation the containerised pipeline earned is unchanged — the
+    only thing that moved is where the bytes being copied come from.
+
+.PARAMETER RepoRoot
+    The main working tree to materialise. Must be a repository with a `.git` directory; a linked
+    worktree is refused by the caller before this runs.
+
+.PARAMETER Project
+    The run's unique compose project name. Used to name the temporary directory, so two concurrent
+    runs cannot share a context and teardown can remove exactly the one it created.
+
+.OUTPUTS
+    System.String — the absolute path of the materialised context directory.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $RepoRoot,
+    [Parameter(Mandatory = $true)] [string] $Project
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-Git {
+    param([string[]] $GitArgs, [string] $What)
+    $output = & git @GitArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "$What failed: $($output | Out-String)"
+    }
+    return ($output | Out-String).Trim()
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw "git was not found on PATH. It is required to materialise the CI context."
+}
+
+$sha = Invoke-Git @('-C', $RepoRoot, 'rev-parse', 'HEAD') 'reading HEAD'
+$branch = Invoke-Git @('-C', $RepoRoot, 'rev-parse', '--abbrev-ref', 'HEAD') 'reading the current branch'
+
+# The origin URL is carried over rather than left pointing at the temporary clone. The pipeline
+# records `remote.origin.url` as the repository the run describes, and a temp path in that field
+# would make the record name a directory that no longer exists.
+$origin = & git -C $RepoRoot config --get remote.origin.url 2>$null
+if ($LASTEXITCODE -ne 0) { $origin = $null }
+
+# The clean-tree requirement is a consequence of the invariant, not an extra rule.
+#
+# Once the context is committed content, an uncommitted edit is invisible to the run — the developer
+# would be shown a verdict about HEAD while believing it covered what they just wrote. That is a
+# false success in the exact sense `errors.no-false-success` names, so it is refused here rather
+# than tolerated. Submission already refused a dirty tree; this moves the same requirement earlier,
+# to the point where it first has consequences.
+#
+# Ignored files are not dirt: `--porcelain` excludes them, so the run's own artifacts directory does
+# not block a run.
+$status = Invoke-Git @('-C', $RepoRoot, 'status', '--porcelain') 'reading working-tree status'
+if ($status) {
+    throw @"
+the working tree has uncommitted changes, and local CI verifies committed content at HEAD.
+Anything not committed would be absent from the run, so a pass would describe a tree you are not
+looking at. Commit or stash, then re-run.
+
+$status
+"@
+}
+
+$contextRoot = Join-Path ([System.IO.Path]::GetTempPath()) "$Project-context"
+if (Test-Path $contextRoot) { Remove-Item $contextRoot -Recurse -Force }
+
+# `--no-checkout` first, so no file is materialised under whatever the host's defaults happen to be;
+# the working tree is then created by an explicit checkout under the config pinned below.
+#
+# `--no-hardlinks` makes the context self-contained. Hardlinked objects would still be readable, but
+# the context is about to be copied into an image as the definitive statement of what was verified,
+# and a definitive statement should not share storage with a directory that can change underneath it.
+#
+# `core.autocrlf=false` and `core.eol=lf` are set at clone time so they are written into the context
+# repository's own config. That matters twice: it decides what this checkout materialises, and it
+# travels into the container, so `git status` in there compares against the same rule rather than
+# re-deriving one from the container's defaults.
+Invoke-Git @(
+    'clone', '--quiet', '--no-checkout', '--no-hardlinks',
+    '-c', 'core.autocrlf=false',
+    '-c', 'core.eol=lf',
+    $RepoRoot, $contextRoot
+) 'cloning the repository into a temporary context'
+
+# The branch name is recreated rather than left detached, because the pipeline records it and a
+# record reading `branch: HEAD` names nothing a reader can act on. A genuinely detached HEAD on the
+# host stays detached here — the context reports the host's state, it does not improve it.
+if ($branch -eq 'HEAD') {
+    Invoke-Git @('-C', $contextRoot, 'checkout', '--quiet', '--detach', $sha) 'checking out the verified commit'
+}
+else {
+    Invoke-Git @('-C', $contextRoot, 'checkout', '--quiet', '-B', $branch, $sha) 'checking out the verified commit'
+}
+
+if ($origin) {
+    Invoke-Git @('-C', $contextRoot, 'remote', 'set-url', 'origin', $origin) 'restoring the origin URL'
+}
+else {
+    & git -C $contextRoot remote remove origin 2>&1 | Out-Null
+}
+
+# The materialised commit is confirmed rather than assumed. A clone that silently landed on a
+# different revision would produce a record naming a commit nobody asked to verify, and the SHA
+# comparison at submission would then be comparing two wrong things that agree.
+$materialised = Invoke-Git @('-C', $contextRoot, 'rev-parse', 'HEAD') 'confirming the materialised commit'
+if ($materialised -ne $sha) {
+    throw "the CI context materialised $materialised, not the requested $sha."
+}
+
+return $contextRoot

--- a/scripts/ci-context.ps1
+++ b/scripts/ci-context.ps1
@@ -69,6 +69,32 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# The project name is validated first, before this script does anything at all.
+#
+# `$Project` names the temporary directory, and this script later removes that directory with
+# `-Recurse -Force`. A name carrying path components therefore chooses where that deletion lands:
+# `-Project ../../work` resolves through the temp root to a sibling directory and takes the recursive
+# delete with it. `--project` is an advertised option on both entry points, so the value arrives from
+# outside this script. Docker Compose would reject such a name as well — but it would reject it once
+# the context stage has already run, which is to say after the delete.
+#
+# The alphabet is Compose's own, and every name this repository derives already satisfies it
+# (`ci.ps1` and `ci.sh` both reduce the directory basename to `[a-z0-9-]` before appending). It is
+# also what makes the constructed path safe rather than merely conventional: a string matching this
+# pattern contains no separator and no dot, so no value of `$Project` can move the target out of the
+# temporary directory. Checked here rather than at the entry points, so it holds for every caller —
+# `submit-decide.ps1` included — and checked before the repository is read, so a hostile name is
+# refused on a dirty tree too.
+if ($Project -notmatch '^[a-z0-9][a-z0-9_-]*$') {
+    throw @"
+'$Project' is not a usable project name.
+
+It names a temporary directory that this script deletes recursively, so it is restricted to a plain
+Compose project name: a lowercase letter or digit, then lowercase letters, digits, hyphens, or
+underscores. A name containing path separators would choose what gets deleted.
+"@
+}
+
 function Invoke-Git {
     param([string[]] $GitArgs, [string] $What)
     $output = & git @GitArgs 2>&1
@@ -116,7 +142,13 @@ if ($LASTEXITCODE -ne 0) { $origin = $null }
 #
 # Ignored files are not dirt: `--porcelain` excludes them, so the run's own artifacts directory does
 # not block a run.
-$status = Invoke-Git @('-C', $RepoRoot, 'status', '--porcelain') 'reading working-tree status'
+#
+# `--untracked-files=normal` is passed explicitly rather than relying on the default, because the
+# default is not a default — it is `status.showUntrackedFiles`, which a developer may have set to
+# `no`. Under that config a brand-new source file reports nothing here, the clone omits it because it
+# is not committed, and the run reports a pass over a tree missing the very file being worked on.
+# That is the false success this check exists to prevent, arriving through the check itself.
+$status = Invoke-Git @('-C', $RepoRoot, 'status', '--porcelain', '--untracked-files=normal') 'reading working-tree status'
 if ($status) {
     throw @"
 the working tree has uncommitted changes, and local CI verifies committed content at HEAD.

--- a/scripts/ci-context.sh
+++ b/scripts/ci-context.sh
@@ -27,6 +27,32 @@ set -euo pipefail
 repo_root="${1:?usage: ci-context.sh <repo-root> <project>}"
 project="${2:?usage: ci-context.sh <repo-root> <project>}"
 
+# The project name is validated first, before this script does anything at all.
+#
+# `$project` names the temporary directory, and this script later removes that directory with
+# `rm -rf`. A name carrying path components therefore chooses where that deletion lands —
+# `--project ../../work` resolves through the temp root to a sibling directory. `--project` is an
+# advertised option on both entry points, so the value arrives from outside this script; Compose
+# would reject it as well, but only once the context stage has run, which is after the delete.
+#
+# The alphabet is Compose's own, and every name this repository derives already satisfies it. It is
+# also what makes the constructed path safe rather than merely conventional: a string matching this
+# pattern contains no separator and no dot, so no value can move the target out of the temporary
+# directory. Checked here rather than at the entry points, so it holds for every caller, and checked
+# before the repository is even read, so a hostile name is refused on a dirty tree too.
+case "$project" in
+  "" | [!a-z0-9]* | *[!a-z0-9_-]*)
+    cat >&2 <<EOF
+'$project' is not a usable project name.
+
+It names a temporary directory that this script deletes recursively, so it is restricted to a plain
+Compose project name: a lowercase letter or digit, then lowercase letters, digits, hyphens, or
+underscores. A name containing path separators would choose what gets deleted.
+EOF
+    exit 2
+    ;;
+esac
+
 command -v git >/dev/null 2>&1 || {
   echo "git was not found on PATH. It is required to materialise the CI context." >&2
   exit 2
@@ -42,7 +68,12 @@ origin="$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null || true
 # uncommitted edit is invisible to the run, so a pass would describe a tree the developer is not
 # looking at — a false success in the sense `errors.no-false-success` names. `--porcelain` excludes
 # ignored files, so the run's own artifacts directory does not block a run.
-status="$(git -C "$repo_root" status --porcelain)"
+#
+# `--untracked-files=normal` is explicit because the default is `status.showUntrackedFiles`, which a
+# developer may have set to `no`. Under that config a new source file reports nothing here, the clone
+# omits it because it is not committed, and the run passes over a tree missing the file being worked
+# on — the false success this check exists to prevent, arriving through the check itself.
+status="$(git -C "$repo_root" status --porcelain --untracked-files=normal)"
 if [ -n "$status" ]; then
   cat >&2 <<EOF
 the working tree has uncommitted changes, and local CI verifies committed content at HEAD.

--- a/scripts/ci-context.sh
+++ b/scripts/ci-context.sh
@@ -57,6 +57,13 @@ fi
 context_root="${TMPDIR:-/tmp}/${project}-context"
 rm -rf "$context_root"
 
+# A half-built context must not survive. The caller only learns the path if this script prints it, so
+# a failure between the clone and the confirmation below would leave a directory nobody owns and
+# nobody deletes — and, worse, one holding a partial materialisation of a commit under a name that
+# says it is that commit. Removed by the exact path this invocation created, never by a sweep.
+cleanup_partial() { rm -rf "$context_root"; }
+trap cleanup_partial ERR
+
 # `--no-checkout` so nothing is materialised under the host's defaults; the working tree is created
 # by the explicit checkout below, under the config pinned here. `--no-hardlinks` makes the context
 # self-contained rather than sharing storage with a directory that can change underneath it. The two
@@ -88,7 +95,10 @@ fi
 materialised="$(git -C "$context_root" rev-parse HEAD)"
 if [ "$materialised" != "$sha" ]; then
   echo "the CI context materialised $materialised, not the requested $sha." >&2
+  # `exit` does not fire the ERR trap, so this path removes the partial context itself.
+  cleanup_partial
   exit 2
 fi
 
+trap - ERR
 printf '%s\n' "$context_root"

--- a/scripts/ci-context.sh
+++ b/scripts/ci-context.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Materialise the Docker build context for a local CI run from committed repository content.
+#
+# The POSIX twin of scripts/ci-context.ps1, which carries the full rationale. In short:
+#
+#   Local CI verifies a deterministic materialisation of the exact committed HEAD, never the host
+#   checkout's byte representation.
+#
+# `COPY . /work` over the working directory verifies what one platform's checkout happened to
+# materialise. Git stores normalised content and materialises it per platform, so the same commit is
+# CRLF on a Windows checkout and LF on `ubuntu-latest`. Measured on a373d4c: 273 pass / 1 fail from
+# one, 274 pass / 0 fail from the other, identical committed content. A local gate that verifies host
+# bytes can fail what the runner passes, and pass what the runner fails.
+#
+# A clone rather than `git archive`, because scripts/repository.mjs asks git — with no fallback, by
+# design — which paths are tracked and ignored, what blob identity a reviewed path has at HEAD, and
+# whether a reviewed path is dirty. An archive plus a synthesised repository would trade the CRLF
+# mismatch for ADR 0008's source-of-truth defect.
+#
+# No bind mount, no Docker socket, no host path reachable from the run: the context is built on the
+# host, copied into the image, and deleted. Isolation is unchanged; only the origin of the bytes moved.
+#
+# Usage:
+#   scripts/ci-context.sh <repo-root> <project>   # prints the context path on stdout
+set -euo pipefail
+
+repo_root="${1:?usage: ci-context.sh <repo-root> <project>}"
+project="${2:?usage: ci-context.sh <repo-root> <project>}"
+
+command -v git >/dev/null 2>&1 || {
+  echo "git was not found on PATH. It is required to materialise the CI context." >&2
+  exit 2
+}
+
+sha="$(git -C "$repo_root" rev-parse HEAD)"
+branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+# Carried over rather than left pointing at the temporary clone: the pipeline records
+# `remote.origin.url` as the repository the run describes.
+origin="$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)"
+
+# A consequence of the invariant rather than an extra rule. Once the context is committed content, an
+# uncommitted edit is invisible to the run, so a pass would describe a tree the developer is not
+# looking at — a false success in the sense `errors.no-false-success` names. `--porcelain` excludes
+# ignored files, so the run's own artifacts directory does not block a run.
+status="$(git -C "$repo_root" status --porcelain)"
+if [ -n "$status" ]; then
+  cat >&2 <<EOF
+the working tree has uncommitted changes, and local CI verifies committed content at HEAD.
+Anything not committed would be absent from the run, so a pass would describe a tree you are not
+looking at. Commit or stash, then re-run.
+
+$status
+EOF
+  exit 2
+fi
+
+context_root="${TMPDIR:-/tmp}/${project}-context"
+rm -rf "$context_root"
+
+# `--no-checkout` so nothing is materialised under the host's defaults; the working tree is created
+# by the explicit checkout below, under the config pinned here. `--no-hardlinks` makes the context
+# self-contained rather than sharing storage with a directory that can change underneath it. The two
+# `core.*` settings are written into the context repository's own config, so they decide both what
+# this checkout materialises and what `git status` compares against inside the container.
+git clone --quiet --no-checkout --no-hardlinks \
+  -c core.autocrlf=false \
+  -c core.eol=lf \
+  "$repo_root" "$context_root"
+
+# The branch name is recreated rather than left detached, because the pipeline records it and
+# `branch: HEAD` names nothing a reader can act on. A genuinely detached host HEAD stays detached:
+# the context reports the host's state, it does not improve it.
+if [ "$branch" = "HEAD" ]; then
+  git -C "$context_root" checkout --quiet --detach "$sha"
+else
+  git -C "$context_root" checkout --quiet -B "$branch" "$sha"
+fi
+
+if [ -n "$origin" ]; then
+  git -C "$context_root" remote set-url origin "$origin"
+else
+  git -C "$context_root" remote remove origin >/dev/null 2>&1 || true
+fi
+
+# Confirmed rather than assumed. A context that landed on another revision would produce a record
+# naming a commit nobody asked to verify, and the submission SHA comparison would then be comparing
+# two wrong things that agree.
+materialised="$(git -C "$context_root" rev-parse HEAD)"
+if [ "$materialised" != "$sha" ]; then
+  echo "the CI context materialised $materialised, not the requested $sha." >&2
+  exit 2
+fi
+
+printf '%s\n' "$context_root"

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -16,6 +16,12 @@
     anything. The checks run against a Node baked into the image at a pinned digest, which is the
     point: a green run here says nothing about what the developer happens to have installed.
 
+    What gets verified is committed content at HEAD, not the working directory. The build context is
+    materialised by scripts/ci-context.ps1 as a temporary clone with pinned checkout attributes;
+    see that file for why, and for the measurement that made it necessary. The practical consequence
+    is that this script refuses to run on a dirty tree: an uncommitted edit would be absent from the
+    run, and a pass would then describe a tree the developer is not looking at.
+
 .PARAMETER KeepOnFailure
     Leave the container and network in place when the run fails, so it can be inspected. The script
     prints the exact commands to use. Without this, teardown happens on every path including failure.
@@ -66,6 +72,10 @@ $Image = "$RepoSlug-ci:$Project"
 
 $CiContainer = "$Project-ci"
 
+# Set once the context exists, and used by teardown to remove it. Declared here so the `finally`
+# block can test it on paths that failed before the context was built.
+$ContextRoot = $null
+
 $env:CI_IMAGE = $Image
 $env:LOCAL_CI_VERBOSE = if ($PSBoundParameters.ContainsKey('Verbose')) { '1' } else { '0' }
 
@@ -108,6 +118,16 @@ function Remove-CiEnvironment {
     # another run, because no other run shares the tag — that is the point of naming it per project.
     # The layers stay in the builder cache, so the next run is still fast.
     & docker image rm $Image 2>&1 | Out-Null
+    Remove-CiContext
+}
+
+# The materialised context, removed by the exact path this run created under the system temp
+# directory. Named per project, so this can no more reach another run's context than teardown can
+# reach another run's containers. Deliberately not a wildcard sweep of the temp directory.
+function Remove-CiContext {
+    if ($ContextRoot -and (Test-Path $ContextRoot)) {
+        Remove-Item $ContextRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
 $exitCode = 1
@@ -137,6 +157,15 @@ try {
     Write-Host "repository : $RepoRoot"
     Write-Host "image      : $Image"
     Write-Host "project    : $Project"
+
+    # The build context is committed content, not the working directory. Everything about why lives
+    # in scripts/ci-context.ps1; what matters here is that this line is the only thing that decides
+    # what Docker copies, and that it refuses a dirty tree rather than quietly verifying HEAD while
+    # the developer looks at something else.
+    Write-Stage "Materialising the CI context from committed HEAD"
+    $ContextRoot = & (Join-Path $PSScriptRoot 'ci-context.ps1') -RepoRoot $RepoRoot -Project $Project
+    $env:CI_CONTEXT = $ContextRoot
+    Write-Host "context    : $ContextRoot"
 
     Write-Stage "Building the CI image"
     if ((Invoke-Compose build) -ne 0) { throw "the CI image failed to build." }
@@ -187,6 +216,7 @@ finally {
     if ($KeepOnFailure -and $exitCode -ne 0) {
         Write-Host ""
         Write-Host "Containers kept for inspection (-KeepOnFailure)." -ForegroundColor Yellow
+        if ($ContextRoot) { Write-Host "  context: $ContextRoot" }
         Write-Host "  docker logs $CiContainer"
         Write-Host "  docker compose -p $Project -f compose.ci.yml run --rm --entrypoint bash ci"
         Write-Host "  docker rm -f $CiContainer; docker compose -p $Project -f compose.ci.yml down --volumes --remove-orphans"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,6 +9,11 @@
 # Host requirements: Docker and git. No Node, no npm, no globally installed anything — the checks
 # run against a Node baked into the image at a pinned digest.
 #
+# What gets verified is committed content at HEAD, not the working directory. The build context is
+# materialised by scripts/ci-context.sh as a temporary clone with pinned checkout attributes. The
+# practical consequence is that this script refuses to run on a dirty tree: an uncommitted edit would
+# be absent from the run, so a pass would describe a tree the developer is not looking at.
+#
 # Usage:
 #   ./scripts/ci.sh [--keep-on-failure] [--verbose] [--project NAME]
 set -euo pipefail
@@ -45,6 +50,8 @@ repo_slug="$(basename "$repo_root" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9'
 # rebuild is a cache hit.
 image="${repo_slug}-ci:${project}"
 ci_container="${project}-ci"
+# Set once the context exists; teardown tests it, so paths that fail earlier tear down cleanly.
+context_root=""
 export CI_IMAGE="$image"
 export LOCAL_CI_VERBOSE="$verbose"
 
@@ -63,12 +70,18 @@ teardown() {
   compose down --volumes --remove-orphans --timeout 10 || true
   # This run's own image tag, removed by that exact name. No other run shares it.
   docker image rm "$image" >/dev/null 2>&1 || true
+  # The materialised context, removed by the exact path this run created. Named per project, so this
+  # can no more reach another run's context than the lines above can reach another run's containers.
+  # Deliberately not a wildcard sweep of the temp directory.
+  [ -n "$context_root" ] && rm -rf "$context_root"
+  return 0
 }
 
 exit_code=1
 finish() {
   if [ "$keep_on_failure" -eq 1 ] && [ "$exit_code" -ne 0 ]; then
     printf '\nContainers kept for inspection (--keep-on-failure).\n'
+    [ -n "$context_root" ] && printf '  context: %s\n' "$context_root"
     printf '  docker logs %s\n' "$ci_container"
     printf '  docker compose -p %s -f compose.ci.yml run --rm --entrypoint bash ci\n' "$project"
     printf '  docker rm -f %s && docker compose -p %s -f compose.ci.yml down --volumes --remove-orphans\n' "$ci_container" "$project"
@@ -104,6 +117,17 @@ fi
 echo "repository : $repo_root"
 echo "image      : $image"
 echo "project    : $project"
+
+# The build context is committed content, not the working directory — see scripts/ci-context.sh.
+# This is the only thing that decides what Docker copies, and it refuses a dirty tree rather than
+# quietly verifying HEAD while the developer looks at something else.
+stage "Materialising the CI context from committed HEAD"
+# Invoked through `bash` rather than as an executable, so this does not depend on the mode bit
+# surviving whatever checkout produced it — which is the same class of host-dependence this change
+# exists to remove.
+context_root="$(bash "$(dirname "${BASH_SOURCE[0]}")/ci-context.sh" "$repo_root" "$project")"
+export CI_CONTEXT="$context_root"
+echo "context    : $context_root"
 
 stage "Building the CI image"
 compose build

--- a/scripts/repository.mjs
+++ b/scripts/repository.mjs
@@ -177,9 +177,17 @@ function hasHistory(root, rel) {
   return r.ok && r.out.trim() !== "";
 }
 
-/** Paths whose working-tree content differs from the index or HEAD, among those asked about. */
+/**
+ * Paths whose working-tree content differs from the index or HEAD, among those asked about.
+ *
+ * `--untracked-files=normal` is stated rather than left to the default, because the default is
+ * `status.showUntrackedFiles` — a repository-local setting. The `??` case this function's callers
+ * reason about disappears entirely under `status.showUntrackedFiles=no`, so without the flag the
+ * answer would depend on the reader's config rather than on the repository. Under the usual config
+ * this changes nothing.
+ */
 function dirtyAmong(root, paths) {
-  const r = git(root, ["status", "--porcelain", "--", ...paths]);
+  const r = git(root, ["status", "--porcelain", "--untracked-files=normal", "--", ...paths]);
   if (!r.ok) return null;
   const dirty = new Set();
   for (const line of r.out.split(/\r?\n/)) {

--- a/scripts/submit-decide.ps1
+++ b/scripts/submit-decide.ps1
@@ -11,9 +11,13 @@
     decides whether a pull request may be opened is evaluated in the same pinned environment that
     decided whether the code passes. There is no network: the decision reads nothing but its input.
 
-    The image is built on every invocation, from the current working tree, and removed afterwards.
+    The image is built on every invocation, from committed content at HEAD, and removed afterwards.
     Not an oversight, and not free: the build is layer-cached and costs seconds. What it buys is that
     the gate evaluating this submission is the gate belonging to the commit being submitted.
+
+    Committed content rather than the working tree, for the same reason ci.ps1 does it: a context
+    taken from the working directory is one platform's materialisation of the tree, and the rule
+    deciding whether a pull request may be opened must not depend on which platform rendered it.
 
     Reusing a predictable tag if one already existed would mean the rule that decides whether a pull
     request may be opened comes from whichever checkout last built that tag. When the gate's rules or
@@ -38,7 +42,10 @@ $RepoSlug = ((Split-Path -Leaf $RepoRoot) -replace '[^A-Za-z0-9]', '-').ToLowerI
 $Project = "$RepoSlug-ci-gate-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())-$PID"
 $Image = "${RepoSlug}-ci:$Project"
 
+$ContextRoot = $null
 try {
+    $ContextRoot = & (Join-Path $PSScriptRoot 'ci-context.ps1') -RepoRoot $RepoRoot -Project $Project
+    $env:CI_CONTEXT = $ContextRoot
     $env:CI_IMAGE = $Image
     & docker compose -p $Project -f (Join-Path $RepoRoot 'compose.ci.yml') build 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "could not build the CI image, so no decision can be made." }
@@ -64,4 +71,7 @@ finally {
     # Removed by the exact name this invocation created, on every path including a thrown decision.
     # No other invocation shares the tag, so this can remove nothing but its own.
     & docker image rm $Image 2>&1 | Out-Null
+    if ($ContextRoot -and (Test-Path $ContextRoot)) {
+        Remove-Item $ContextRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/scripts/submit-pr.ps1
+++ b/scripts/submit-pr.ps1
@@ -82,7 +82,10 @@ try {
     # --- Facts, gathered before anything expensive runs -------------------------------------------
     $isRepo = $null -ne (Git-Out rev-parse --git-dir)
     $branch = if ($isRepo) { Git-Out rev-parse --abbrev-ref HEAD } else { $null }
-    $dirty = if ($isRepo) { @(& git status --porcelain) | Where-Object { $_ } } else { @() }
+    # `--untracked-files=normal` explicitly, not by default: the default is `status.showUntrackedFiles`,
+    # which a developer may have set to `no`. A submission gate that consults a configurable definition
+    # of "clean" refuses exactly what that config lets through.
+    $dirty = if ($isRepo) { @(& git status --porcelain --untracked-files=normal) | Where-Object { $_ } } else { @() }
     $shaBefore = if ($isRepo) { Git-Out rev-parse HEAD } else { $null }
 
     # The pre-CI decision. Every refusal that does not depend on CI's result is made here, so a
@@ -120,7 +123,7 @@ try {
         isRepository = $isRepo
         branch       = $branch
         base         = $Base
-        dirty        = @(@(& git status --porcelain) | Where-Object { $_ })
+        dirty        = @(@(& git status --porcelain --untracked-files=normal) | Where-Object { $_ })
         shaBefore    = $shaBefore
         shaAfter     = $shaAfter
         ciExitCode   = $ciExit

--- a/scripts/verify-materialisation.ps1
+++ b/scripts/verify-materialisation.ps1
@@ -1,0 +1,319 @@
+<#
+.SYNOPSIS
+    Prove that local CI's result depends on the commit and not on how a checkout materialised it.
+
+.DESCRIPTION
+    The acceptance test for the build-context invariant:
+
+        Local CI verifies a deterministic materialisation of the exact committed HEAD, never the
+        host checkout's byte representation.
+
+    It is adversarial by construction. Rather than asserting the property from the implementation's
+    shape, it creates the disagreement the old implementation actually produced and requires the
+    pipeline to be blind to it.
+
+      1. Materialise one commit into two clean checkouts — one forced to LF, one forced to CRLF.
+      2. Confirm their working-tree bytes really do differ. A test that skipped this could pass
+         because the difference never existed, which is the failure mode of every "identical inputs
+         produce identical outputs" check ever written.
+      3. Run the complete local Docker pipeline from each.
+      4. Require the verified SHA, every stage outcome and exit code, the compliance verdict, and the
+         repository's own freshness and tracked/ignored answers to be identical.
+
+    Step 5 is `-Mutate`, and it is the reason the other four mean anything. It reverts the
+    implementation to the defect — the raw `COPY .` host-context behaviour, reproduced by pointing
+    the build context at each working directory — and requires the comparison to FAIL. A falsifier
+    that cannot be made to fail is decoration.
+
+    Windows-only, deliberately. CRLF materialisation is the transform this defends against and it is
+    the Windows checkout that performs it; `scripts/ci.sh` exists for Linux and macOS developers, but
+    the asymmetry documented in docs/local-ci.md applies here too. Running the pipeline twice takes
+    a few minutes.
+
+    Host requirements: Docker, git, PowerShell. No Node.
+
+.PARAMETER Mutate
+    Reproduce the pre-fix behaviour — build each run's image from its own working directory instead
+    of from committed content — and require the equivalence check to fail. Exit 0 means the
+    falsifier worked: the check is capable of detecting the defect. Exit 1 means the check passed
+    under the defect, which would mean it establishes nothing.
+
+.PARAMETER KeepCheckouts
+    Leave the two temporary checkouts and their captured logs in place for inspection.
+
+.EXAMPLE
+    .\scripts\verify-materialisation.ps1
+.EXAMPLE
+    .\scripts\verify-materialisation.ps1 -Mutate
+#>
+[CmdletBinding()]
+param(
+    [switch] $Mutate,
+    [switch] $KeepCheckouts
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Stamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+$WorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) "materialisation-$Stamp-$PID"
+
+function Write-Step([string] $Text) {
+    Write-Host ""
+    Write-Host "==> $Text" -ForegroundColor Cyan
+}
+
+function Invoke-Git {
+    param([string[]] $GitArgs, [string] $What)
+    $out = & git @GitArgs 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "$What failed: $($out | Out-String)" }
+    return ($out | Out-String).Trim()
+}
+
+<#
+    The working-tree byte identity of a checkout: a hash over the raw bytes of every tracked file.
+
+    Raw bytes on purpose. Reading as text would let PowerShell normalise line endings on the way in
+    and this whole comparison would report two identical checkouts that are not identical — the
+    measurement destroying the thing it measures.
+#>
+function Get-WorkingTreeBytes([string] $Root) {
+    $files = (Invoke-Git @('-C', $Root, 'ls-files') 'listing tracked files') -split "`r?`n" | Where-Object { $_ }
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        foreach ($rel in ($files | Sort-Object)) {
+            $full = Join-Path $Root $rel
+            if (-not (Test-Path $full -PathType Leaf)) { continue }
+            $bytes = [System.IO.File]::ReadAllBytes($full)
+            $sha.TransformBlock($bytes, 0, $bytes.Length, $null, 0) | Out-Null
+        }
+        $sha.TransformFinalBlock([byte[]]::new(0), 0, 0) | Out-Null
+        return ($sha.Hash | ForEach-Object { $_.ToString('x2') }) -join ''
+    }
+    finally { $sha.Dispose() }
+}
+
+<#
+    One stage's captured output, with everything that legitimately varies between runs removed.
+
+    What is stripped is per-run identity — timestamps, the unique project and image names, temp
+    paths — and nothing else. Stripping anything a check actually decided would be manufacturing the
+    agreement this script exists to test for.
+#>
+function Get-StageOutput([string] $LogPath, [string] $StageId) {
+    $text = Get-Content -Raw -LiteralPath $LogPath
+    $start = $text.IndexOf("=== $StageId ::")
+    if ($start -lt 0) { return "" }
+    $endMarker = "--- ${StageId}: "
+    $end = $text.IndexOf($endMarker, $start)
+    if ($end -lt 0) { return $text.Substring($start) }
+    $endLine = $text.IndexOf("`n", $end)
+    $slice = if ($endLine -lt 0) { $text.Substring($start) } else { $text.Substring($start, $endLine - $start) }
+    return ($slice `
+        -replace '\d{4}-\d{2}-\d{2}T[\d:.]+Z', '<timestamp>' `
+        -replace '(?i)[a-z0-9-]+-ci-\d+-\d+(-context)?', '<run>' `
+        -replace '(?i)[a-z]:\\[^\s"]*', '<path>' `
+        -replace '\s+$', '' `
+        -replace "`r`n", "`n")
+}
+
+<#
+    Materialise the commit into a checkout whose line-ending conversion is forced.
+
+    `origin` is set to the source repository's own origin so both checkouts describe the same
+    repository; otherwise each would name its own temp path and the records would differ for a
+    reason that has nothing to do with the property under test.
+#>
+function New-Checkout([string] $Name, [string] $Autocrlf, [string] $Eol, [string] $Sha, [string] $Origin) {
+    $dir = Join-Path $WorkRoot $Name
+    Invoke-Git @(
+        'clone', '--quiet', '--no-checkout', '--no-hardlinks',
+        '-c', "core.autocrlf=$Autocrlf",
+        '-c', "core.eol=$Eol",
+        $RepoRoot, $dir
+    ) "cloning the $Name checkout"
+    Invoke-Git @('-C', $dir, 'checkout', '--quiet', '--detach', $Sha) "checking out $Sha in the $Name checkout"
+    if ($Origin) { Invoke-Git @('-C', $dir, 'remote', 'set-url', 'origin', $Origin) 'setting the origin URL' | Out-Null }
+    return $dir
+}
+
+<#
+    Run the complete pipeline from one checkout and return everything the comparison looks at.
+
+    Under `-Mutate` the context is forced to the checkout's own working directory before ci.ps1
+    runs, which is exactly the pre-fix `COPY .`. ci.ps1 overwrites `CI_CONTEXT` itself, so the
+    mutation cannot be performed by setting an environment variable — it patches the one line in the
+    copied script that decides what Docker is given. The patch is applied to the temporary
+    checkout's copy, never to the repository.
+#>
+function Invoke-PipelineIn([string] $Dir, [string] $Label) {
+    if ($Mutate) {
+        $ciScript = Join-Path $Dir 'scripts/ci.ps1'
+        $text = Get-Content -Raw -LiteralPath $ciScript
+        $patched = $text -replace
+            '\$ContextRoot = & \(Join-Path \$PSScriptRoot ''ci-context\.ps1''\)[^\r\n]*',
+            '$ContextRoot = $null; $env:CI_CONTEXT = $RepoRoot'
+        if ($patched -eq $text) {
+            throw "the mutation found nothing to patch in ci.ps1; if that line moved, fix this falsifier rather than deleting it."
+        }
+        Set-Content -LiteralPath $ciScript -Value $patched -NoNewline
+    }
+
+    $log = Join-Path $WorkRoot "$Label.log"
+    Write-Host "    running the pipeline in $Label ..."
+    Push-Location $Dir
+    try {
+        & pwsh -NoProfile -File (Join-Path $Dir 'scripts/ci.ps1') *>&1 | Out-File -LiteralPath $log -Encoding utf8
+    }
+    finally { Pop-Location }
+
+    $recordPath = Join-Path $Dir 'artifacts/local-ci/latest.json'
+    if (-not (Test-Path $recordPath)) {
+        throw "$Label produced no verification record. Its log is at $log"
+    }
+    $record = Get-Content -Raw -LiteralPath $recordPath | ConvertFrom-Json
+
+    return [pscustomobject]@{
+        label   = $Label
+        log     = $log
+        commit  = $record.commit
+        result  = $record.result
+        failed  = $record.failedStage
+        scope   = $record.scope
+        # Stage identity: what ran, in what order, with what outcome. Durations and timestamps are
+        # not part of it — they vary between two runs of the same commit for reasons nobody claims
+        # otherwise.
+        stages  = ($record.checks | ForEach-Object { "$($_.id)=$($_.outcome)/$($_.exitCode)" }) -join ' '
+        # The compliance verdict and, with it, every attestation freshness answer the validator
+        # printed. This is the part `git archive` alone would have quietly broken: freshness is
+        # computed from committed blob identity through git, so a context without a real repository
+        # would answer it differently — or not at all.
+        validate = Get-StageOutput $log 'validate'
+        # The self-audit, which is where the repository's tracked/ignored seam shows up in output.
+        audit    = Get-StageOutput $log 'audit'
+    }
+}
+
+$failures = @()
+function Compare-Field([string] $Name, $A, $B) {
+    if ($A -eq $B) {
+        Write-Host ("  {0,-22} identical" -f $Name) -ForegroundColor Green
+    }
+    else {
+        Write-Host ("  {0,-22} DIFFERS" -f $Name) -ForegroundColor Red
+        Write-Host "      lf   : $A"
+        Write-Host "      crlf : $B"
+        $script:failures += $Name
+    }
+}
+
+$exitCode = 1
+try {
+    New-Item -ItemType Directory -Force -Path $WorkRoot | Out-Null
+
+    $sha = Invoke-Git @('-C', $RepoRoot, 'rev-parse', 'HEAD') 'reading HEAD'
+    $origin = & git -C $RepoRoot config --get remote.origin.url 2>$null
+    if ($LASTEXITCODE -ne 0) { $origin = $null }
+
+    Write-Host "commit  : $sha"
+    Write-Host "work    : $WorkRoot"
+    Write-Host "mode    : $(if ($Mutate) { 'MUTATED — host context, failure expected' } else { 'normal' })"
+
+    Write-Step "Materialising $sha into two checkouts with opposite line-ending conversion"
+    $lfDir = New-Checkout 'lf' 'false' 'lf' $sha $origin
+    $crlfDir = New-Checkout 'crlf' 'true' 'crlf' $sha $origin
+
+    Write-Step "Confirming the two checkouts genuinely differ on disk"
+    $lfBytes = Get-WorkingTreeBytes $lfDir
+    $crlfBytes = Get-WorkingTreeBytes $crlfDir
+    Write-Host "  lf   working-tree bytes : $lfBytes"
+    Write-Host "  crlf working-tree bytes : $crlfBytes"
+    if ($lfBytes -eq $crlfBytes) {
+        # Not a pass. If the two materialisations are identical there is nothing for the pipeline to
+        # be blind to, and continuing would report a green that establishes nothing.
+        throw @"
+the two checkouts materialised identical bytes, so this run cannot establish anything.
+Check that .gitattributes has not been changed to pin every path to one line ending — that would
+make this test vacuous rather than satisfied.
+"@
+    }
+    # Both checkouts must nonetheless be clean, or the difference is a working-tree edit rather than
+    # a materialisation difference, and the pipeline would refuse them for an unrelated reason.
+    foreach ($d in @($lfDir, $crlfDir)) {
+        $dirty = Invoke-Git @('-C', $d, 'status', '--porcelain') 'checking the checkout is clean'
+        if ($dirty) { throw "the checkout at $d is not clean:`n$dirty" }
+    }
+    Write-Host "  the same commit is on disk as different bytes, and git considers both unmodified" -ForegroundColor Yellow
+
+    Write-Step "Running the complete local Docker pipeline from each checkout"
+    $lf = Invoke-PipelineIn $lfDir 'lf'
+    $crlf = Invoke-PipelineIn $crlfDir 'crlf'
+
+    Write-Step "Comparing what the two runs established"
+    Compare-Field 'verified commit' $lf.commit $crlf.commit
+    Compare-Field 'result' $lf.result $crlf.result
+    Compare-Field 'failed stage' "$($lf.failed)" "$($crlf.failed)"
+    Compare-Field 'scope' $lf.scope $crlf.scope
+    Compare-Field 'stage outcomes' $lf.stages $crlf.stages
+
+    foreach ($name in @('validate', 'audit')) {
+        if ($lf.$name -eq $crlf.$name) {
+            Write-Host ("  {0,-22} identical" -f "$name output") -ForegroundColor Green
+        }
+        else {
+            Write-Host ("  {0,-22} DIFFERS" -f "$name output") -ForegroundColor Red
+            Write-Host "      lf   log: $($lf.log)"
+            Write-Host "      crlf log: $($crlf.log)"
+            $failures += "$name output"
+        }
+    }
+    if ($lf.commit -ne $sha) { $failures += "the runs verified $($lf.commit), not the requested $sha" }
+
+    Write-Host ""
+    if ($Mutate) {
+        # Inverted on purpose. Under the defect the comparison must fail; a mutated run that agrees
+        # would mean the comparison above cannot see the thing it was written to see.
+        if ($failures.Count -gt 0) {
+            Write-Host "FALSIFIER WORKED: with the host-context defect restored, the runs disagreed on:" -ForegroundColor Green
+            foreach ($f in $failures) { Write-Host "  - $f" }
+            Write-Host "The equivalence check is capable of failing, so passing it means something."
+            $exitCode = 0
+        }
+        else {
+            Write-Host "FALSIFIER FAILED: the defect was restored and the runs still agreed." -ForegroundColor Red
+            Write-Host "The equivalence check cannot detect the defect it exists to detect."
+            $exitCode = 1
+        }
+    }
+    elseif ($failures.Count -gt 0) {
+        Write-Host "MATERIALISATION EQUIVALENCE FAILED" -ForegroundColor Red
+        Write-Host "Two checkouts of $sha produced different results. Local CI is verifying the checkout,"
+        Write-Host "not the commit. Differing: $($failures -join ', ')"
+        $exitCode = 1
+    }
+    else {
+        Write-Host "MATERIALISATION EQUIVALENCE HELD" -ForegroundColor Green
+        Write-Host "Two checkouts of $sha with demonstrably different bytes on disk produced the same"
+        Write-Host "verified SHA, the same stage outcomes, the same verdict, and the same repository answers."
+        $exitCode = 0
+    }
+}
+catch {
+    Write-Host ""
+    Write-Host "could not complete: $($_.Exception.Message)" -ForegroundColor Red
+    $exitCode = 2
+}
+finally {
+    if ($KeepCheckouts) {
+        Write-Host ""
+        Write-Host "Checkouts and logs kept at $WorkRoot" -ForegroundColor Yellow
+    }
+    elseif (Test-Path $WorkRoot) {
+        # Scoped to the directory this invocation created under the system temp directory, by exact
+        # path. Never a wildcard sweep.
+        Remove-Item $WorkRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+exit $exitCode

--- a/scripts/verify-materialisation.ps1
+++ b/scripts/verify-materialisation.ps1
@@ -142,34 +142,60 @@ function New-Checkout([string] $Name, [string] $Autocrlf, [string] $Eol, [string
 }
 
 <#
-    Run the complete pipeline from one checkout and return everything the comparison looks at.
+    The pre-fix implementation, reproduced: build the image with the checkout's own working directory
+    as the Docker context, run the pipeline, copy the record out.
 
-    Under `-Mutate` the context is forced to the checkout's own working directory before ci.ps1
-    runs, which is exactly the pre-fix `COPY .`. ci.ps1 overwrites `CI_CONTEXT` itself, so the
-    mutation cannot be performed by setting an environment variable — it patches the one line in the
-    copied script that decides what Docker is given. The patch is applied to the temporary
-    checkout's copy, never to the repository.
+    This is what `-Mutate` restores. It is written out here rather than produced by patching the
+    checkout's copy of ci.ps1, and the difference is not stylistic — an earlier version did patch the
+    script, which made both checkouts dirty in the same way, so both failed the byte-identity check
+    identically and the harness reported agreement. A mutation that perturbs both arms equally proves
+    nothing. Nothing is modified in either checkout now; only the context handed to Docker differs.
+
+    The commands mirror scripts/ci.ps1: same compose file, same per-run project and image name, same
+    named container so the record can be copied out of it, same teardown scoped to what this created.
+#>
+function Invoke-LegacyPipelineIn([string] $Dir, [string] $Label, [string] $Log) {
+    $project = "materialisation-$Stamp-$Label"
+    $image = "materialisation-ci:$project"
+    $container = "$project-ci"
+    $compose = Join-Path $Dir 'compose.ci.yml'
+    $env:CI_IMAGE = $image
+    # The defect, in one assignment: Docker is given the working directory.
+    $env:CI_CONTEXT = $Dir
+    try {
+        & docker compose -p $project -f $compose build *>&1 | Out-File -LiteralPath $Log -Encoding utf8
+        & docker compose -p $project -f $compose run --name $container ci *>&1 |
+            Out-File -LiteralPath $Log -Encoding utf8 -Append
+        $recordDir = Join-Path $Dir 'artifacts/local-ci'
+        New-Item -ItemType Directory -Force -Path $recordDir | Out-Null
+        & docker cp "${container}:/work/artifacts/local-ci/latest.json" (Join-Path $recordDir 'latest.json') 2>&1 |
+            Out-Null
+    }
+    finally {
+        & docker rm --force --volumes $container 2>&1 | Out-Null
+        & docker compose -p $project -f $compose down --volumes --remove-orphans --timeout 10 2>&1 | Out-Null
+        & docker image rm $image 2>&1 | Out-Null
+        $env:CI_CONTEXT = $null
+    }
+}
+
+<#
+    Run the complete pipeline from one checkout and return everything the comparison looks at.
 #>
 function Invoke-PipelineIn([string] $Dir, [string] $Label) {
-    if ($Mutate) {
-        $ciScript = Join-Path $Dir 'scripts/ci.ps1'
-        $text = Get-Content -Raw -LiteralPath $ciScript
-        $patched = $text -replace
-            '\$ContextRoot = & \(Join-Path \$PSScriptRoot ''ci-context\.ps1''\)[^\r\n]*',
-            '$ContextRoot = $null; $env:CI_CONTEXT = $RepoRoot'
-        if ($patched -eq $text) {
-            throw "the mutation found nothing to patch in ci.ps1; if that line moved, fix this falsifier rather than deleting it."
-        }
-        Set-Content -LiteralPath $ciScript -Value $patched -NoNewline
-    }
-
     $log = Join-Path $WorkRoot "$Label.log"
     Write-Host "    running the pipeline in $Label ..."
-    Push-Location $Dir
-    try {
-        & pwsh -NoProfile -File (Join-Path $Dir 'scripts/ci.ps1') *>&1 | Out-File -LiteralPath $log -Encoding utf8
+
+    if ($Mutate) {
+        Invoke-LegacyPipelineIn $Dir $Label $log
     }
-    finally { Pop-Location }
+    else {
+        Push-Location $Dir
+        try {
+            & pwsh -NoProfile -File (Join-Path $Dir 'scripts/ci.ps1') *>&1 | Out-File -LiteralPath $log -Encoding utf8
+        }
+        finally { Pop-Location }
+    }
 
     $recordPath = Join-Path $Dir 'artifacts/local-ci/latest.json'
     if (-not (Test-Path $recordPath)) {

--- a/scripts/verify-materialisation.ps1
+++ b/scripts/verify-materialisation.ps1
@@ -127,13 +127,16 @@ function Get-StageOutput([string] $LogPath, [string] $StageId) {
 #>
 function New-Checkout([string] $Name, [string] $Autocrlf, [string] $Eol, [string] $Sha, [string] $Origin) {
     $dir = Join-Path $WorkRoot $Name
+    # `| Out-Null` on every call made for its effect. In PowerShell an un-consumed return value is
+    # output, so a bare call here would prepend blank lines to this function's return value and the
+    # caller would receive a path with leading whitespace. That trap cost a run of this very change.
     Invoke-Git @(
         'clone', '--quiet', '--no-checkout', '--no-hardlinks',
         '-c', "core.autocrlf=$Autocrlf",
         '-c', "core.eol=$Eol",
         $RepoRoot, $dir
-    ) "cloning the $Name checkout"
-    Invoke-Git @('-C', $dir, 'checkout', '--quiet', '--detach', $Sha) "checking out $Sha in the $Name checkout"
+    ) "cloning the $Name checkout" | Out-Null
+    Invoke-Git @('-C', $dir, 'checkout', '--quiet', '--detach', $Sha) "checking out $Sha in the $Name checkout" | Out-Null
     if ($Origin) { Invoke-Git @('-C', $dir, 'remote', 'set-url', 'origin', $Origin) 'setting the origin URL' | Out-Null }
     return $dir
 }

--- a/scripts/verify-materialisation.ps1
+++ b/scripts/verify-materialisation.ps1
@@ -270,7 +270,7 @@ make this test vacuous rather than satisfied.
     # Both checkouts must nonetheless be clean, or the difference is a working-tree edit rather than
     # a materialisation difference, and the pipeline would refuse them for an unrelated reason.
     foreach ($d in @($lfDir, $crlfDir)) {
-        $dirty = Invoke-Git @('-C', $d, 'status', '--porcelain') 'checking the checkout is clean'
+        $dirty = Invoke-Git @('-C', $d, 'status', '--porcelain', '--untracked-files=normal') 'checking the checkout is clean'
         if ($dirty) { throw "the checkout at $d is not clean:`n$dirty" }
     }
     Write-Host "  the same commit is on disk as different bytes, and git considers both unmodified" -ForegroundColor Yellow

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -24,6 +24,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -296,6 +297,60 @@ test("moving the context out of the working tree did not open a hole in the cont
     // be re-argued rather than absorbed.
     assert.doesNotMatch(text, /\bdocker\b/i, `${file} touches Docker at all`);
   }
+});
+
+test("the tree a verifying run executes is the committed tree, byte for byte", (t) => {
+  // The invariant, asserted from inside the run rather than from the shape of the scripts that set
+  // it up. Everything else in this section is a text assertion about ci.ps1 and compose.ci.yml; this
+  // is the one check that would notice if all of that were wired correctly and still delivered the
+  // wrong bytes.
+  //
+  // It is also what makes the cross-materialisation harness non-vacuous. That harness proves two
+  // checkouts agree, and two checkouts agree trivially when nothing in the suite can tell them
+  // apart. This can: under the old `COPY .` behaviour a CRLF checkout fails here and an LF one does
+  // not, which is exactly the divergence the harness needs to be able to observe.
+  //
+  // Deliberately scoped to runs that make verification claims. On a developer's Windows host the
+  // working tree legitimately is not the committed bytes — that is what `core.autocrlf` does — and
+  // failing `npm test` there would be reporting a checkout convention as a defect. Skipped with a
+  // reason rather than silently passing, because a check that quietly does nothing is the failure
+  // this repository names most often.
+  const verifying = process.env.LOCAL_CI_CONTAINER === "1" || process.env.GITHUB_ACTIONS === "true";
+  if (!verifying) {
+    t.skip("not a verifying run — the host checkout's byte representation is its own business");
+    return;
+  }
+
+  const git = (args, input) =>
+    spawnSync("git", ["-C", ROOT, ...args], { encoding: "utf8", input, maxBuffer: 64 * 1024 * 1024 });
+
+  // Committed identity for every regular file at HEAD. Modes other than 100644/100755 — symlinks,
+  // gitlinks — are excluded because their working-tree representation is not their blob content.
+  const tree = git(["ls-tree", "-r", "-z", "HEAD"]);
+  assert.equal(tree.status, 0, "git could not read the tree at HEAD");
+  const committed = new Map();
+  for (const entry of tree.stdout.split("\0").filter(Boolean)) {
+    const m = entry.match(/^(\d{6}) blob ([0-9a-f]{40})\t(.*)$/);
+    if (m && (m[1] === "100644" || m[1] === "100755")) committed.set(m[3], m[2]);
+  }
+  assert.ok(committed.size > 100, `only ${committed.size} committed files found — has the tree shape changed?`);
+
+  // Identity of the bytes actually on disk. `--no-filters` is the whole point: it hashes the file as
+  // it lies there, without re-applying the normalisation that makes git call a CRLF checkout clean.
+  // One process for every path rather than one process per path.
+  const paths = [...committed.keys()];
+  const onDisk = git(["hash-object", "--no-filters", "--stdin-paths"], `${paths.join("\n")}\n`);
+  assert.equal(onDisk.status, 0, `git could not hash the working tree: ${onDisk.stderr}`);
+  const hashes = onDisk.stdout.split("\n").filter(Boolean);
+  assert.equal(hashes.length, paths.length, "git hashed a different number of files than were asked about");
+
+  const differing = paths.filter((rel, i) => hashes[i] !== committed.get(rel));
+  assert.deepEqual(
+    differing.slice(0, 10),
+    [],
+    `${differing.length} file(s) on disk differ from their committed content. This run is verifying a ` +
+      "materialisation of the commit rather than the commit — see ADR 0015.",
+  );
 });
 
 test("the cross-materialisation falsifier can fail, and says so in both directions", () => {

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -23,7 +23,8 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -270,6 +271,81 @@ test("a dirty tree is refused before anything is verified", () => {
     assert.match(text, /status['", ]+--porcelain/, `${file} does not check for uncommitted changes`);
     assert.match(text, /uncommitted changes/, `${file} does not name the cause`);
   }
+});
+
+test("what counts as clean is not left to the reader's git config", () => {
+  // `git status --porcelain` honours `status.showUntrackedFiles`. Where that is set to `no`, a new
+  // and uncommitted source file reports nothing, the context clone omits it because it is not
+  // committed, and the run reports a pass over a tree missing the file being worked on. A gate whose
+  // definition of "clean" is configurable exempts precisely what the configuration hides, so every
+  // cleanliness question in this repository states the flag rather than inheriting an answer.
+  const gates = [
+    "scripts/ci-context.ps1",
+    "scripts/ci-context.sh",
+    "scripts/submit-pr.ps1",
+    "scripts/verify-materialisation.ps1",
+    "scripts/repository.mjs",
+  ];
+  for (const file of gates) {
+    const text = withoutComments(read(file));
+    for (const line of text.split(/\r?\n/)) {
+      if (!/status['", ]+--porcelain/.test(line)) continue;
+      assert.match(
+        line,
+        /--untracked-files=/,
+        `${file} asks git whether the tree is clean without saying what clean means:\n${line.trim()}`,
+      );
+    }
+  }
+});
+
+test("a project name cannot choose what the context builder deletes", (t) => {
+  // `--project` is an advertised option on both entry points, and its value names the temporary
+  // directory that the context builder removes recursively. A name carrying path components
+  // therefore aimed that delete: `--project ../../work` resolved through the temp root to a sibling
+  // directory. Compose would have rejected the name eventually, but the context stage — and its
+  // delete — runs first.
+  //
+  // Driven for real rather than asserted as text, because the failure being guarded is a deletion.
+  // A sandbox is built with a sentinel directory sitting exactly where the traversal would land; if
+  // the guard is removed, this test destroys it and fails on its absence.
+  const bash = spawnSync("bash", ["-c", "exit 0"], { encoding: "utf8" });
+  if (bash.error || bash.status !== 0) {
+    t.skip("bash is unavailable, so the POSIX twin cannot be driven here");
+    return;
+  }
+
+  const sandbox = mkdtempSync(path.join(tmpdir(), "ci-context-guard-"));
+  try {
+    const temp = path.join(sandbox, "temp");
+    mkdirSync(temp);
+    // `<sandbox>/temp/../sentinel-context` — what `--project ../sentinel` resolves to, since the
+    // builder appends `-context` to the name it is given.
+    const sentinel = path.join(sandbox, "sentinel-context");
+    mkdirSync(sentinel);
+    writeFileSync(path.join(sentinel, "keep.txt"), "not the context builder's to delete\n");
+
+    const run = spawnSync("bash", [path.join(ROOT, "scripts/ci-context.sh"), ROOT, "../sentinel"], {
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: temp },
+    });
+
+    assert.ok(
+      existsSync(path.join(sentinel, "keep.txt")),
+      "the context builder deleted a directory outside the temp root it was given",
+    );
+    assert.notEqual(run.status, 0, "a project name carrying path components was accepted");
+    assert.match(`${run.stderr}`, /not a usable project name/, "the refusal does not say what is wrong");
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+
+  // The PowerShell twin cannot be driven from here — pwsh is not in the image that runs this suite —
+  // so it is checked as text, with the limitation this file already records for every environment
+  // assertion. The two guards are written to refuse the same alphabet.
+  const ps = withoutComments(read("scripts/ci-context.ps1"));
+  assert.match(ps, /\$Project -notmatch '\^\[a-z0-9\]\[a-z0-9_-\]\*\$'/, "the PowerShell twin has no such guard");
+  assert.match(ps, /not a usable project name/, "the PowerShell twin does not name the refusal");
 });
 
 test("the context is removed by exact path and never by a sweep of the temp directory", () => {

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -194,6 +194,127 @@ test("a linked worktree is refused by name rather than failing inside the contai
   }
 });
 
+// --- The build context is the commit, not the checkout ------------------------------------------
+
+test("Docker is given a materialised context, never the working directory", () => {
+  // The defect this replaced: `context: .` made the run verify one platform's materialisation of
+  // the tree rather than the tree. Measured on a373d4c — 273 pass / 1 fail from a CRLF checkout,
+  // 274 pass / 0 fail from an LF one, identical committed content — so the gate produced a red the
+  // runner did not, and the same mechanism runs the other way.
+  const compose = withoutComments(read("compose.ci.yml"));
+  assert.match(compose, /context:\s*\$\{CI_CONTEXT:-\.\}/, "the compose build context is not parameterised");
+
+  const ps = withoutComments(read("scripts/ci.ps1"));
+  const sh = withoutComments(read("scripts/ci.sh"));
+  assert.match(ps, /ci-context\.ps1/, "ci.ps1 does not materialise a context");
+  assert.match(ps, /\$env:CI_CONTEXT\s*=\s*\$ContextRoot/, "ci.ps1 does not hand the context to compose");
+  assert.match(sh, /ci-context\.sh/, "ci.sh does not materialise a context");
+  assert.match(sh, /export CI_CONTEXT="\$context_root"/, "ci.sh does not hand the context to compose");
+});
+
+test("the gate that decides submission is built from committed content too", () => {
+  // The gate deciding whether a pull request may be opened must not depend on which platform
+  // rendered the tree, for the same reason the pipeline must not.
+  const text = withoutComments(read("scripts/submit-decide.ps1"));
+  assert.match(text, /ci-context\.ps1/, "submit-decide builds from the working directory");
+  assert.match(text, /\$env:CI_CONTEXT\s*=\s*\$ContextRoot/, "submit-decide does not hand the context to compose");
+  assert.match(text, /finally\s*\{[\s\S]*Remove-Item \$ContextRoot/, "submit-decide leaves its context behind");
+});
+
+test("the context is a real repository, not an export", () => {
+  // `git archive HEAD` would give committed file content and no repository. scripts/repository.mjs
+  // asks git which paths are tracked and ignored, what blob identity a reviewed path has at HEAD,
+  // and whether a reviewed path is dirty — with no fallback, deliberately. An export plus a
+  // synthesised repository would answer those from something that is not the repository, trading
+  // this defect for ADR 0008's.
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    // Spelled two ways — `git clone …` in the shell twin, `@('clone', …)` in the PowerShell one —
+    // so the assertion is on the subcommand rather than on one file's calling convention.
+    assert.match(text, /(?:^|\W)clone(?:\W|$)/, `${file} does not clone the repository`);
+    assert.match(text, /--no-checkout/, `${file} materialises files before pinning how they materialise`);
+    assert.doesNotMatch(text, /\barchive\b/, `${file} exports a tree instead of cloning a repository`);
+    assert.match(text, /--no-hardlinks/, `${file} shares object storage with a directory that can change`);
+  }
+});
+
+test("the context's checkout attributes are pinned rather than inherited from the host", () => {
+  // The whole point. A context materialised under the host's `core.autocrlf` would reproduce the
+  // defect inside the fix.
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    assert.match(text, /core\.autocrlf=false/, `${file} inherits the host's line-ending conversion`);
+    assert.match(text, /core\.eol=lf/, `${file} does not pin the materialised line ending`);
+  }
+});
+
+test("the context is confirmed to be the commit that was asked for", () => {
+  // A context that silently landed on another revision would produce a record naming a commit
+  // nobody asked to verify, and the submission SHA comparison would compare two wrong things that
+  // agree with each other.
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    assert.match(text, /rev-parse['", ]+HEAD/, `${file} never reads the commit it materialised`);
+    assert.match(text, /materialised/i, `${file} does not confirm what it materialised`);
+  }
+});
+
+test("a dirty tree is refused before anything is verified", () => {
+  // Once the context is committed content, an uncommitted edit is invisible to the run — a pass
+  // would describe a tree the developer is not looking at, which is the false-success class
+  // `errors.no-false-success` names. Submission already refused a dirty tree; this moves the same
+  // requirement to the point where it first has consequences.
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    assert.match(text, /status['", ]+--porcelain/, `${file} does not check for uncommitted changes`);
+    assert.match(text, /uncommitted changes/, `${file} does not name the cause`);
+  }
+});
+
+test("the context is removed by exact path and never by a sweep of the temp directory", () => {
+  // The same rule as container teardown: this can remove what this run created and nothing else.
+  for (const file of ["scripts/ci.ps1", "scripts/ci.sh", "scripts/verify-materialisation.ps1"]) {
+    const text = withoutComments(read(file));
+    assert.doesNotMatch(text, /Remove-Item[^\n]*\*/, `${file} removes temp paths by wildcard`);
+    assert.doesNotMatch(text, /rm -rf[^\n]*\*/, `${file} removes temp paths by wildcard`);
+  }
+  assert.match(withoutComments(read("scripts/ci.ps1")), /Remove-CiContext/, "ci.ps1 leaves its context behind");
+  assert.match(withoutComments(read("scripts/ci.sh")), /rm -rf "\$context_root"/, "ci.sh leaves its context behind");
+});
+
+test("moving the context out of the working tree did not open a hole in the container", () => {
+  // The fix had to make the input deterministic without weakening what #27 established. The context
+  // is built on the host and copied in; nothing was mounted to compensate afterwards.
+  const compose = withoutComments(read("compose.ci.yml"));
+  assert.doesNotMatch(compose, /^\s*volumes:/m, "a volume appeared alongside the context change");
+  assert.doesNotMatch(compose, /docker\.sock/, "the Docker socket is exposed");
+  assert.match(compose, /network_mode:\s*none/, "the CI container gained network access");
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    // The context builder is a git operation and nothing else. If it ever needs to talk to Docker —
+    // to mount, to bind, to reach back at the host — the isolation argument has changed and should
+    // be re-argued rather than absorbed.
+    assert.doesNotMatch(text, /\bdocker\b/i, `${file} touches Docker at all`);
+  }
+});
+
+test("the cross-materialisation falsifier can fail, and says so in both directions", () => {
+  // The acceptance test is only worth its runtime if it can fail. `-Mutate` restores the
+  // host-context defect and inverts the verdict: agreement under the defect is reported as the
+  // check being incapable, not as a pass. This asserts the harness keeps both halves — a falsifier
+  // quietly reduced to a one-way check is the failure mode.
+  const text = read("scripts/verify-materialisation.ps1");
+  const active = withoutComments(text);
+  assert.match(active, /\[switch\]\s*\$Mutate/, "the falsifier has no mutation mode");
+  assert.match(active, /FALSIFIER FAILED/, "agreement under the defect is not reported as a failure");
+  assert.match(active, /the two checkouts materialised identical bytes/, "the harness does not verify the inputs differ");
+  // The comparison must cover more than the exit code: a run can agree on pass/fail while
+  // disagreeing about what it verified.
+  for (const field of ["verified commit", "stage outcomes", "validate", "audit"]) {
+    assert.ok(active.includes(field), `the falsifier does not compare ${field}`);
+  }
+});
+
 // --- The submission gate -----------------------------------------------------------------------
 
 const SHA_A = "a".repeat(40);


### PR DESCRIPTION
A follow-up to #27, taken immediately rather than deferred, because the local Docker gate should not
be treated as equivalent to the hosted required gate while this holds.

## The defect

`COPY . /work` built the image from the developer's working directory, so the gate verified **one
platform's materialisation of the tree** rather than the tree. `.gitattributes` pins `*.sh` and
`ci/Dockerfile` to LF because a CRLF shebang is not executable, and deliberately leaves everything
else to the checkout. On Windows with `core.autocrlf=true` that means every `.mjs`, `.json`, and
`.md` file lands as CRLF; `ubuntu-latest` lands the same commit as LF.

Measured on `a373d4c`, committed content held constant, only the checkout's conversion varied:

| Materialisation | Pipeline result |
| --- | --- |
| CRLF (Windows default) | 273 pass, 1 fail |
| LF (what git stores, what `ubuntu-latest` checks out) | 274 pass, 0 fail |
| GitHub-hosted runner | pass |

The direction is the least interesting part. The mechanism is symmetric: a gate whose input is the
host's byte representation can equally pass what the runner fails.

## The fix

> Local CI verifies a deterministic materialisation of the exact committed `HEAD`, never the host
> checkout's byte representation.

The build context is now a temporary clone at the commit `HEAD` names, with `core.autocrlf=false`
and `core.eol=lf` written into its own config, its materialised commit confirmed against the
requested one, removed by exact path on every exit path — including partial contexts left by a
failure. `ci.ps1`, `ci.sh`, and `submit-decide.ps1` all build from it.

**Not** `eol=lf` on every path: that bends repository policy around the verifier and closes only the
one transform someone thought of. **Not** `git archive`: the audit resolves tracked and ignored paths
through git and attestation freshness reads committed blob identity, so an export plus a synthesised
repository would trade this defect for [ADR 0008](artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)'s.

**Isolation is unchanged.** No bind mount, no Docker socket, no host path reachable from the run. The
context builders touch git and nothing else, asserted by test, because the tempting shape of this fix
is to open a channel and compensate inside the container.

**A clean tree is now required.** Uncommitted work is absent from the run, so a pass would otherwise
describe a tree the developer cannot see.

## Evidence

Both directions of the acceptance test were run on `7e5e155`:

```
verify-materialisation.ps1            EXIT 0   equivalence held
  lf   working-tree bytes 0fb32818…   crlf working-tree bytes 8590d1b9…   (confirmed different)
  verified commit / result / failed stage / scope / stage outcomes / validate / audit — all identical

verify-materialisation.ps1 -Mutate    EXIT 0   falsifier worked
  lf   test=passed/0 … validate=advisory-failed/1
  crlf test=failed/1
  the equivalence check is capable of failing, so passing it means something
```

Full gate on `7e5e155`: inventory, fidelity, policy, diagrams, test (270 pass, 0 fail), audit all
pass; `validate` advisory-failed exit 1, which is this repository's correct and permanent verdict
while four recorded human rejections stand. No rejection was touched and advisory-red semantics are
unchanged.

## Things found along the way, recorded rather than tidied away

- Two commits here fix bugs introduced by the first. An un-consumed return value is stdout in
  PowerShell, so the context path reached Docker with leading blanks; and a half-built context
  outlived the failure that produced it. Both are kept as their own commits with their own messages.
- The falsifier initially reported success under its own mutation. It patched the checkout's copy of
  `ci.ps1`, which perturbed both arms equally. It now reproduces the pre-fix implementation directly
  and modifies nothing.
- The linked-worktree refusal is now **conservative rather than necessary** — `git clone` resolves a
  linked worktree into a self-contained repository, measured while making this change. The guard is
  left in place; lifting it is its own decision.

## What this does not establish

That local CI and the hosted gate are equivalent in general. It removes one measured source of
divergence — the input. Everything under *What cannot be reproduced locally* in `docs/local-ci.md`
remains unreproduced.


---

## Local CI

This pipeline ran in an ephemeral Docker container on the author's machine.
It is **not** a GitHub-hosted Actions run and makes no claim about one.

- Verified commit: `7e5e15516504d8877119bea21ccd9d51cd59ab7e`
- Branch: `fix/ci-context-from-committed-head`
- Result: **PASS**
- Environment: Docker (`engineeringstandards-ci:engineeringstandards-ci-1786897572420-60356`, Node v20.20.2)
- Completed: 2026-08-16T16:26:25.318Z

<details><summary>Stages executed</summary>

- `inventory` — passed (exit 0)
- `fidelity` — passed (exit 0)
- `policy` — passed (exit 0)
- `diagrams` — passed (exit 0)
- `test` — passed (exit 0)
- `audit` — passed (exit 0)
- `validate` — advisory-failed (exit 1) _[advisory, non-gating]_

</details>

