### PR TITLE
A red check means four different things, and counting them means none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,30 @@ Two defects found in review of the above, before it merged:
   refuse anything outside a plain Compose project name, before reading the repository at all. Driven
   by a test that destroys a sentinel directory if the guard is removed.
 
+**A red check is classified rather than counted** — `scripts/ci-triage.mjs`. This repository keeps two
+jobs permanently red on purpose, so a reader that treats `conclusion: failure` alike either alarms on
+correct governance evidence or learns to ignore it. Four things a red can mean, and three answers:
+
+| | |
+| --- | --- |
+| `EXPECTED` | the evidence establishes the expected state — exit 0 |
+| `ACTIONABLE` | the evidence establishes an unexpected state — exit 1 |
+| `INDETERMINATE` | the evidence cannot establish the state — exit 2 |
+
+`INDETERMINATE` is not a softer `ACTIONABLE`. A job that executed no step, an unreadable API, an
+unreadable policy — none are evidence that the repository is wrong, and saying so would be its own
+false claim. The same split `validate` already draws between `NON_COMPLIANT` and `NOT_EVALUATED`.
+
+- The established rejection set is **derived from `project-policy.yml`**, never listed in the tool: a
+  copied list would still call a cleared rejection expected. A test fails if any rejection id appears
+  in the source.
+- `classify()` is pure, so every terminal branch is reachable from a small structured fixture rather
+  than a fabricated runner log. Log parsing is separate, tested against tiny raw specimens.
+- Disagreement between the inside and outside evaluator placements is actionable and named as such —
+  the one result neither arm can report alone.
+- A reader, not a gate. It does not modify the policy, re-run checks, form its own compliance
+  opinion, or suppress the jobs it interprets, and tests assert each of those.
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/scripts/ci-triage.mjs
+++ b/scripts/ci-triage.mjs
@@ -1,0 +1,458 @@
+/**
+ * Classify a pull request's checks by what they mean, not by what colour they are.
+ *
+ * This repository has three intentionally different CI signals, and a reader that treats
+ * `conclusion: failure` as "something is broken" flattens them into one:
+ *
+ *   test                      required   green expected
+ *   validate                  advisory   red is meaningful and expected
+ *   validate-self / validate  advisory   red is meaningful and expected
+ *
+ * The two advisory jobs are red permanently and correctly: four prohibitions were reviewed by the
+ * project owner and found unmet, and a recorded rejection is a failure rather than silence. Alerting
+ * on them is a false alarm, and repeated false alarms train a reader to ignore the real one.
+ *
+ * Silencing them would be worse. Those jobs carry evidence nothing else produces: `validate` runs the
+ * evaluator from inside the repository, `validate-self` installs the framework and evaluates the
+ * repository as an external project. Their *agreement* is what establishes that placement does not
+ * change a verdict — the invariant neither arm can report alone — and their exit code distinguishes
+ * "a verdict was produced and it is red" from "no verdict was produced at all". Both facts disappear
+ * the moment the job is ignored.
+ *
+ * ## What a red check can mean
+ *
+ * Four different things, and collapsing them is the defect this file exists to prevent:
+ *
+ *   EXPECTED       the evidence establishes the expected state          exit 0
+ *   ACTIONABLE     the evidence establishes an unexpected state         exit 1
+ *   INDETERMINATE  the evidence cannot establish the state at all       exit 2
+ *
+ * `INDETERMINATE` is not a softer `ACTIONABLE`. An unreadable GitHub API, a job that executed no
+ * steps, an unreadable policy — none of these are evidence that anything is wrong with the
+ * repository, and reporting them as though the repository were proven defective is its own false
+ * claim. It still deserves attention, which is why it exits non-zero; it simply does not assert what
+ * it has not measured. The same distinction `standards validate` already draws between
+ * `NON_COMPLIANT` and `NOT_EVALUATED`.
+ *
+ * ## Scope
+ *
+ * A reader and a classifier. It consumes GitHub evidence and `project-policy.yml`, classifies, and
+ * exits. It does not modify the policy, re-run checks, form a compliance opinion of its own, or
+ * suppress the red jobs it interprets. It is not a gate and must not become one.
+ *
+ * ## Structure
+ *
+ *   GitHub + policy  ->  extractEvidence()  ->  observation  ->  classify()  ->  verdict
+ *
+ * `classify` is pure: an observation in, a verdict out, no I/O. That is what lets every semantic
+ * branch be tested from a small structured fixture rather than a fabricated ten-thousand-line runner
+ * log — and it is why a use/mention defect cannot hide inside a fixture nobody reads. Log parsing is
+ * separated into `parseValidatorLog` and tested against a few tiny raw specimens.
+ *
+ * The established rejection set is **derived from the policy**, never listed here. A second copy of
+ * that list would be a second source of truth whose first act is to drift, still calling a cleared
+ * rejection "expected".
+ *
+ * Usage:
+ *   node scripts/ci-triage.mjs <pr-number> [--json]
+ */
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseYaml } from "./yaml.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export const EXPECTED = "EXPECTED";
+export const ACTIONABLE = "ACTIONABLE";
+export const INDETERMINATE = "INDETERMINATE";
+
+/** Exit codes, matching the epistemic split rather than a pass/fail binary. */
+export const EXIT = { [EXPECTED]: 0, [ACTIONABLE]: 1, [INDETERMINATE]: 2 };
+
+/** The two jobs that run the evaluator, and the placement each represents. */
+export const VALIDATION_ARMS = {
+  "validate": "inside — the evaluator run from within the repository",
+  "validate-self / validate": "outside — the framework installed, this repository as its subject",
+};
+
+// ---------------------------------------------------------------------------------------------
+// Log parsing — separated so it can be tested against tiny raw specimens
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * A runner log reduced to what the job actually emitted.
+ *
+ * Two transformations, both load-bearing.
+ *
+ * Every line carries a leading ISO timestamp, so a pattern anchored at the start of a line matches
+ * nothing without stripping it. The first version of this file anchored on `^\s*Status:` and found no
+ * verdict at all — then reported that four expected rejections had disappeared.
+ *
+ * More importantly, a runner log contains *the script it is about to run* as well as that script's
+ * output, rendered inside a colour escape. This repository's workflow contains the literal text
+ * `echo "::error::NO VERDICT (exit 2)"` inside a `case` branch, so a naive search for that phrase
+ * matches the source of a branch that never executed. The first version did exactly that and reported
+ * exit 2 for a job that had produced a verdict — the use-versus-mention defect this repository has
+ * now shipped seven times, committed inside the tool written to classify its own CI honestly.
+ * Emitted annotations appear as `##[error]…`; an echoed command cannot produce one.
+ */
+export function logLines(raw) {
+  return String(raw)
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\S+Z\s/, ""))
+    .filter((line) => !/\[36;1m/.test(line));
+}
+
+/**
+ * What a validator job said, as a structured observation.
+ *
+ * `validatorExit` is 2 when the job emitted the no-verdict annotation, 1 when it emitted a red
+ * verdict, and null when neither was emitted — never inferred from prose.
+ */
+export function parseValidatorLog(raw) {
+  const lines = logLines(raw);
+  const annotations = lines.filter((l) => l.startsWith("##[error]")).map((l) => l.slice("##[error]".length));
+
+  let status = null;
+  const reportedRules = [];
+  for (const line of lines) {
+    const s = /^\s*Status:\s*(\S+)\s*$/.exec(line);
+    if (s) status = s[1];
+    const f = /^\s+([a-z][\w.-]*\.[\w.-]+)\s+\[(forbidden|required|recommended)\]/.exec(line);
+    if (f) reportedRules.push(f[1]);
+  }
+
+  const noVerdict = annotations.some((a) => /^NO VERDICT/.test(a));
+  const redVerdict = annotations.some((a) => /^NON-COMPLIANT/.test(a));
+
+  return {
+    status,
+    reportedRules: [...new Set(reportedRules)].sort(),
+    annotations,
+    validatorExit: noVerdict ? 2 : redVerdict ? 1 : null,
+  };
+}
+
+/**
+ * The rules a policy currently records as reviewed and rejected.
+ *
+ * Each rule's live review is the one no other review supersedes, so a rejection later re-reviewed and
+ * approved is absent without anyone maintaining a list. Returns null when the policy cannot be read
+ * or has no attestations — an unreadable policy establishes nothing, and must not read as "no
+ * rejections are expected".
+ */
+export function establishedRejectionsFrom(policy) {
+  const attestations = policy?.attestations;
+  if (!attestations || typeof attestations !== "object" || Array.isArray(attestations)) return null;
+
+  const rejected = [];
+  for (const [rule, node] of Object.entries(attestations)) {
+    const reviews = Array.isArray(node?.reviews) ? node.reviews : [];
+    const superseded = new Set(reviews.map((r) => r?.supersedes).filter(Boolean));
+    const live = reviews.filter((r) => !superseded.has(r?.id));
+    if (live.some((r) => r?.status === "rejected")) rejected.push(rule);
+  }
+  return rejected.sort();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Classification — pure
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Classify an observation.
+ *
+ * Pure. Everything it needs is in the observation:
+ *
+ *   {
+ *     establishedRejections: string[] | null,   // null when the policy could not be read
+ *     jobs: [{
+ *       name, conclusion, stepsExecuted, required,   // required: boolean | null (null = unreadable)
+ *       logRead, status, reportedRules, validatorExit, annotations
+ *     }]
+ *   }
+ *
+ * `ACTIONABLE` outranks `INDETERMINATE`, which outranks `EXPECTED`: a run that both proved something
+ * wrong and failed to establish something else is a run that needs a human for the first reason.
+ */
+export function classify(observation) {
+  const established = observation?.establishedRejections ?? null;
+  const jobs = Array.isArray(observation?.jobs) ? observation.jobs : [];
+  const findings = [];
+  const arms = [];
+
+  for (const job of jobs) {
+    const name = job?.name ?? "(unnamed)";
+    const isArm = name in VALIDATION_ARMS;
+
+    // 1. Did it execute? A job that concluded without running a step is infrastructure, not code.
+    //    Calling it a failure sends someone hunting a defect in something that never ran; calling it
+    //    a pass is worse.
+    if (job?.stepsExecuted === 0) {
+      findings.push({
+        check: name, class: INDETERMINATE,
+        why: "the job concluded without executing any step — infrastructure blocked, neither a pass nor a failing code path",
+      });
+      if (isArm) arms.push({ name, usable: false });
+      continue;
+    }
+    if (typeof job?.stepsExecuted !== "number") {
+      findings.push({
+        check: name, class: INDETERMINATE,
+        why: "whether the job executed could not be read, so its conclusion cannot be interpreted",
+      });
+      if (isArm) arms.push({ name, usable: false });
+      continue;
+    }
+
+    if (job.conclusion === "success") {
+      findings.push({ check: name, class: EXPECTED, why: "passed" });
+      if (isArm) arms.push({ name, usable: true, status: "COMPLIANT", reportedRules: [] });
+      continue;
+    }
+
+    // 2. A non-validation job that ran real steps and did not succeed is an established unexpected
+    //    state whether or not it is required. Required-ness changes how loud it is, not whether it
+    //    happened, so an unreadable protection setting is reported without downgrading the finding.
+    if (!isArm) {
+      const note = job.required === null || job.required === undefined
+        ? " (whether it is required could not be read from branch protection)"
+        : job.required ? " (required)" : " (not required)";
+      findings.push({
+        check: name, class: ACTIONABLE,
+        why: `concluded ${job.conclusion} after executing ${job.stepsExecuted} step(s)${note}`,
+      });
+      continue;
+    }
+
+    // 3. A validation arm.
+    if (!job.logRead) {
+      findings.push({ check: name, class: INDETERMINATE, why: "the job log could not be read, so its red is uninterpreted" });
+      arms.push({ name, usable: false });
+      continue;
+    }
+    if (job.validatorExit === 2) {
+      findings.push({
+        check: name, class: ACTIONABLE,
+        why: "exit 2 — the validator produced no verdict. The policy could not be read, or the declared standards version is not the one executing",
+      });
+      arms.push({ name, usable: false });
+      continue;
+    }
+    if (established === null) {
+      findings.push({
+        check: name, class: INDETERMINATE,
+        why: "project-policy.yml could not be read, so no rejection set is established to compare against",
+      });
+      arms.push({ name, usable: true, status: job.status, reportedRules: job.reportedRules ?? [] });
+      continue;
+    }
+
+    const reported = job.reportedRules ?? [];
+    const added = reported.filter((r) => !established.includes(r));
+    const removed = established.filter((r) => !reported.includes(r));
+    arms.push({ name, usable: true, status: job.status, reportedRules: reported });
+
+    if (added.length || removed.length) {
+      const parts = [];
+      if (added.length) parts.push(`newly failing: ${added.join(", ")}`);
+      if (removed.length) parts.push(`established rejection(s) no longer reported: ${removed.join(", ")}`);
+      findings.push({ check: name, class: ACTIONABLE, why: `the rejection set changed — ${parts.join("; ")}` });
+      continue;
+    }
+
+    findings.push({
+      check: name, class: EXPECTED,
+      why: `${job.status} over the established rejection set (${reported.length}) — ${VALIDATION_ARMS[name]}`,
+    });
+  }
+
+  // 4. Do the placements agree? Disagreement means where the evaluator ran changed its verdict, which
+  //    is the one result neither arm can report on its own.
+  const present = Object.keys(VALIDATION_ARMS).filter((n) => arms.some((a) => a.name === n));
+  const usable = arms.filter((a) => a.usable);
+  if (present.length < 2) {
+    findings.push({
+      check: "inside vs outside", class: INDETERMINATE,
+      why: `only ${present.length} of 2 validation arms reported, so placement equivalence was not established this run`,
+    });
+  } else if (usable.length < 2) {
+    findings.push({
+      check: "inside vs outside", class: INDETERMINATE,
+      why: "an arm produced nothing comparable, so placement equivalence was not established this run",
+    });
+  } else {
+    const [a, b] = usable;
+    const same = a.status === b.status && a.reportedRules.join() === b.reportedRules.join();
+    if (!same) {
+      findings.push({
+        check: "inside vs outside", class: ACTIONABLE,
+        why: `the two evaluator placements disagree — ${a.name}: ${a.status} [${a.reportedRules.join(" ")}] vs ${b.name}: ${b.status} [${b.reportedRules.join(" ")}]`,
+      });
+    }
+  }
+
+  const verdict = findings.some((f) => f.class === ACTIONABLE)
+    ? ACTIONABLE
+    : findings.some((f) => f.class === INDETERMINATE)
+      ? INDETERMINATE
+      : EXPECTED;
+
+  return { verdict, findings };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Evidence extraction — impure
+// ---------------------------------------------------------------------------------------------
+
+function gh(args, { json = false } = {}) {
+  const r = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (r.error || r.status !== 0) return { ok: false, out: `${r.stderr ?? r.error?.message ?? ""}`.trim() };
+  let data;
+  if (json) {
+    try {
+      data = JSON.parse(r.stdout);
+    } catch {
+      return { ok: false, out: "the response was not valid JSON" };
+    }
+  }
+  return { ok: true, out: r.stdout, data };
+}
+
+/** The job id embedded in a check run's details URL, or null when it is not a job URL. */
+export function jobIdFrom(detailsUrl) {
+  const m = /\/job\/(\d+)/.exec(detailsUrl ?? "");
+  return m ? m[1] : null;
+}
+
+/**
+ * Which checks the base branch requires.
+ *
+ * Only GitHub knows, and it may be unreadable — no branch protection, or no permission. Reported as
+ * null rather than as an empty set: assuming nothing is required would silently downgrade a real
+ * gating failure.
+ */
+function requiredChecks(repo, base) {
+  const r = gh(["api", `repos/${repo}/branches/${base}/protection/required_status_checks`], { json: true });
+  if (!r.ok) return null;
+  const contexts = r.data?.contexts ?? r.data?.checks?.map((c) => c.context) ?? [];
+  return contexts;
+}
+
+/** Build the observation `classify` consumes. All I/O lives here. */
+export function extractEvidence(prNumber) {
+  const view = gh(["pr", "view", String(prNumber), "--json", "statusCheckRollup,baseRefName,headRefOid,number,url"], { json: true });
+  if (!view.ok) return { error: `could not read pull request ${prNumber}: ${view.out}` };
+
+  const repoView = gh(["repo", "view", "--json", "nameWithOwner"], { json: true });
+  if (!repoView.ok) return { error: "could not determine the repository" };
+  const repo = repoView.data.nameWithOwner;
+
+  let policy = null;
+  try {
+    policy = parseYaml(readFileSync(path.join(ROOT, "project-policy.yml"), "utf8"));
+  } catch {
+    // Left null on purpose: an unreadable policy establishes no rejection set, and the classifier
+    // reports that as INDETERMINATE rather than guessing one.
+    policy = null;
+  }
+
+  const required = requiredChecks(repo, view.data.baseRefName);
+  const jobs = [];
+
+  for (const check of view.data.statusCheckRollup ?? []) {
+    const name = check.name;
+    const jobId = jobIdFrom(check.detailsUrl);
+    const conclusion = String(check.conclusion ?? "").toLowerCase();
+
+    let stepsExecuted;
+    if (jobId) {
+      const jobApi = gh(["api", `repos/${repo}/actions/jobs/${jobId}`], { json: true });
+      if (jobApi.ok && Array.isArray(jobApi.data?.steps)) {
+        stepsExecuted = jobApi.data.steps.filter((s) => s?.conclusion && s.conclusion !== "skipped").length;
+      }
+    }
+
+    const job = {
+      name,
+      conclusion,
+      stepsExecuted,
+      required: required === null ? null : required.includes(name),
+      logRead: false,
+      status: null,
+      reportedRules: [],
+      validatorExit: null,
+      annotations: [],
+    };
+
+    if (name in VALIDATION_ARMS && conclusion !== "success" && jobId) {
+      const logs = gh(["api", `repos/${repo}/actions/jobs/${jobId}/logs`]);
+      if (logs.ok) Object.assign(job, { logRead: true }, parseValidatorLog(logs.out));
+    } else if (name in VALIDATION_ARMS && conclusion === "success") {
+      job.logRead = true;
+    }
+
+    jobs.push(job);
+  }
+
+  return {
+    pr: view.data.number,
+    url: view.data.url,
+    head: view.data.headRefOid,
+    base: view.data.baseRefName,
+    repo,
+    requiredChecks: required,
+    establishedRejections: establishedRejectionsFrom(policy),
+    jobs,
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------------------------
+
+function render(observation, result) {
+  const out = [];
+  out.push(`PR #${observation.pr} — ${String(observation.head ?? "").slice(0, 7)}`);
+  out.push(`required checks        : ${observation.requiredChecks === null ? "unreadable" : observation.requiredChecks.join(", ") || "none"}`);
+  out.push(`established rejections : ${observation.establishedRejections === null ? "unreadable" : observation.establishedRejections.join(", ") || "none"}`);
+  out.push("");
+  for (const f of result.findings) {
+    out.push(`  ${f.class.padEnd(14)}${f.check}`);
+    out.push(`                ${f.why}`);
+  }
+  out.push("");
+  out.push(result.verdict);
+  if (result.verdict === EXPECTED) {
+    out.push("Both evaluator placements executed, agreed, and named exactly the rejections the policy records.");
+  } else if (result.verdict === INDETERMINATE) {
+    out.push("Nothing here says the repository is wrong. It says the evidence could not establish what happened.");
+  }
+  return out.join("\n") + "\n";
+}
+
+export function main(argv) {
+  const json = argv.includes("--json");
+  const pr = argv.find((a) => /^\d+$/.test(a));
+  if (!pr) {
+    process.stderr.write("usage: node scripts/ci-triage.mjs <pr-number> [--json]\n");
+    return EXIT[INDETERMINATE];
+  }
+
+  const observation = extractEvidence(pr);
+  if (observation.error) {
+    process.stderr.write(`${observation.error}\n`);
+    return EXIT[INDETERMINATE];
+  }
+
+  const result = classify(observation);
+  process.stdout.write(json ? JSON.stringify({ ...observation, ...result }, null, 2) + "\n" : render(observation, result));
+  return EXIT[result.verdict];
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/test/ci-triage.test.mjs
+++ b/test/ci-triage.test.mjs
@@ -1,0 +1,267 @@
+/**
+ * What a red check means, and the three answers that are not the same answer.
+ *
+ * `scripts/ci-triage.mjs` exists because this repository deliberately keeps two jobs permanently red,
+ * and a reader that treats every `conclusion: failure` alike would either alarm on correct governance
+ * evidence or, worse, learn to ignore it. The distinction it draws:
+ *
+ *   EXPECTED       the evidence establishes the expected state          exit 0
+ *   ACTIONABLE     the evidence establishes an unexpected state         exit 1
+ *   INDETERMINATE  the evidence cannot establish the state              exit 2
+ *
+ * Two kinds of test live here, and the split is the point.
+ *
+ * **The classifier is tested from structured observations.** `classify` is pure, so every terminal
+ * branch is reachable from a small fixture describing what was observed — `stepsExecuted`,
+ * `conclusion`, `reportedRules`, `validatorExit` — rather than from a fabricated runner log. A
+ * ten-thousand-line log fixture would bake in timestamps and runner formatting, and would be exactly
+ * the place a use/mention defect could hide unread.
+ *
+ * **Log parsing is tested separately, against tiny raw specimens.** That is where the runner's actual
+ * shape matters, and where the defect this tool already committed once has to stay dead: a workflow
+ * log contains the script it is about to run as well as that script's output, and this repository's
+ * workflow contains the literal text `echo "::error::NO VERDICT (exit 2)"` in a branch that normally
+ * never executes.
+ *
+ * The tool is a reader, not a gate. Nothing here asserts that it blocks anything.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  classify,
+  parseValidatorLog,
+  logLines,
+  establishedRejectionsFrom,
+  jobIdFrom,
+  EXPECTED,
+  ACTIONABLE,
+  INDETERMINATE,
+  EXIT,
+} from "../scripts/ci-triage.mjs";
+import { parseYaml } from "../scripts/yaml.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const FIXTURES = path.join(ROOT, "test", "fixtures", "ci-triage");
+
+const fixture = (name) => JSON.parse(readFileSync(path.join(FIXTURES, name), "utf8"));
+
+// -------------------------------------------------------------------------------------------
+// Every terminal branch, from a structured observation
+// -------------------------------------------------------------------------------------------
+
+test("every fixture classifies as the state it describes", () => {
+  const files = readdirSync(FIXTURES).filter((f) => f.endsWith(".json")).sort();
+  assert.ok(files.length >= 12, `only ${files.length} fixtures — the branch coverage was reduced`);
+
+  for (const file of files) {
+    const f = fixture(file);
+    const { verdict } = classify(f);
+    assert.equal(verdict, f.expect, `${file}: ${f.note}`);
+  }
+});
+
+test("an established red beside a green required job is expected, and exits 0", () => {
+  const result = classify(fixture("established-red.json"));
+  assert.equal(result.verdict, EXPECTED);
+  assert.equal(EXIT[result.verdict], 0);
+  // Both arms are named as expected, individually — not merely absent from the complaints.
+  const armFindings = result.findings.filter((r) => r.check.startsWith("validate"));
+  assert.equal(armFindings.length, 2, "one of the two placements was not classified");
+  assert.ok(armFindings.every((r) => r.class === EXPECTED), "an arm was not reported as expected");
+});
+
+test("a job that executed no step is infrastructure, never a failing code path", () => {
+  const result = classify(fixture("zero-execution.json"));
+  assert.equal(result.verdict, INDETERMINATE);
+  assert.equal(EXIT[result.verdict], 2);
+  const finding = result.findings.find((r) => r.check === "test");
+  assert.equal(finding.class, INDETERMINATE, "a zero-step job was reported as a failure");
+  assert.match(finding.why, /without executing any step/);
+  assert.doesNotMatch(finding.why, /\bfailed\b/, "the wording still blames the code");
+});
+
+test("a real exit 2 is actionable and says the verdict was never produced", () => {
+  const result = classify(fixture("real-exit-2.json"));
+  assert.equal(result.verdict, ACTIONABLE);
+  const finding = result.findings.find((r) => r.check === "validate");
+  assert.equal(finding.class, ACTIONABLE);
+  assert.match(finding.why, /exit 2/);
+  assert.match(finding.why, /no verdict/i);
+});
+
+test("the two placements disagreeing is actionable, and the finding names both", () => {
+  const result = classify(fixture("arms-disagree.json"));
+  assert.equal(result.verdict, ACTIONABLE);
+  const finding = result.findings.find((r) => r.check === "inside vs outside");
+  assert.equal(finding.class, ACTIONABLE);
+  assert.match(finding.why, /disagree/);
+  assert.match(finding.why, /validate/);
+  assert.match(finding.why, /validate-self/);
+});
+
+test("a rejection set that grew and one that shrank are both actionable, and distinguishable", () => {
+  const grew = classify(fixture("rejection-set-grew.json"));
+  assert.equal(grew.verdict, ACTIONABLE);
+  const grewWhy = grew.findings.find((r) => r.check === "validate").why;
+  assert.match(grewWhy, /newly failing: data\.no-silent-discard/);
+  assert.doesNotMatch(grewWhy, /no longer reported/, "an addition was described as a removal");
+
+  const shrank = classify(fixture("rejection-set-shrank.json"));
+  assert.equal(shrank.verdict, ACTIONABLE);
+  const shrankWhy = shrank.findings.find((r) => r.check === "validate").why;
+  assert.match(shrankWhy, /no longer reported: errors\.no-false-success/);
+  assert.doesNotMatch(shrankWhy, /newly failing/, "a removal was described as an addition");
+});
+
+test("the required job failing is actionable even while both advisory arms are correctly red", () => {
+  const result = classify(fixture("required-test-fails.json"));
+  assert.equal(result.verdict, ACTIONABLE);
+  assert.equal(result.findings.find((r) => r.check === "test").class, ACTIONABLE);
+  // The advisory arms are still reported as expected — the gating failure does not recolour them.
+  for (const name of ["validate", "validate-self / validate"]) {
+    assert.equal(result.findings.find((r) => r.check === name).class, EXPECTED, `${name} was recoloured`);
+  }
+});
+
+test("unavailable evidence is never expected, and never reported as the repository being wrong", () => {
+  // The load-bearing default. Each of these could collapse to EXPECTED through an `?? []` or a
+  // truthiness check, and each would then hide the thing it was built to surface.
+  for (const file of ["unreadable-policy.json", "unreadable-logs.json", "unreadable-execution.json", "missing-arm.json"]) {
+    const result = classify(fixture(file));
+    assert.equal(result.verdict, INDETERMINATE, `${file}: ${fixture(file).note}`);
+    assert.notEqual(result.verdict, EXPECTED);
+    assert.ok(
+      result.findings.some((r) => r.class === INDETERMINATE),
+      `${file} produced no indeterminate finding to explain itself`,
+    );
+  }
+});
+
+test("actionable outranks indeterminate", () => {
+  // A run that proved something wrong and failed to establish something else needs a human for the
+  // first reason. Reporting it as merely indeterminate would understate a known failure.
+  const result = classify(fixture("actionable-outranks-indeterminate.json"));
+  assert.equal(result.verdict, ACTIONABLE);
+  assert.ok(result.findings.some((r) => r.class === INDETERMINATE), "the indeterminate finding was dropped rather than outranked");
+});
+
+test("an empty observation establishes nothing rather than passing", () => {
+  assert.equal(classify({}).verdict, INDETERMINATE);
+  assert.equal(classify({ jobs: [], establishedRejections: [] }).verdict, INDETERMINATE);
+});
+
+// -------------------------------------------------------------------------------------------
+// Log parsing, against tiny raw specimens
+// -------------------------------------------------------------------------------------------
+
+const TS = "2026-08-16T17:42:13.9456194Z ";
+
+test("the echoed script is not mistaken for the output of the script", () => {
+  // The defect this tool committed on its first run. The workflow's own source contains the no-verdict
+  // branch; the runner renders the command it is about to run inside a colour escape, and that is the
+  // only thing distinguishing the branch's text from its execution.
+  const log = [
+    `${TS}[36;1m  2) echo "::error::NO VERDICT (exit 2) — the policy could not be read." ; exit 2 ;;[0m`,
+    `${TS}  Status: NON_COMPLIANT`,
+    `${TS}    errors.no-false-success [forbidden] reviewed by project-owner and found unmet.`,
+    `${TS}##[error]NON-COMPLIANT (exit 1) — a required or forbidden rule failed.`,
+  ].join("\n");
+
+  const parsed = parseValidatorLog(log);
+  assert.equal(parsed.validatorExit, 1, "the mentioned exit-2 branch was read as though it had run");
+  assert.equal(parsed.status, "NON_COMPLIANT");
+  assert.deepEqual(parsed.reportedRules, ["errors.no-false-success"]);
+});
+
+test("an emitted no-verdict annotation is read as exit 2", () => {
+  const log = [
+    `${TS}[36;1m  1) echo "::error::NON-COMPLIANT (exit 1)" ;;[0m`,
+    `${TS}##[error]NO VERDICT (exit 2) — the declared standards version is not the one executing.`,
+  ].join("\n");
+
+  const parsed = parseValidatorLog(log);
+  assert.equal(parsed.validatorExit, 2);
+  assert.equal(parsed.status, null, "a status was invented where none was printed");
+});
+
+test("the leading runner timestamp does not defeat the line anchors", () => {
+  // The second defect: every anchored pattern matched nothing, and the tool reported that four
+  // expected rejections had vanished.
+  const withStamp = parseValidatorLog(`${TS}  Status: NON_COMPLIANT`);
+  assert.equal(withStamp.status, "NON_COMPLIANT");
+  assert.deepEqual(logLines(`${TS}hello`), ["hello"]);
+});
+
+test("a log with neither annotation reports no exit class rather than guessing one", () => {
+  const parsed = parseValidatorLog(`${TS}  Status: COMPLIANT`);
+  assert.equal(parsed.validatorExit, null);
+  assert.equal(parsed.status, "COMPLIANT");
+  assert.deepEqual(parsed.reportedRules, []);
+});
+
+// -------------------------------------------------------------------------------------------
+// Policy derivation — the authority for what "expected" means
+// -------------------------------------------------------------------------------------------
+
+test("the rejection set is derived from live reviews, and a superseded rejection does not count", () => {
+  const policy = {
+    attestations: {
+      "a.rule": { reviews: [{ id: "r1", status: "rejected" }] },
+      "b.rule": { reviews: [{ id: "r1", status: "rejected" }, { id: "r2", supersedes: "r1", status: "approved" }] },
+      "c.rule": { reviews: [{ id: "r1", status: "approved" }, { id: "r2", supersedes: "r1", status: "rejected" }] },
+    },
+  };
+  assert.deepEqual(establishedRejectionsFrom(policy), ["a.rule", "c.rule"]);
+});
+
+test("an unreadable policy establishes nothing rather than an empty rejection set", () => {
+  // The difference between "no rejections are expected" and "we could not tell" is the whole point.
+  assert.equal(establishedRejectionsFrom(null), null);
+  assert.equal(establishedRejectionsFrom({}), null);
+  assert.equal(establishedRejectionsFrom({ attestations: [] }), null);
+  assert.deepEqual(establishedRejectionsFrom({ attestations: {} }), []);
+});
+
+test("this repository's own policy still yields a non-empty rejection set", () => {
+  // If this ever returns empty, either the four rejections were cleared — an owner decision, not a
+  // silent one — or the derivation broke. Both need a human, and neither should be discovered by a
+  // classifier quietly reporting EXPECTED.
+  const policy = parseYaml(readFileSync(path.join(ROOT, "project-policy.yml"), "utf8"));
+  const rejected = establishedRejectionsFrom(policy);
+  assert.ok(Array.isArray(rejected) && rejected.length > 0, "the repository's own rejections could not be derived");
+});
+
+test("no list of rejection ids is hardcoded in the tool", () => {
+  // The derivation is the design. A copied list would still call a cleared rejection "expected".
+  const source = readFileSync(path.join(ROOT, "scripts", "ci-triage.mjs"), "utf8");
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  for (const rule of ["ai.no-fabricated-capabilities", "ai.no-safety-bypass", "errors.no-false-success", "scm.no-shared-history-rewrite"]) {
+    assert.doesNotMatch(code, new RegExp(rule.replace(/\./g, "\\.")), `${rule} is hardcoded in the classifier`);
+  }
+});
+
+test("the tool reads and classifies, and does not act", () => {
+  // Scope, asserted rather than intended. It must not gain the ability to change the policy, re-run
+  // checks, or suppress the jobs it interprets.
+  const source = readFileSync(path.join(ROOT, "scripts", "ci-triage.mjs"), "utf8");
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  assert.doesNotMatch(code, /writeFileSync|rmSync|unlinkSync|appendFileSync/, "the classifier writes to disk");
+  assert.doesNotMatch(code, /"(rerun|cancel)"|pr\s+(merge|close|edit)/, "the classifier acts on the pull request");
+  assert.doesNotMatch(code, /\bgh\(\[\s*"api"[^\]]*-X\s*(POST|PATCH|PUT|DELETE)/, "the classifier issues a mutating API call");
+});
+
+test("the exit codes match the epistemic split", () => {
+  assert.equal(EXIT[EXPECTED], 0);
+  assert.equal(EXIT[ACTIONABLE], 1);
+  assert.equal(EXIT[INDETERMINATE], 2);
+});
+
+test("a job id is read from a details URL, and absence is not an id", () => {
+  assert.equal(jobIdFrom("https://github.com/o/r/actions/runs/123/job/456"), "456");
+  assert.equal(jobIdFrom("https://github.com/o/r/actions/runs/123"), null);
+  assert.equal(jobIdFrom(undefined), null);
+});

--- a/test/fixtures/ci-triage/actionable-outranks-indeterminate.json
+++ b/test/fixtures/ci-triage/actionable-outranks-indeterminate.json
@@ -1,0 +1,52 @@
+{
+  "note": "A run that proved something wrong and failed to establish something else needs a human for the first reason.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": null,
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "failure",
+      "stepsExecuted": 7,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/arms-disagree.json
+++ b/test/fixtures/ci-triage/arms-disagree.json
@@ -1,0 +1,54 @@
+{
+  "note": "Inside reports the established set; outside reports a different one. Placement changed a verdict.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-safety-bypass"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/established-red.json
+++ b/test/fixtures/ci-triage/established-red.json
@@ -1,0 +1,56 @@
+{
+  "note": "Both arms execute, agree, and name exactly the policy's live rejections.",
+  "expect": "EXPECTED",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/missing-arm.json
+++ b/test/fixtures/ci-triage/missing-arm.json
@@ -1,0 +1,39 @@
+{
+  "note": "One placement did not report, so equivalence was not established this run.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/real-exit-2.json
+++ b/test/fixtures/ci-triage/real-exit-2.json
@@ -1,0 +1,52 @@
+{
+  "note": "The validator emitted the no-verdict annotation. Not source text mentioning exit 2.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": 2,
+      "annotations": [
+        "NO VERDICT (exit 2) \u2014 the policy could not be read."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/rejection-set-grew.json
+++ b/test/fixtures/ci-triage/rejection-set-grew.json
@@ -1,0 +1,58 @@
+{
+  "note": "Runtime reports a rule the policy does not record as rejected.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "data.no-silent-discard",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "data.no-silent-discard",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/rejection-set-shrank.json
+++ b/test/fixtures/ci-triage/rejection-set-shrank.json
@@ -1,0 +1,54 @@
+{
+  "note": "An established rejection is no longer reported. Silently green is the danger.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/required-test-fails.json
+++ b/test/fixtures/ci-triage/required-test-fails.json
@@ -1,0 +1,56 @@
+{
+  "note": "The gating job failed. Actionable regardless of the advisory arms being expected-red.",
+  "expect": "ACTIONABLE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "failure",
+      "stepsExecuted": 7,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/unreadable-execution.json
+++ b/test/fixtures/ci-triage/unreadable-execution.json
@@ -1,0 +1,56 @@
+{
+  "note": "Whether the job ran could not be read, so its conclusion cannot be interpreted.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "failure",
+      "stepsExecuted": null,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/unreadable-logs.json
+++ b/test/fixtures/ci-triage/unreadable-logs.json
@@ -1,0 +1,50 @@
+{
+  "note": "A red arm whose log could not be read is uninterpreted, not proven wrong.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/unreadable-policy.json
+++ b/test/fixtures/ci-triage/unreadable-policy.json
@@ -1,0 +1,52 @@
+{
+  "note": "No rejection set is established, so nothing can be compared. Never EXPECTED.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": null,
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 9,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/zero-execution.json
+++ b/test/fixtures/ci-triage/zero-execution.json
@@ -1,0 +1,56 @@
+{
+  "note": "A job concluded without running a step. Infrastructure, not a failing code path.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "failure",
+      "stepsExecuted": 0,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 12,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) \u2014 a required or forbidden rule failed."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Commits

- A red check means four different things, and counting them means none

---

## Local CI

This pipeline ran in an ephemeral Docker container on the author's machine.
It is **not** a GitHub-hosted Actions run and makes no claim about one.

- Verified commit: `4d7088ffac70073845e3a276d339e08d1cde2e9c`
- Branch: `feat/ci-triage-classification`
- Result: **PASS**
- Environment: Docker (`engineeringstandards-ci:engineeringstandards-ci-1786903805975-71796`, Node v20.20.2)
- Completed: 2026-08-16T18:10:18.117Z

<details><summary>Stages executed</summary>

- `inventory` — passed (exit 0)
- `fidelity` — passed (exit 0)
- `policy` — passed (exit 0)
- `diagrams` — passed (exit 0)
- `test` — passed (exit 0)
- `audit` — passed (exit 0)
- `validate` — advisory-failed (exit 1) _[advisory, non-gating]_

</details>

