### PR TITLE
A verdict about the wrong commit is still a true verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,19 @@ subject, the identity-versus-content substitution the submission gate already re
   branch, a branch by its own protection, and a bare commit by nothing that can be named — a commit
   may sit on any number of branches, so the question is reported as *unasked* rather than as an
   unreadable answer. A failing job is still actionable either way; only the wording changes.
+- **The commit's check runs are read completely, not one page of them.** Found in review of the
+  above, before it merged. The endpoint pages at 30 by default, so a commit with more checks than
+  that could carry a failed job on page two that never entered the evidence at all — and `--sha` and
+  `--branch` would return `EXPECTED` over a surface never seen. A false assurance produced silently
+  by the tool written to prevent it. The walk now continues while pages come back full; a page that
+  cannot be read is an error rather than a partial set, and non-terminating pagination is an error
+  rather than a loop.
+- **Duplicate check runs cannot manufacture agreement.** Walking a moving list can return the same
+  run twice, which now collapses by id. Two *different* runs under one name is contradictory rather
+  than redundant, and is reported unestablished instead of resolved by picking one. The cross-arm
+  comparison also selects by name rather than taking the first two usable entries, so two copies of
+  `validate` can never be compared against each other and report placement equivalence established
+  while the other placement never ran.
 - **An arm's outcome has two independent sources, and neither is required.** Only one workflow emits
   the `::error::` annotation, so a missing exit class is normal, not a failure to observe. When the
   printed verdict is *also* unreadable, the arm is now `INDETERMINATE`: previously the empty rule set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,26 @@ false claim. The same split `validate` already draws between `NON_COMPLIANT` and
 - A reader, not a gate. It does not modify the policy, re-run checks, form its own compliance
   opinion, or suppress the jobs it interprets, and tests assert each of those.
 
+**A verdict now names the commit it is about, and can be pointed at one.** The classifier addressed
+its evidence only by pull request, and a pull request's checks describe its own head — which GitHub
+does not update when a rebase merge rewrites the commit onto the base branch. Run against #29 after
+that merge, it read `4d7088f` and its check runs while `develop` carried `69de0c8` and its own, and
+returned `EXPECTED` about a commit that was no longer anywhere: a true verdict about the wrong
+subject, the identity-versus-content substitution the submission gate already refuses.
+
+- `--sha <commit>` and `--branch <name>` read check runs for a commit directly. Two targets is an
+  error rather than a precedence rule — a reader asked about both has been asked two questions, and
+  answering whichever is checked first is how the verdict lands on the wrong subject again.
+- **Required-ness is answered per mode rather than defaulted.** A pull request is gated by its base
+  branch, a branch by its own protection, and a bare commit by nothing that can be named — a commit
+  may sit on any number of branches, so the question is reported as *unasked* rather than as an
+  unreadable answer. A failing job is still actionable either way; only the wording changes.
+- **An arm's outcome has two independent sources, and neither is required.** Only one workflow emits
+  the `::error::` annotation, so a missing exit class is normal, not a failure to observe. When the
+  printed verdict is *also* unreadable, the arm is now `INDETERMINATE`: previously the empty rule set
+  compared against the policy's four rejections and reported them as cleared — a claim about the
+  project derived from a defect in reading it.
+
 ## 2.0.0 — 2026-08-09
 
 **`MAJOR`.** The must-never layer: nine new standards, 26 new rules, and a change to what the verdict

--- a/scripts/ci-triage.mjs
+++ b/scripts/ci-triage.mjs
@@ -200,9 +200,28 @@ export function classify(observation) {
   const findings = [];
   const arms = [];
 
+  // Two check runs under one name is contradictory evidence about a single check, and a paginated
+  // snapshot does not say which is current. Picking one — the first seen, the newest-looking — would
+  // be a guess reported as an observation, so the name is reported unestablished instead.
+  const occurrences = new Map();
+  for (const job of jobs) occurrences.set(job?.name, (occurrences.get(job?.name) ?? 0) + 1);
+  const reportedDuplicate = new Set();
+
   for (const job of jobs) {
     const name = job?.name ?? "(unnamed)";
     const isArm = name in VALIDATION_ARMS;
+
+    if ((occurrences.get(job?.name) ?? 0) > 1) {
+      if (!reportedDuplicate.has(name)) {
+        reportedDuplicate.add(name);
+        findings.push({
+          check: name, class: INDETERMINATE,
+          why: `${occurrences.get(job?.name)} check runs report under this name, so which one describes the commit is unestablished`,
+        });
+      }
+      if (isArm) arms.push({ name, usable: false });
+      continue;
+    }
 
     // 1. Did it execute? A job that concluded without running a step is infrastructure, not code.
     //    Calling it a failure sends someone hunting a defect in something that never ran; calling it
@@ -304,8 +323,13 @@ export function classify(observation) {
 
   // 4. Do the placements agree? Disagreement means where the evaluator ran changed its verdict, which
   //    is the one result neither arm can report on its own.
-  const present = Object.keys(VALIDATION_ARMS).filter((n) => arms.some((a) => a.name === n));
-  const usable = arms.filter((a) => a.usable);
+  // Selected by name, never positionally. Two entries for one arm — a retried check run, a duplicate
+  // across page boundaries — would otherwise be compared against each other and agree, satisfying
+  // placement equivalence while the other placement never ran at all.
+  const byName = new Map();
+  for (const a of arms) if (!byName.has(a.name)) byName.set(a.name, a);
+  const present = Object.keys(VALIDATION_ARMS).filter((n) => byName.has(n));
+  const usable = present.map((n) => byName.get(n)).filter((a) => a.usable);
   if (present.length < 2) {
     findings.push({
       check: "inside vs outside", class: INDETERMINATE,
@@ -407,6 +431,65 @@ export function parseTarget(argv) {
   return targets[0];
 }
 
+export const CHECK_RUNS_PER_PAGE = 100;
+
+/**
+ * Combine paginated check-run responses into one set. Pure, so the page arithmetic is testable
+ * without GitHub.
+ *
+ * Deduplicated by check-run id, because a run created while the pages are being walked shifts the
+ * window and can show the same run twice. Two *different* runs sharing a name are left in place
+ * rather than reconciled here: which one is current is not something a paginated snapshot answers,
+ * and `classify` reports that as unestablished instead of picking.
+ */
+export function combineCheckRunPages(pages) {
+  const seen = new Map();
+  for (const page of pages) {
+    for (const run of page?.check_runs ?? []) {
+      if (run?.id === undefined || run?.id === null) continue;
+      if (!seen.has(run.id)) seen.set(run.id, run);
+    }
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Every check run on a commit, not the first page of them.
+ *
+ * The endpoint pages at 30 by default. Reading one page and classifying the result would let a
+ * failed job on page two be absent from the evidence entirely, and the verdict would be `EXPECTED`
+ * over a surface that was never seen — a false assurance produced by the tool built to prevent
+ * exactly that, and produced silently, which is worse than producing it loudly.
+ *
+ * A page that cannot be read, or pagination that does not terminate, is an error rather than a
+ * partial set. Classifying what happened to arrive is the same defect one layer down.
+ */
+export function collectCheckRunPages(fetchPage) {
+  const pages = [];
+  for (let page = 1; ; page += 1) {
+    if (page > 100) return { error: "check run pagination did not terminate after 100 pages" };
+    const r = fetchPage(page);
+    if (!r.ok) return { error: `page ${page} could not be read: ${r.out ?? ""}`.trim() };
+    pages.push(r.data);
+
+    const returned = (r.data?.check_runs ?? []).length;
+    if (returned < CHECK_RUNS_PER_PAGE) break;
+
+    // `total_count` is the server's own statement of the size of the set, so it ends the walk one
+    // request earlier than waiting for a short page. It is a stopping aid, never the authority on
+    // what was actually collected — that is the deduplicated set itself.
+    const total = Number(r.data?.total_count);
+    if (Number.isFinite(total) && combineCheckRunPages(pages).length >= total) break;
+  }
+  return { runs: combineCheckRunPages(pages) };
+}
+
+function allCheckRuns(repo, head) {
+  const result = collectCheckRunPages((page) =>
+    gh(["api", `repos/${repo}/commits/${head}/check-runs?per_page=${CHECK_RUNS_PER_PAGE}&page=${page}`], { json: true }));
+  return result.error ? { error: `could not read check runs for ${head}: ${result.error}` } : result;
+}
+
 /**
  * The commit whose checks are being read, the checks themselves, and which branch — if any — governs
  * required-ness.
@@ -447,8 +530,8 @@ function resolveSubject(target, repo) {
   const head = commit.data?.sha;
   if (!head) return { error: `${target.mode} ${target.value} resolved to no commit` };
 
-  const runs = gh(["api", `repos/${repo}/commits/${head}/check-runs`], { json: true });
-  if (!runs.ok) return { error: `could not read check runs for ${head}: ${runs.out}` };
+  const runs = allCheckRuns(repo, head);
+  if (runs.error) return runs;
 
   return {
     pr: null,
@@ -459,7 +542,7 @@ function resolveSubject(target, repo) {
     // For a GitHub Actions check run the check-run id is the job id, which is what `actions/jobs/<id>`
     // and its `/logs` want. `details_url` states the same id, so it is preferred where present and the
     // id is the fallback rather than the other way round.
-    checks: (runs.data?.check_runs ?? []).map((c) => ({
+    checks: runs.runs.map((c) => ({
       name: c.name,
       conclusion: c.conclusion,
       jobId: jobIdFrom(c.details_url) ?? (c.id === undefined || c.id === null ? null : String(c.id)),

--- a/scripts/ci-triage.mjs
+++ b/scripts/ci-triage.mjs
@@ -53,8 +53,23 @@
  * that list would be a second source of truth whose first act is to drift, still calling a cleared
  * rejection "expected".
  *
+ * ## Addressing
+ *
+ * Evidence is addressed three ways, and the difference matters after a rebase merge. A pull request's
+ * `statusCheckRollup` describes its own head, which GitHub does not update when it rewrites the commit
+ * onto the base branch: after #29 merged, `gh pr view 29` still reported `4d7088f` and that commit's
+ * check runs, while the merged `69de0c8` on `develop` carried its own. Classifying the pull request and
+ * calling the answer a statement about the merged branch is the identity-versus-content substitution
+ * this repository's submission gate already refuses — a true verdict about the wrong commit.
+ *
+ * So `--sha` and `--branch` read check runs for a commit directly. The observation always names the
+ * commit it describes, in every mode, because a verdict that does not name its subject cannot be
+ * checked against one.
+ *
  * Usage:
  *   node scripts/ci-triage.mjs <pr-number> [--json]
+ *   node scripts/ci-triage.mjs --sha <commit-sha> [--json]
+ *   node scripts/ci-triage.mjs --branch <branch-name> [--json]
  */
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -169,6 +184,7 @@ export function establishedRejectionsFrom(policy) {
  *
  *   {
  *     establishedRejections: string[] | null,   // null when the policy could not be read
+ *     requiredChecksNote: string,               // why required-ness is unknown, when it is
  *     jobs: [{
  *       name, conclusion, stepsExecuted, required,   // required: boolean | null (null = unreadable)
  *       logRead, status, reportedRules, validatorExit, annotations
@@ -218,8 +234,9 @@ export function classify(observation) {
     //    state whether or not it is required. Required-ness changes how loud it is, not whether it
     //    happened, so an unreadable protection setting is reported without downgrading the finding.
     if (!isArm) {
+      const unknown = observation?.requiredChecksNote ?? "whether it is required could not be read from branch protection";
       const note = job.required === null || job.required === undefined
-        ? " (whether it is required could not be read from branch protection)"
+        ? ` (${unknown})`
         : job.required ? " (required)" : " (not required)";
       findings.push({
         check: name, class: ACTIONABLE,
@@ -238,6 +255,21 @@ export function classify(observation) {
       findings.push({
         check: name, class: ACTIONABLE,
         why: "exit 2 — the validator produced no verdict. The policy could not be read, or the declared standards version is not the one executing",
+      });
+      arms.push({ name, usable: false });
+      continue;
+    }
+
+    // An arm's outcome can be established two independent ways: the emitted exit annotation, or the
+    // printed report. Only one workflow here emits the annotation, so a missing exit class is normal
+    // and must not be treated as a failure to observe. When *neither* is present the log was read and
+    // yielded nothing — and the rejection-set comparison below would then read an empty reported set
+    // as "every established rejection has been cleared" and call the repository changed, which is a
+    // claim about the project made from a defect in reading it.
+    if (job.validatorExit === null && (job.status === null || job.status === undefined)) {
+      findings.push({
+        check: name, class: INDETERMINATE,
+        why: "the log was read but yielded neither a verdict line nor an exit annotation, so the arm's outcome is unestablished",
       });
       arms.push({ name, usable: false });
       continue;
@@ -329,27 +361,126 @@ export function jobIdFrom(detailsUrl) {
 }
 
 /**
- * Which checks the base branch requires.
+ * Which checks a branch requires.
  *
  * Only GitHub knows, and it may be unreadable — no branch protection, or no permission. Reported as
  * null rather than as an empty set: assuming nothing is required would silently downgrade a real
  * gating failure.
  */
-function requiredChecks(repo, base) {
-  const r = gh(["api", `repos/${repo}/branches/${base}/protection/required_status_checks`], { json: true });
+function requiredChecks(repo, branch) {
+  if (!branch) return null;
+  const r = gh(["api", `repos/${repo}/branches/${branch}/protection/required_status_checks`], { json: true });
   if (!r.ok) return null;
   const contexts = r.data?.contexts ?? r.data?.checks?.map((c) => c.context) ?? [];
   return contexts;
 }
 
-/** Build the observation `classify` consumes. All I/O lives here. */
-export function extractEvidence(prNumber) {
-  const view = gh(["pr", "view", String(prNumber), "--json", "statusCheckRollup,baseRefName,headRefOid,number,url"], { json: true });
-  if (!view.ok) return { error: `could not read pull request ${prNumber}: ${view.out}` };
+/**
+ * Read the target out of the argument list. Pure, so the addressing rules are testable without gh.
+ *
+ * Two targets are an error rather than a precedence rule. A reader asked about both a pull request and
+ * a commit has been asked two different questions, and answering the one that happens to be checked
+ * first is how a verdict ends up attached to the wrong subject — the defect this mode exists to fix.
+ */
+export function parseTarget(argv) {
+  const args = argv.filter((a) => a !== "--json");
+  const targets = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--sha" || a === "--branch") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) return { error: `${a} needs a value` };
+      targets.push({ mode: a.slice(2), value });
+      i += 1;
+    } else if (/^\d+$/.test(a)) {
+      targets.push({ mode: "pr", value: a });
+    } else {
+      return { error: `unrecognised argument: ${a}` };
+    }
+  }
+
+  if (targets.length === 0) return { error: "no target given" };
+  if (targets.length > 1) {
+    return { error: `more than one target given (${targets.map((t) => `${t.mode} ${t.value}`).join(", ")}) — name one subject` };
+  }
+  return targets[0];
+}
+
+/**
+ * The commit whose checks are being read, the checks themselves, and which branch — if any — governs
+ * required-ness.
+ *
+ * Required-ness is deliberately different per mode rather than defaulting.
+ *
+ *   pr      the base branch the request would merge into. That is what would block the merge.
+ *   branch  that branch's own protection. A commit on `develop` is gated by `develop`'s rules.
+ *   sha     no branch is named, so the question is not asked. A commit can sit on any number of
+ *           branches with different protection, and picking one would be a guess reported as a fact.
+ *
+ * All three can also come back unreadable, which is a different thing from unasked, so they are
+ * distinguished in the note rather than collapsed into a single "unreadable".
+ */
+function resolveSubject(target, repo) {
+  if (target.mode === "pr") {
+    const view = gh(["pr", "view", target.value, "--json", "statusCheckRollup,baseRefName,headRefOid,number,url"], { json: true });
+    if (!view.ok) return { error: `could not read pull request ${target.value}: ${view.out}` };
+    return {
+      pr: view.data.number,
+      url: view.data.url,
+      head: view.data.headRefOid,
+      base: view.data.baseRefName,
+      protectedBranch: view.data.baseRefName,
+      checks: (view.data.statusCheckRollup ?? []).map((c) => ({
+        name: c.name,
+        conclusion: c.conclusion,
+        jobId: jobIdFrom(c.detailsUrl),
+      })),
+    };
+  }
+
+  // `commits/<ref>` accepts a branch name or a sha, and always answers with the resolved sha. Asking
+  // it even when a sha was given is what turns an abbreviated or stale sha into an explicit failure
+  // rather than an empty check list read as "nothing ran".
+  const commit = gh(["api", `repos/${repo}/commits/${target.value}`], { json: true });
+  if (!commit.ok) return { error: `could not resolve ${target.mode} ${target.value}: ${commit.out}` };
+  const head = commit.data?.sha;
+  if (!head) return { error: `${target.mode} ${target.value} resolved to no commit` };
+
+  const runs = gh(["api", `repos/${repo}/commits/${head}/check-runs`], { json: true });
+  if (!runs.ok) return { error: `could not read check runs for ${head}: ${runs.out}` };
+
+  return {
+    pr: null,
+    url: `https://github.com/${repo}/commit/${head}`,
+    head,
+    base: target.mode === "branch" ? target.value : null,
+    protectedBranch: target.mode === "branch" ? target.value : null,
+    // For a GitHub Actions check run the check-run id is the job id, which is what `actions/jobs/<id>`
+    // and its `/logs` want. `details_url` states the same id, so it is preferred where present and the
+    // id is the fallback rather than the other way round.
+    checks: (runs.data?.check_runs ?? []).map((c) => ({
+      name: c.name,
+      conclusion: c.conclusion,
+      jobId: jobIdFrom(c.details_url) ?? (c.id === undefined || c.id === null ? null : String(c.id)),
+    })),
+  };
+}
+
+/**
+ * Build the observation `classify` consumes. All I/O lives here.
+ *
+ * Accepts a target from `parseTarget`, or a bare pull request number for the original call shape.
+ */
+export function extractEvidence(target) {
+  const subjectTarget = typeof target === "object" && target !== null ? target : { mode: "pr", value: String(target) };
 
   const repoView = gh(["repo", "view", "--json", "nameWithOwner"], { json: true });
   if (!repoView.ok) return { error: "could not determine the repository" };
   const repo = repoView.data.nameWithOwner;
+
+  const subject = resolveSubject(subjectTarget, repo);
+  if (subject.error) return subject;
 
   let policy = null;
   try {
@@ -360,12 +491,18 @@ export function extractEvidence(prNumber) {
     policy = null;
   }
 
-  const required = requiredChecks(repo, view.data.baseRefName);
+  const required = requiredChecks(repo, subject.protectedBranch);
+  const requiredChecksNote = subject.protectedBranch === null
+    ? "no branch was named, so which checks gate this commit was not asked"
+    : required === null
+      ? `branch protection on ${subject.protectedBranch} could not be read`
+      : `required on ${subject.protectedBranch}`;
+
   const jobs = [];
 
-  for (const check of view.data.statusCheckRollup ?? []) {
+  for (const check of subject.checks) {
     const name = check.name;
-    const jobId = jobIdFrom(check.detailsUrl);
+    const jobId = check.jobId;
     const conclusion = String(check.conclusion ?? "").toLowerCase();
 
     let stepsExecuted;
@@ -399,12 +536,13 @@ export function extractEvidence(prNumber) {
   }
 
   return {
-    pr: view.data.number,
-    url: view.data.url,
-    head: view.data.headRefOid,
-    base: view.data.baseRefName,
+    pr: subject.pr,
+    url: subject.url,
+    head: subject.head,
+    base: subject.base,
     repo,
     requiredChecks: required,
+    requiredChecksNote,
     establishedRejections: establishedRejectionsFrom(policy),
     jobs,
   };
@@ -416,8 +554,11 @@ export function extractEvidence(prNumber) {
 
 function render(observation, result) {
   const out = [];
-  out.push(`PR #${observation.pr} — ${String(observation.head ?? "").slice(0, 7)}`);
-  out.push(`required checks        : ${observation.requiredChecks === null ? "unreadable" : observation.requiredChecks.join(", ") || "none"}`);
+  // The subject is named the same way in every mode. A verdict that does not say which commit it is
+  // about cannot be checked against one, and after a rebase merge that is exactly the mistake to make.
+  const sha = String(observation.head ?? "").slice(0, 7);
+  out.push(observation.pr ? `PR #${observation.pr} — ${sha}` : `commit ${sha}${observation.base ? ` on ${observation.base}` : ""}`);
+  out.push(`required checks        : ${observation.requiredChecks === null ? observation.requiredChecksNote ?? "unreadable" : observation.requiredChecks.join(", ") || "none"}`);
   out.push(`established rejections : ${observation.establishedRejections === null ? "unreadable" : observation.establishedRejections.join(", ") || "none"}`);
   out.push("");
   for (const f of result.findings) {
@@ -436,13 +577,14 @@ function render(observation, result) {
 
 export function main(argv) {
   const json = argv.includes("--json");
-  const pr = argv.find((a) => /^\d+$/.test(a));
-  if (!pr) {
-    process.stderr.write("usage: node scripts/ci-triage.mjs <pr-number> [--json]\n");
+  const target = parseTarget(argv);
+  if (target.error) {
+    process.stderr.write(`${target.error}\n`);
+    process.stderr.write("usage: node scripts/ci-triage.mjs <pr-number> | --sha <commit> | --branch <name> [--json]\n");
     return EXIT[INDETERMINATE];
   }
 
-  const observation = extractEvidence(pr);
+  const observation = extractEvidence(target);
   if (observation.error) {
     process.stderr.write(`${observation.error}\n`);
     return EXIT[INDETERMINATE];

--- a/test/ci-triage.test.mjs
+++ b/test/ci-triage.test.mjs
@@ -37,6 +37,7 @@ import {
   logLines,
   establishedRejectionsFrom,
   jobIdFrom,
+  parseTarget,
   EXPECTED,
   ACTIONABLE,
   INDETERMINATE,
@@ -55,7 +56,7 @@ const fixture = (name) => JSON.parse(readFileSync(path.join(FIXTURES, name), "ut
 
 test("every fixture classifies as the state it describes", () => {
   const files = readdirSync(FIXTURES).filter((f) => f.endsWith(".json")).sort();
-  assert.ok(files.length >= 12, `only ${files.length} fixtures — the branch coverage was reduced`);
+  assert.ok(files.length >= 14, `only ${files.length} fixtures — the branch coverage was reduced`);
 
   for (const file of files) {
     const f = fixture(file);
@@ -147,6 +148,31 @@ test("actionable outranks indeterminate", () => {
   const result = classify(fixture("actionable-outranks-indeterminate.json"));
   assert.equal(result.verdict, ACTIONABLE);
   assert.ok(result.findings.some((r) => r.class === INDETERMINATE), "the indeterminate finding was dropped rather than outranked");
+});
+
+test("an arm whose verdict printed without an exit annotation is still established", () => {
+  // Only one of the two workflows emits `::error::`, so a missing exit class is the normal shape for
+  // the other arm. Treating it as a failure to observe would make every run of that workflow
+  // indeterminate and retire the tool on its second day.
+  const result = classify(fixture("verdict-without-annotation.json"));
+  assert.equal(result.verdict, EXPECTED);
+  const finding = result.findings.find((r) => r.check === "validate");
+  assert.equal(finding.class, EXPECTED, "a printed verdict with no annotation was discarded");
+  assert.match(finding.why, /NON_COMPLIANT/);
+});
+
+test("an arm whose log yielded neither verdict nor exit class is unestablished, not cleared", () => {
+  // The dangerous shape. With no reported rules parsed, a set comparison would read the empty result
+  // as every established rejection having been cleared and call the repository changed — a claim about
+  // the project derived from a defect in reading it. The exit class and the printed verdict are two
+  // independent ways to establish the outcome; the absence of both is the absence of evidence.
+  const result = classify(fixture("unreadable-verdict.json"));
+  assert.equal(result.verdict, INDETERMINATE);
+  const finding = result.findings.find((r) => r.check === "validate");
+  assert.equal(finding.class, INDETERMINATE);
+  assert.match(finding.why, /unestablished|neither/);
+  assert.doesNotMatch(finding.why, /no longer reported/, "unread evidence was reported as a cleared rejection");
+  for (const f of result.findings) assert.notEqual(f.class, ACTIONABLE, "unread evidence was reported as the repository being wrong");
 });
 
 test("an empty observation establishes nothing rather than passing", () => {
@@ -258,6 +284,50 @@ test("the exit codes match the epistemic split", () => {
   assert.equal(EXIT[EXPECTED], 0);
   assert.equal(EXIT[ACTIONABLE], 1);
   assert.equal(EXIT[INDETERMINATE], 2);
+});
+
+// -------------------------------------------------------------------------------------------
+// Addressing — which commit the verdict is about
+// -------------------------------------------------------------------------------------------
+
+test("each addressing mode names one subject", () => {
+  assert.deepEqual(parseTarget(["26"]), { mode: "pr", value: "26" });
+  assert.deepEqual(parseTarget(["--sha", "69de0c8"]), { mode: "sha", value: "69de0c8" });
+  assert.deepEqual(parseTarget(["--branch", "develop"]), { mode: "branch", value: "develop" });
+  assert.deepEqual(parseTarget(["--json", "--branch", "develop"]), { mode: "branch", value: "develop" });
+});
+
+test("two targets is an error, not a precedence rule", () => {
+  // The whole reason this mode exists is that a verdict can be true about the wrong commit. Silently
+  // preferring one of two subjects would reintroduce that at the argument list.
+  assert.match(parseTarget(["26", "--sha", "69de0c8"]).error, /more than one target/);
+  assert.match(parseTarget(["--branch", "develop", "--branch", "master"]).error, /more than one target/);
+  assert.match(parseTarget([]).error, /no target/);
+  assert.match(parseTarget(["--sha"]).error, /needs a value/);
+  assert.match(parseTarget(["--sha", "--json"]).error, /needs a value/);
+  assert.match(parseTarget(["--wat"]).error, /unrecognised/);
+});
+
+test("a run that cannot name its subject's gating branch says so, rather than reporting unreadable", () => {
+  // A commit can sit on any number of branches with different protection. "Not asked" and "asked and
+  // could not read" are different states, and collapsing them would let a guess read as a measurement.
+  const unasked = classify({
+    requiredChecksNote: "no branch was named, so which checks gate this commit was not asked",
+    establishedRejections: [],
+    jobs: [{ name: "build", conclusion: "failure", stepsExecuted: 4, required: null, logRead: false }],
+  });
+  const finding = unasked.findings.find((r) => r.check === "build");
+  assert.equal(finding.class, ACTIONABLE, "a real failure was downgraded because required-ness was unknown");
+  assert.match(finding.why, /was not asked/);
+  assert.doesNotMatch(finding.why, /could not be read/, "an unasked question was reported as an unreadable answer");
+
+  // With no note supplied the wording stays the original one, so a fixture that predates this field
+  // still describes itself correctly.
+  const noNote = classify({
+    establishedRejections: [],
+    jobs: [{ name: "build", conclusion: "failure", stepsExecuted: 4, required: null, logRead: false }],
+  });
+  assert.match(noNote.findings.find((r) => r.check === "build").why, /could not be read from branch protection/);
 });
 
 test("a job id is read from a details URL, and absence is not an id", () => {

--- a/test/ci-triage.test.mjs
+++ b/test/ci-triage.test.mjs
@@ -38,6 +38,9 @@ import {
   establishedRejectionsFrom,
   jobIdFrom,
   parseTarget,
+  combineCheckRunPages,
+  collectCheckRunPages,
+  CHECK_RUNS_PER_PAGE,
   EXPECTED,
   ACTIONABLE,
   INDETERMINATE,
@@ -328,6 +331,137 @@ test("a run that cannot name its subject's gating branch says so, rather than re
     jobs: [{ name: "build", conclusion: "failure", stepsExecuted: 4, required: null, logRead: false }],
   });
   assert.match(noNote.findings.find((r) => r.check === "build").why, /could not be read from branch protection/);
+});
+
+// -------------------------------------------------------------------------------------------
+// Pagination — the evidence surface has to be complete before it can be classified
+// -------------------------------------------------------------------------------------------
+
+const PAGES = path.join(ROOT, "test", "fixtures", "ci-triage-pages");
+const pageFixture = (name) => JSON.parse(readFileSync(path.join(PAGES, name), "utf8"));
+
+/**
+ * The check-run-to-job mapping, standing in for the one inside `extractEvidence`. The fixtures carry
+ * the parsed log fields directly, because what is under test here is which runs reach the classifier
+ * — not how a log is read, which has its own specimens above.
+ */
+const asJobs = (runs, established) => runs.map((r) => ({
+  name: r.name,
+  conclusion: r.conclusion,
+  stepsExecuted: r.stepsExecuted,
+  required: r.name === "test",
+  logRead: r.name in { "validate": 1, "validate-self / validate": 1 },
+  status: r.status ?? null,
+  reportedRules: r.reportedRules ?? [],
+  validatorExit: r.status === undefined ? null : 1,
+  annotations: [],
+  established,
+}));
+
+test("a failed job on a later page is not invisible", () => {
+  // The endpoint pages at 30 by default. One page read as the whole set means a real failure can be
+  // absent from the evidence entirely, and the verdict is EXPECTED over a surface never seen — the
+  // false assurance this tool exists to prevent, produced by the tool itself and produced silently.
+  const f = pageFixture("hidden-failure.json");
+  const observe = (runs) => ({ establishedRejections: f.establishedRejections, jobs: asJobs(runs, f.establishedRejections) });
+
+  const firstPageOnly = combineCheckRunPages(f.pages.slice(0, 1));
+  assert.equal(classify(observe(firstPageOnly)).verdict, f.expectFirstPageOnly, "the fixture no longer demonstrates the defect");
+
+  const combined = combineCheckRunPages(f.pages);
+  assert.equal(combined.length, 4, "the pages were not combined");
+  const result = classify(observe(combined));
+  assert.equal(result.verdict, f.expectCombined);
+  const finding = result.findings.find((r) => r.check === "package");
+  assert.equal(finding.class, ACTIONABLE, "the job hidden on page two was not classified");
+});
+
+test("a run seen twice across pages is one run; two runs under one name are unestablished", () => {
+  // Both hazards of walking a moving list. An identical id on two pages is the same run, and
+  // collapsing it is enough. A second, different run under a name that already appeared is not
+  // redundant but contradictory, and picking one would be a guess reported as an observation.
+  const f = pageFixture("retried-duplicates.json");
+  const combined = combineCheckRunPages(f.pages);
+  assert.equal(combined.length, f.expectDistinctRuns, "the repeated id was not collapsed");
+
+  const result = classify({ establishedRejections: f.establishedRejections, jobs: asJobs(combined, f.establishedRejections) });
+  assert.equal(result.verdict, f.expectCombined);
+  const finding = result.findings.find((r) => r.check === "validate");
+  assert.equal(finding.class, INDETERMINATE);
+  assert.match(finding.why, /which one describes the commit is unestablished/);
+});
+
+test("duplicate arms do not establish placement equivalence between themselves", () => {
+  // Everything in this fixture agrees, so a classifier that simply ignored the duplication would
+  // report EXPECTED — the comparison would be `validate` against its own copy, which agrees by
+  // construction and says nothing about where the evaluator ran.
+  //
+  // Two guards produce this result and only the first is exercised here: duplicated names are marked
+  // unusable, and the cross-arm comparison selects by name rather than taking the first two usable
+  // entries. The second is defence in depth for the day the first is relaxed, and this test cannot
+  // distinguish them — with duplicates unusable, three usable arms can no longer arise.
+  const f = pageFixture("retried-duplicates.json");
+  const combined = combineCheckRunPages(f.pages);
+  const result = classify({ establishedRejections: f.establishedRejections, jobs: asJobs(combined, f.establishedRejections) });
+
+  assert.notEqual(result.verdict, EXPECTED, "duplicate copies of one arm satisfied placement equivalence");
+  const equivalence = result.findings.find((r) => r.check === "inside vs outside");
+  assert.ok(equivalence, "placement equivalence was silently treated as established");
+  assert.equal(equivalence.class, INDETERMINATE);
+});
+
+test("the walk keeps asking while pages come back full, and stops when one does not", () => {
+  // The loop itself, not its inputs. The tests above classify pages that were already assembled, so
+  // they stay green against an extractor that quietly stopped after page one — which is the defect
+  // this fix exists for. A fake fetcher is what makes the walk observable.
+  const run = (id) => ({ id, name: `check-${id}`, conclusion: "success" });
+  const full = { total_count: CHECK_RUNS_PER_PAGE + 2, check_runs: Array.from({ length: CHECK_RUNS_PER_PAGE }, (_, i) => run(i + 1)) };
+  const tail = { total_count: CHECK_RUNS_PER_PAGE + 2, check_runs: [run(CHECK_RUNS_PER_PAGE + 1), run(CHECK_RUNS_PER_PAGE + 2)] };
+
+  const asked = [];
+  const result = collectCheckRunPages((page) => {
+    asked.push(page);
+    return { ok: true, data: page === 1 ? full : tail };
+  });
+
+  assert.deepEqual(asked, [1, 2], "the walk did not continue past the first full page");
+  assert.equal(result.runs.length, CHECK_RUNS_PER_PAGE + 2);
+
+  // A single short page is the whole set, and must not cost a second request.
+  const once = [];
+  collectCheckRunPages((page) => { once.push(page); return { ok: true, data: { total_count: 2, check_runs: [run(1), run(2)] } }; });
+  assert.deepEqual(once, [1]);
+});
+
+test("a page that cannot be read is an error, never a partial set", () => {
+  // Classifying whatever happened to arrive is the same false-assurance defect one layer down: the
+  // verdict would describe a surface that was cut short by a failed request nobody was told about.
+  const result = collectCheckRunPages((page) => (page === 1
+    ? { ok: true, data: { total_count: 500, check_runs: Array.from({ length: CHECK_RUNS_PER_PAGE }, (_, i) => ({ id: i + 1, name: `c${i}` })) } }
+    : { ok: false, out: "502 Bad Gateway" }));
+
+  assert.ok(result.error, "a failed page was reported as a complete set");
+  assert.match(result.error, /page 2/);
+  assert.equal(result.runs, undefined, "a partial set was returned alongside the error");
+});
+
+test("a walk that never terminates is an error rather than an infinite loop", () => {
+  const result = collectCheckRunPages(() => ({
+    ok: true,
+    data: { check_runs: Array.from({ length: CHECK_RUNS_PER_PAGE }, (_, i) => ({ id: `${Math.random()}-${i}`, name: "c" })) },
+  }));
+  assert.match(result.error, /did not terminate/);
+});
+
+test("the commit check-runs request is paginated at the call site", () => {
+  // The classifier-side tests above run on assembled pages, so they cannot see an extractor that
+  // stopped asking for page two. This one reads the request itself.
+  const source = readFileSync(path.join(ROOT, "scripts", "ci-triage.mjs"), "utf8");
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const request = /commits\/\$\{[^}]+\}\/check-runs([^`]*)`/.exec(code);
+  assert.ok(request, "the commit check-runs request could not be found");
+  assert.match(request[1], /per_page=/, "the request does not set a page size");
+  assert.match(request[1], /page=\$\{/, "the request asks for one fixed page");
 });
 
 test("a job id is read from a details URL, and absence is not an id", () => {

--- a/test/fixtures/ci-triage-pages/hidden-failure.json
+++ b/test/fixtures/ci-triage-pages/hidden-failure.json
@@ -1,0 +1,38 @@
+{
+  "note": "A commit with more check runs than one page holds. Page one carries both validation arms, correctly red over the established set; page two carries a job that ran real steps and failed. Reading page one alone reports EXPECTED over evidence that was never seen.",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "errors.no-false-success"
+  ],
+  "expectFirstPageOnly": "EXPECTED",
+  "expectCombined": "ACTIONABLE",
+  "pages": [
+    {
+      "total_count": 4,
+      "check_runs": [
+        { "id": 101, "name": "test", "conclusion": "success", "stepsExecuted": 12 },
+        {
+          "id": 102,
+          "name": "validate",
+          "conclusion": "failure",
+          "stepsExecuted": 6,
+          "status": "NON_COMPLIANT",
+          "reportedRules": ["ai.no-fabricated-capabilities", "errors.no-false-success"]
+        },
+        {
+          "id": 103,
+          "name": "validate-self / validate",
+          "conclusion": "failure",
+          "stepsExecuted": 15,
+          "status": "NON_COMPLIANT",
+          "reportedRules": ["ai.no-fabricated-capabilities", "errors.no-false-success"]
+        }
+      ]
+    },
+    {
+      "check_runs": [
+        { "id": 104, "name": "package", "conclusion": "failure", "stepsExecuted": 7 }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage-pages/retried-duplicates.json
+++ b/test/fixtures/ci-triage-pages/retried-duplicates.json
@@ -1,0 +1,70 @@
+{
+  "note": "Two shapes of duplication. Check run 202 appears on both pages — the same run seen twice because a new run shifted the window mid-walk, and it must collapse to one. Check run 205 is a different run reporting under a name that already appeared, which is contradictory rather than redundant: a snapshot does not say which describes the commit. Everything else here agrees, so duplication is the only thing the verdict can be coming from.",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "errors.no-false-success"
+  ],
+  "expectDistinctRuns": 4,
+  "expectCombined": "INDETERMINATE",
+  "pages": [
+    {
+      "total_count": 4,
+      "check_runs": [
+        {
+          "id": 201,
+          "name": "test",
+          "conclusion": "success",
+          "stepsExecuted": 12
+        },
+        {
+          "id": 202,
+          "name": "validate",
+          "conclusion": "failure",
+          "stepsExecuted": 6,
+          "status": "NON_COMPLIANT",
+          "reportedRules": [
+            "ai.no-fabricated-capabilities",
+            "errors.no-false-success"
+          ]
+        }
+      ]
+    },
+    {
+      "check_runs": [
+        {
+          "id": 202,
+          "name": "validate",
+          "conclusion": "failure",
+          "stepsExecuted": 6,
+          "status": "NON_COMPLIANT",
+          "reportedRules": [
+            "ai.no-fabricated-capabilities",
+            "errors.no-false-success"
+          ]
+        },
+        {
+          "id": 205,
+          "name": "validate",
+          "conclusion": "failure",
+          "stepsExecuted": 6,
+          "status": "NON_COMPLIANT",
+          "reportedRules": [
+            "ai.no-fabricated-capabilities",
+            "errors.no-false-success"
+          ]
+        },
+        {
+          "id": 206,
+          "name": "validate-self / validate",
+          "conclusion": "failure",
+          "stepsExecuted": 15,
+          "status": "NON_COMPLIANT",
+          "reportedRules": [
+            "ai.no-fabricated-capabilities",
+            "errors.no-false-success"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/unreadable-verdict.json
+++ b/test/fixtures/ci-triage/unreadable-verdict.json
@@ -1,0 +1,50 @@
+{
+  "note": "The log was fetched but yielded neither a verdict line nor an exit annotation. Nothing about the run is established — and the empty reported set must not be read as the four rejections having been cleared.",
+  "expect": "INDETERMINATE",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 12,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 6,
+      "required": false,
+      "logRead": true,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 15,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) — a required or forbidden rule failed."
+      ]
+    }
+  ]
+}

--- a/test/fixtures/ci-triage/verdict-without-annotation.json
+++ b/test/fixtures/ci-triage/verdict-without-annotation.json
@@ -1,0 +1,54 @@
+{
+  "note": "The live shape on develop: one workflow emits no ::error:: annotation, so the arm has no exit class while its report is fully readable. The printed verdict establishes the outcome on its own.",
+  "expect": "EXPECTED",
+  "establishedRejections": [
+    "ai.no-fabricated-capabilities",
+    "ai.no-safety-bypass",
+    "errors.no-false-success"
+  ],
+  "jobs": [
+    {
+      "name": "test",
+      "conclusion": "success",
+      "stepsExecuted": 12,
+      "required": true,
+      "logRead": false,
+      "status": null,
+      "reportedRules": [],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate",
+      "conclusion": "failure",
+      "stepsExecuted": 6,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": null,
+      "annotations": []
+    },
+    {
+      "name": "validate-self / validate",
+      "conclusion": "failure",
+      "stepsExecuted": 15,
+      "required": false,
+      "logRead": true,
+      "status": "NON_COMPLIANT",
+      "reportedRules": [
+        "ai.no-fabricated-capabilities",
+        "ai.no-safety-bypass",
+        "errors.no-false-success"
+      ],
+      "validatorExit": 1,
+      "annotations": [
+        "NON-COMPLIANT (exit 1) — a required or forbidden rule failed."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds commit and branch addressing to `scripts/ci-triage.mjs`, and decides a classification branch the fixtures had never reached.

## Why

The classifier addressed its evidence only by pull request. A pull request's `statusCheckRollup` describes its own head, and GitHub does not update that when a rebase merge rewrites the commit onto the base branch. Observed live on 2026-08-16: after #29 merged, `gh pr view 29` still reported `4d7088f` and check runs `952057448xx`, while the merged `69de0c8` on `develop` carried `952064097xx`. Running the tool against #29 returned `EXPECTED` — a true verdict about a commit no branch pointed at, which is the identity-versus-content substitution the submission gate already refuses.

## What changed

- `--sha <commit>` and `--branch <name>` resolve check runs for a commit directly. The bare `<pr-number>` form is unchanged.
- Two targets is an error, not a precedence rule. A reader asked about both a pull request and a commit has been asked two questions; answering whichever argument is checked first is how a verdict lands on the wrong subject again.
- Required-ness is answered per mode rather than defaulted: a pull request by its base branch, a branch by its own protection, a bare commit by nothing nameable — reported as *unasked*, which is a different state from *unreadable*. A failing job stays actionable either way.
- An arm's outcome has two independent sources. Only one workflow emits the `::error::` annotation, so a missing exit class is normal rather than a failure to observe. When the printed verdict is unreadable too, the arm is now `INDETERMINATE` — previously the empty rule set compared against the policy's four rejections and reported them as cleared, a claim about the project derived from a defect in reading it.

## Architecture unchanged

All I/O stays in `extractEvidence`; `classify()` is still pure; the observation still carries `head` in every mode, so the verdict names its subject. `parseTarget` is pure and exported, so the addressing rules are tested without `gh`. Still a reader — the scope test asserting it cannot write, merge, or issue a mutating call is unchanged and passing.

## Evidence

Two fixtures added (14 total). Both new branches falsified: disabling the unestablished-verdict branch fails 2 tests; letting two targets through fails the addressing test. All three modes exercised live against `develop`, `69de0c8`, and #26.

---

## Local CI

This pipeline ran in an ephemeral Docker container on the author's machine.
It is **not** a GitHub-hosted Actions run and makes no claim about one.

- Verified commit: `5538f10c3ae8733a40c89acb61859fa90b01b279`
- Branch: `feat/ci-triage-commit-addressing`
- Result: **PASS**
- Environment: Docker (`engineeringstandards-ci:engineeringstandards-ci-1786904944400-65480`, Node v20.20.2)
- Completed: 2026-08-16T18:29:16.9Z

<details><summary>Stages executed</summary>

- `inventory` — passed (exit 0)
- `fidelity` — passed (exit 0)
- `policy` — passed (exit 0)
- `diagrams` — passed (exit 0)
- `test` — passed (exit 0)
- `audit` — passed (exit 0)
- `validate` — advisory-failed (exit 1) _[advisory, non-gating]_

</details>

