### PR TITLE
Section 08 owns the sequencing defect, without deciding how to resolve it

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -8,8 +8,8 @@ Before the plan repair, eleven GitHub issues, four recorded rule rejections, and
 deferred design questions existed as a parallel obligation system that no plan item claimed. A plan
 that omits its own open work will always report itself complete.
 
-**Every open GitHub issue is claimed by exactly one plan item.** Fifteen are open. Nine are claimed
-here — #1, #4, #5, #6, #7, #8, #17, #19, #21 — and the other six are claimed where their subject
+**Every open GitHub issue is claimed by exactly one plan item.** Sixteen are open. Ten are claimed
+here — #1, #4, #5, #6, #7, #8, #17, #19, #21, #32 — and the other six are claimed where their subject
 lives: [#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
 [#3](06-must-never-standards.md) by the detectors, and
 [#2, #9 and #16](07-distributed-validation-and-ci.md) by the adoption path. None is rejected as
@@ -590,6 +590,58 @@ that approval deliberately does not cover.
   `develop` and the repository is currently clean. That establishes nothing about whether the next
   ones would be caught, and this item stays open until a check with both fixtures exists. The two
   claims are kept separate deliberately.
+
+### Make remediation consistent with the repository state that gives it meaning
+
+- **Status:** READY
+- **Tracked by:** GitHub issue
+  [#32](https://github.com/mikeycdavis/EngineeringStandards/issues/32)
+- **Evidence:** open as of 2026-08-16, verified at `e842a5a`.
+  [`scripts/init.mjs`](../../scripts/init.mjs) recognises the reconstruction state and sets
+  `nextStep` to *"Run the project-reconstruction skill (Standard 44). Do NOT author a plan as though
+  this project were starting now."* In that same state `artifacts/project-plan-breakdown/` is created
+  empty on purpose, so `planning.breakdown-directory` fails, and its remediation in
+  [`rules/planning.json`](../../rules/planning.json) reads *"Run /plan-structure and /plan-handoff,
+  writing each top-level section to its own file…"* unconditionally.
+  `planning.one-file-per-section` names `/plan-handoff` too and is bound to no detector, so it emits
+  nothing today — **catalog-wide scope evidence, not a second live specimen.**
+- **Purpose:** Ensure that when this framework explicitly recognises a repository state, a rule
+  remediation cannot instruct the user to perform an action another authoritative framework surface
+  forbids in that same state. The two instructions above cannot both be authoritative for one
+  repository: following the validator violates `init`, and following `init` leaves a required rule
+  failing. **The defective part is the remediation, not the finding** — `planning.breakdown-directory`
+  failing in the reconstruction state may well be correct, and "make reconstruction pass" is
+  explicitly out of scope.
+- **Deliverables:** a measured decision among the remediation and applicability alternatives, the
+  normative invariant, implementation of the selected mechanism, and regression coverage over the
+  reconstruction state. **The mechanism is deliberately not chosen here.** Conditional remediation,
+  suppression in that state, a reconstruction-specific alternative, and a deeper applicability change
+  all remain candidates until measured; naming one now would convert a recorded defect into an
+  implementation decision the evidence has not yet earned.
+- **Acceptance Criteria:**
+  - The invariant is recorded normatively, in a form a future rule author is bound by: *for every
+    repository state the framework explicitly recognises, a reported rule's remediation must never
+    instruct the user to take an action another authoritative framework surface explicitly forbids in
+    that same state.*
+  - For a repository in the reconstruction state, no reported finding's remediation instructs the
+    user to author a plan as though the project were starting now.
+  - The chosen implementation is recorded together with the alternatives measured and rejected.
+  - A test exercises the reconstruction state end to end and fails if any emitted remediation
+    contradicts `init`'s `nextStep` for that same state.
+  - `planning.breakdown-directory` remains a legitimate finding in the reconstruction state unless a
+    measured decision says otherwise.
+- **Verification:** `npm test` with the reconstruction-state fixture; the self-audit unchanged.
+- **Dependencies:** none. **Do not modify rule, remediation, or reconstruction semantics before the
+  mechanism is measured and selected.**
+- **Boundaries, recorded so they are not crossed later.** Section 04 owns the compliance and policy
+  architecture and may ultimately receive the implementation, but this item is **not** also assigned
+  there and no cross-section `Tracked by` is added — that would be use, not ownership, and would
+  prematurely imply the remedy belongs in the compliance engine. It is **not** FE-21 fallout:
+  StandardsEnforcer's policy-marker defect measurably does not transfer here, since
+  `project-policy.yml` is the only marker any surface names and there is no `--policy` override to
+  widen. It is **not** #9 or #16 — adjacency is not ownership. It is **not** evidence that Standard 44
+  is wrong; the defect is disagreement between two of this framework's surfaces about what action
+  follows from the reconstruction state.
 
 ---
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -591,7 +591,7 @@ that approval deliberately does not cover.
   ones would be caught, and this item stays open until a check with both fixtures exists. The two
   claims are kept separate deliberately.
 
-### Make remediation consistent with the repository state that gives it meaning
+### Make remediation carry the sequencing its repository state requires
 
 - **Status:** READY
 - **Tracked by:** GitHub issue
@@ -599,35 +599,55 @@ that approval deliberately does not cover.
 - **Evidence:** open as of 2026-08-16, verified at `e842a5a`.
   [`scripts/init.mjs`](../../scripts/init.mjs) recognises the reconstruction state and sets
   `nextStep` to *"Run the project-reconstruction skill (Standard 44). Do NOT author a plan as though
-  this project were starting now."* In that same state `artifacts/project-plan-breakdown/` is created
-  empty on purpose, so `planning.breakdown-directory` fails, and its remediation in
-  [`rules/planning.json`](../../rules/planning.json) reads *"Run /plan-structure and /plan-handoff,
-  writing each top-level section to its own file…"* unconditionally.
-  `planning.one-file-per-section` names `/plan-handoff` too and is bound to no detector, so it emits
-  nothing today — **catalog-wide scope evidence, not a second live specimen.**
-- **Purpose:** Ensure that when this framework explicitly recognises a repository state, a rule
-  remediation cannot instruct the user to perform an action another authoritative framework surface
-  forbids in that same state. The two instructions above cannot both be authoritative for one
-  repository: following the validator violates `init`, and following `init` leaves a required rule
-  failing. **The defective part is the remediation, not the finding** — `planning.breakdown-directory`
-  failing in the reconstruction state may well be correct, and "make reconstruction pass" is
-  explicitly out of scope.
-- **Deliverables:** a measured decision among the remediation and applicability alternatives, the
-  normative invariant, implementation of the selected mechanism, and regression coverage over the
-  reconstruction state. **The mechanism is deliberately not chosen here.** Conditional remediation,
-  suppression in that state, a reconstruction-specific alternative, and a deeper applicability change
-  all remain candidates until measured; naming one now would convert a recorded defect into an
-  implementation decision the evidence has not yet earned.
+  this project were starting now."*
+  [Standard 44](../../standards/44-existing-project-reconstruction.md) requires the reconstructed
+  plan to live under `artifacts/project-plan-breakdown/`, and requires that `/plan-structure` and
+  `/plan-handoff` **MUST be applied to the reconstructed plan**.
+  In that state the directory is created empty on purpose, so `planning.breakdown-directory` fails,
+  and its remediation in [`rules/planning.json`](../../rules/planning.json) reads *"Run
+  /plan-structure and /plan-handoff, writing each top-level section to its own file…"* with no
+  mention of what must happen first.
+  `planning.handoff` also prescribes `/plan-handoff` and is `manual-review`, so it emits no
+  finding — **catalog-wide scope evidence, not a second live specimen.**
+- **Purpose:** Ensure that when this framework explicitly recognises a repository state, remediation
+  preserves the prerequisites, sequencing and context that make the prescribed action valid in that
+  state.
+
+  ```text
+  wrong implication
+      reconstruction state
+      -> run /plan-structure + /plan-handoff now
+
+  required sequence
+      reconstruction state
+      -> reconstruct an evidence-based plan under Standard 44
+      -> apply /plan-structure + /plan-handoff to that reconstructed plan
+  ```
+
+  **The two instructions are not literally contradictory, and this item does not claim they are.**
+  The remediation never says to fabricate a greenfield plan, and the prescribed tools are eventually
+  required by Standard 44 itself. What is missing is the ordering: a user shown this remediation
+  before reconstruction can reasonably run the right tools at the wrong stage and produce planning
+  material without the reconstruction evidence that gives it meaning. **The defective part is the
+  remediation, not the finding** — `planning.breakdown-directory` failing in the reconstruction state
+  may well be correct, and "make reconstruction pass" is explicitly out of scope.
+- **Deliverables:** a measured decision among the remediation alternatives, the normative invariant,
+  implementation of the selected mechanism, and regression coverage over the reconstruction state.
+  **The mechanism is deliberately not chosen here**, but the candidates are no longer equally
+  motivated. State-conditional remediation and a reconstruction-specific remediation string are the
+  two the specimen directly supports. **Suppression is not**, because the finding may be legitimate;
+  a deeper applicability change stays open for measurement but is no longer implied, since it was
+  implied only by a contradiction that does not exist.
 - **Acceptance Criteria:**
   - The invariant is recorded normatively, in a form a future rule author is bound by: *for every
-    repository state the framework explicitly recognises, a reported rule's remediation must never
-    instruct the user to take an action another authoritative framework surface explicitly forbids in
-    that same state.*
-  - For a repository in the reconstruction state, no reported finding's remediation instructs the
-    user to author a plan as though the project were starting now.
+    repository state the framework explicitly recognises, remediation must preserve the
+    prerequisites, sequencing and context that make the prescribed action valid in that state.*
+  - For a repository in the reconstruction state, remediation that prescribes `/plan-structure` or
+    `/plan-handoff` also states that reconstruction comes first and that those skills apply to the
+    reconstructed plan.
   - The chosen implementation is recorded together with the alternatives measured and rejected.
-  - A test exercises the reconstruction state end to end and fails if any emitted remediation
-    contradicts `init`'s `nextStep` for that same state.
+  - A test exercises the reconstruction state end to end and fails if emitted remediation omits the
+    sequencing `init`'s `nextStep` establishes for that same state.
   - `planning.breakdown-directory` remains a legitimate finding in the reconstruction state unless a
     measured decision says otherwise.
 - **Verification:** `npm test` with the reconstruction-state fixture; the self-audit unchanged.
@@ -640,8 +660,14 @@ that approval deliberately does not cover.
   StandardsEnforcer's policy-marker defect measurably does not transfer here, since
   `project-policy.yml` is the only marker any surface names and there is no `--policy` override to
   widen. It is **not** #9 or #16 — adjacency is not ownership. It is **not** evidence that Standard 44
-  is wrong; the defect is disagreement between two of this framework's surfaces about what action
-  follows from the reconstruction state.
+  is wrong; Standard 44 is the surface that supplies the missing ordering.
+- **Corrected 2026-08-16 before merge, and the original claim is not preserved as if it held.** This
+  item was first written as a direct contradiction — that the remediation instructs an action `init`
+  forbids. Review against Standard 44 falsified that: the standard requires those same skills over
+  the reconstructed plan, so the two literal instructions can both be followed in the right order.
+  The user-facing outcome was identified correctly and its causal model was overstated. The record
+  of the overstatement is kept here because the ownership-before-implementation sequence is what
+  caught it, while no code had been changed.
 
 ---
 


### PR DESCRIPTION
Gives [#32](https://github.com/mikeycdavis/EngineeringStandards/issues/32) a plan owner. **Administrative only — no rule, remediation, or reconstruction semantics change.**

> **Basis corrected at `7838014`, before merge.** The first commit described the defect as a direct contradiction between `init` and `planning.breakdown-directory`'s remediation. Codex review falsified that. Both findings held, both are fixed here, and both threads are answered and resolved. The item records that it was corrected rather than reading as though it always said this.

## The defect, as it actually stands

`scripts/init.mjs:253-254` says reconstruction happens first and forbids authoring a plan as though the project were starting now. `standards/44-existing-project-reconstruction.md:264,283` requires the reconstructed plan to live under `artifacts/project-plan-breakdown/` and requires `/plan-structure` and `/plan-handoff` to be applied **to that reconstructed plan**. `planning.breakdown-directory`'s remediation names those same skills.

So the instructions are not mutually exclusive — the remediation never says to fabricate a greenfield plan, and the tools it names are eventually required. What is missing is the ordering:

```text
wrong implication
    reconstruction state
    -> run /plan-structure + /plan-handoff now

required sequence
    reconstruction state
    -> reconstruct an evidence-based plan under Standard 44
    -> apply /plan-structure + /plan-handoff to that reconstructed plan
```

A user shown the remediation before reconstruction can reasonably run the right tools at the wrong stage and construct planning material without the reconstruction evidence that gives it meaning.

The invariant moves with the model: from *remediation must never instruct an action another surface forbids* to **remediation must preserve the prerequisites, sequencing and context that make the prescribed action valid in that state**.

That re-weights the candidates. Suppression is no longer motivated, because the finding may be legitimate. A deeper applicability change stays open for measurement but is no longer implied, since it was implied only by a contradiction that does not exist. State-conditional and reconstruction-specific remediation are what the specimen supports. The mechanism is still not chosen.

The second correction: the scope note named `planning.one-file-per-section`, which only prescribes splitting the plan into ordered files. The entry that prescribes `/plan-handoff` is `planning.handoff` (`rules/planning.json:82-94`), and it is `manual-review`, so it emits no finding. It remains catalog-wide scope evidence, explicitly not a second live specimen.

## Why section 08 and not section 04

Section 08 exists so a known-but-unresolved defect can be explicit without its existence becoming an implementation decision. #32 is exactly that shape.

Section 04 owns the compliance and policy architecture and may ultimately receive the implementation, but assigning ownership there now would prematurely imply the remedy belongs in the compliance engine or the policy layer. No cross-section `Tracked by` is added to 04 either: that would be use, not ownership.

## Shape of the change

One file. The claim-invariant paragraph is corrected in place — fifteen issues open and nine claimed here becomes sixteen and ten — because that paragraph is the only place the one-item-one-issue invariant is asserted, and an invariant whose own arithmetic does not hold cannot check anything.

The item carries its boundaries as part of the record: not FE-21 fallout (the policy-marker defect measurably does not transfer — `project-policy.yml` is the only marker any surface here names, and there is no `--policy` override to widen), not #9 or #16, and not evidence against Standard 44 — which is in fact the surface supplying the missing ordering.

## Gate

Verified in Docker at `7838014`: inventory, fidelity, policy, diagrams, test, audit all passed; `validate` advisory-red over the same four established rejections, unchanged. The push was a fast-forward, `8f056f7..7838014` — the reviewed commit is still reachable.
