### PR TITLE
Three answers where the resolver had two

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -780,7 +780,7 @@ that approval deliberately does not cover.
 
 ### Decouple `Tracked by` resolution from one backlog implementation
 
-- **Status:** COMPLETE — 2026-08-24 at `85787e6`, established by the full repository gate at that
+- **Status:** COMPLETE — 2026-08-24 at `a63cb17`, established by the full repository gate at that
   commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and `audit` all passed, 361 tests, 0
   failures, 0 skipped. `validate` at that content is unchanged from `develop` at `be30c081` — 23 passed, 4
   failed, 23 skipped, with the four failures being the four standing recorded human rejections and no
@@ -788,7 +788,7 @@ that approval deliberately does not cover.
   section.
 
   **The seam was correct and the check that guards it was not.** GitHub's `test` job failed at
-  `ef87565` where six local gate runs had passed: `scripts/links.mjs` listed `scripts/`, then opened
+  the pre-rebase `ef87565` where six local gate runs had passed: `scripts/links.mjs` listed `scripts/`, then opened
   each file, and `test/invocation-ownership.test.mjs` deleted its dot-prefixed negative control in
   between. The scan was not honouring a convention the repository already keeps — that control is
   dot-prefixed precisely so nothing treats it as a source file. Dot-prefixed entries are now out of
@@ -878,7 +878,9 @@ that approval deliberately does not cover.
 
   All eleven were written before `scripts/tracking.mjs` existed and were run against a missing
   module first.
-- **Verification:** `npm test`; 361 tests, 0 failures, 0 skipped at `85787e6`. The `ST-999` assertion still
+- **Verification:** `npm test`; 361 tests, 0 failures, 0 skipped at `a63cb17`, rebased onto
+  `9e90c24`, where `validate` is unchanged from `develop` — 23 passed, 4 failed, 23 skipped, no rule
+  changing status or assurance. The `ST-999` assertion still
   produces exactly one finding, and `node scripts/standards.mjs audit .` on this repository now
   reports fourteen unverifiable delegations where it previously reported none.
 - **Dependencies:** the discrepancy categories in [`03`](03-standards-audit-cli.md) — satisfied; this

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -8,8 +8,8 @@ Before the plan repair, eleven GitHub issues, four recorded rule rejections, and
 deferred design questions existed as a parallel obligation system that no plan item claimed. A plan
 that omits its own open work will always report itself complete.
 
-**Every open GitHub issue is claimed by exactly one plan item.** Sixteen are open. Ten are claimed
-here — #1, #4, #5, #6, #7, #8, #19, #21, #32, #38 — and the other six are claimed where their subject
+**Every open GitHub issue is claimed by exactly one plan item.** Fifteen are open. Nine are claimed
+here — #1, #4, #6, #7, #8, #19, #21, #32, #38 — and the other six are claimed where their subject
 lives: [#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
 [#3](06-must-never-standards.md) by the detectors, and
 [#2, #9 and #16](07-distributed-validation-and-ci.md) by the adoption path. None is rejected as
@@ -780,26 +780,100 @@ that approval deliberately does not cover.
 
 ### Decouple `Tracked by` resolution from one backlog implementation
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-24 at `d53a627`, established by the full repository gate at that
+  commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and `audit` all passed, 358 tests, 0
+  failures. `validate` at that content is unchanged from `develop` at `be30c081` — 23 passed, 4
+  failed, 23 skipped, with the four failures being the four standing recorded human rejections and no
+  rule changing status or assurance. This row is the commit after `d53a627` and changes only this
+  section.
 - **Tracked by:** GitHub issue [#5](https://github.com/mikeycdavis/EngineeringStandards/issues/5)
-- **Evidence:** open as of 2026-08-11; the resolver in
-  [`scripts/standards.mjs`](../../scripts/standards.mjs) builds
-  `artifacts/backlog/items/<ID>.md` directly, and the id pattern it accepts is `[A-Z]{2}-\d+`.
+- **Evidence:** opened 2026-08-11; measured and closed 2026-08-24. The recorded gap was accurate at
+  `develop`: the resolver in [`scripts/standards.mjs`](../../scripts/standards.mjs) built
+  `artifacts/backlog/items/<ID>.md` directly and accepted only `[A-Z]{2}-\d+`. **Missing behaviour,
+  not stale wording — and on two axes, of which the issue records one.**
+
+  1. **The recorded axis.** The backlog root was hardcoded, so a project keeping its backlog anywhere
+     else had every tracked item reported dangling: a wall of red asserting *untracked work is
+     presented as tracked* about work that was tracked.
+  2. **The unrecorded axis, which is worse.** The resolver answered a three-valued question with a
+     boolean. *The authority was found and does not contain this id* and *there was no authority to
+     ask* arrived at the same branch — and a reference it could not parse at all, such as a GitHub
+     issue or a Jira key, matched nothing, was dropped, and left the item falling through to its own
+     cached `Status`. Silence read as agreement.
+
+  **This repository demonstrated the second axis on itself.** It has no `artifacts/backlog/` at all,
+  and **fourteen** plan items across sections 03, 04, 06, 07 and this one carry
+  `Tracked by: GitHub issue …`. `node scripts/standards.mjs audit .` at `be30c081` returned three
+  informational findings and nothing else — a clean plan reported over fourteen items whose authority
+  the run had never contacted, and indistinguishable from a correct clean result. That is the trap
+  [`03`](03-standards-audit-cli.md) already names one level up, in its own words: an implementation
+  that *"returns zero findings on precisely the repositories that follow the standard most
+  completely."*
 - **Purpose:** Plan validation is coupled to one backlog storage implementation. A project tracking
   work in GitHub issues, Jira, or any other system cannot have its `Tracked by` pointers verified —
   which this very plan demonstrates: the items in
   [`04`](04-compliance-and-policy-system.md) and [`07`](07-distributed-validation-and-ci.md) point at
   GitHub issues and are checked by hand.
 - **Deliverables:** a resolution seam, so the storage layout is a property of the project rather than
-  of the checker.
+  of the checker. Delivered as [`scripts/tracking.mjs`](../../scripts/tracking.mjs), answering with
+  `resolved`, `missing` or `unverifiable` and no fourth outcome.
+
+  **Built on repository discovery, and deliberately not on the mechanism the issue asked for.** Issue
+  #5's *Expected direction* proposes declaring a backlog root in `project-policy.yml`. That is the
+  option [ADR 0008](../adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)
+  rejects by name: *detectors also serve `audit`, which takes no policy at all*
+  ([ADR 0004](../adr/0004-audit-and-validate-are-separate-commands.md)), so *sourcing evidence
+  discovery from configuration would give the two commands different answers about what a repository
+  contains*. `detectPlanDiscrepancies` is an audit detector, so the objection applies exactly.
+  Conventional layouts are discovered from the repository instead — the shape `adrDirs` already uses
+  in `scripts/standards.mjs` for the same problem, where three ADR locations are accepted rather than
+  one imposed. **Recorded here rather than implemented silently**: an issue's proposed mechanism
+  being overruled by a standing decision is a thing to write down, not to route around.
+
+  **An id-shaped reference is not always local, and this is where the two outcomes divide.**
+  `PROJ-1234` and `ST-014` are the same shape, so syntax cannot separate a Jira key from a backlog
+  id. What separates them is whether a local authority exists to consult. With a backlog discovered,
+  an id it does not contain is `missing` — the authority was asked and answered. With none
+  discovered, the same string is `unverifiable`, because reporting it absent from a backlog that does
+  not exist would assert something nothing checked. The residual case is stated rather than hidden: a
+  project using Jira keys *and* keeping a local backlog will see its Jira references reported
+  `missing`, which is honest — the local authority genuinely was consulted — and the fix for it is an
+  adapter contract for reachable external systems, a larger decision than this seam.
+
+  **The `unverifiable` finding carries no `rule`, and that is load-bearing.** A finding bound to
+  `planning.plan-code-consistency` fails that rule outright, whatever its own severity. Binding this
+  one would make a repository non-compliant with *a completed plan item's deliverables exist* because
+  it tracks work in GitHub issues — converting a limit on what the run could reach into a claim that
+  the plan is inconsistent, which is the exact inversion the finding exists to stop. It is reported
+  at `warning`, scores nothing in either direction, and this repository's `validate` result is
+  therefore byte-identical in shape to `develop`'s. A new catalog rule is the other way to carry it,
+  and that is a versioning decision with adopter consequences rather than a detail of this fix:
+  **recorded as available and not taken.**
 - **Acceptance Criteria:**
-  - An unresolvable reference is still an `error` finding. This must not become a way to make
-    dangling references stop being reported — that check is the whole point of Standard 44 R7.
-  - The existing `delegated` fixture, including its `ST-999` dangling reference, behaves unchanged.
-  - A reference to a system the resolver cannot reach is reported as *unverifiable*, not as *valid*.
-    An unreachable tracker is the search-mechanism case of Standard 44 R12.
-- **Verification:** `npm test`; the `ST-999` assertion still produces exactly one finding.
-- **Dependencies:** the discrepancy categories in [`03`](03-standards-audit-cli.md).
+
+  | # | Criterion | Established by |
+  |---|---|---|
+  | 1 | An unresolvable reference is still an `error` finding — this must not become a way to stop reporting dangling references (Standard 44 R7) | `an id-shaped reference the discovered backlog does not contain is missing, not unverifiable`, and the unchanged `a backlog id that resolves to nothing is reported` in `test/audit.test.mjs`, which still asserts exactly one finding at severity `error` |
+  | 2 | The existing `delegated` fixture, including its `ST-999` dangling reference, behaves unchanged | All 60 tests in `test/audit.test.mjs` pass untouched, including the four that drive that fixture. `the conventional layout resolves, exactly as it did when the path was hardcoded` holds the default at the seam level |
+  | 3 | A reference to a system the resolver cannot reach is reported as *unverifiable*, not as *valid* (Standard 44 R12) | `a GitHub issue reference is unverifiable — neither valid nor dangling`, `an unrecognised or Jira-style reference is unverifiable when no backlog was discovered`, and — against the repository that had the defect — `this repository's externally tracked items produce evidence rather than silence` |
+
+  Two further falsifiers hold properties nothing in the criteria names but the design depends on.
+  `audit and validate resolve the same references identically` runs both commands against this
+  repository and compares the finding's evidence, message and severity, so ADR 0004's separation is
+  asserted end to end rather than argued from both calling one function. `the seam locates the item
+  and deliberately does not read it` keeps reading with the caller, so a backlog item passes through
+  the same read accounting as every other file the run opens rather than becoming a second,
+  unbudgeted way into the repository — the evidence-surface hole the exclusions item above closed,
+  reopened one module along.
+
+  All eleven were written before `scripts/tracking.mjs` existed and were run against a missing
+  module first.
+- **Verification:** `npm test`; 358 tests, 0 failures at `d53a627`. The `ST-999` assertion still
+  produces exactly one finding, and `node scripts/standards.mjs audit .` on this repository now
+  reports fourteen unverifiable delegations where it previously reported none.
+- **Dependencies:** the discrepancy categories in [`03`](03-standards-audit-cli.md) — satisfied; this
+  extends `plan-code-discrepancies` rather than replacing it, and the delegated-liveness trap that
+  item records is now guarded in both directions rather than one.
 
 ### Unavailable content evidence must never be read as content
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -780,12 +780,22 @@ that approval deliberately does not cover.
 
 ### Decouple `Tracked by` resolution from one backlog implementation
 
-- **Status:** COMPLETE — 2026-08-24 at `d53a627`, established by the full repository gate at that
-  commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and `audit` all passed, 358 tests, 0
-  failures. `validate` at that content is unchanged from `develop` at `be30c081` — 23 passed, 4
+- **Status:** COMPLETE — 2026-08-24 at `85787e6`, established by the full repository gate at that
+  commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and `audit` all passed, 361 tests, 0
+  failures, 0 skipped. `validate` at that content is unchanged from `develop` at `be30c081` — 23 passed, 4
   failed, 23 skipped, with the four failures being the four standing recorded human rejections and no
   rule changing status or assurance. This row is the commit after `d53a627` and changes only this
   section.
+
+  **The seam was correct and the check that guards it was not.** GitHub's `test` job failed at
+  `ef87565` where six local gate runs had passed: `scripts/links.mjs` listed `scripts/`, then opened
+  each file, and `test/invocation-ownership.test.mjs` deleted its dot-prefixed negative control in
+  between. The scan was not honouring a convention the repository already keeps — that control is
+  dot-prefixed precisely so nothing treats it as a source file. Dot-prefixed entries are now out of
+  scope, at no cost in coverage (1562 links across 131 files before and after), and a file that
+  cannot be opened is recorded as `unread` and named rather than crashing the run or vanishing from
+  it. Recorded here because a green gate obtained after CI found what six local runs missed is worth
+  saying out loud.
 - **Tracked by:** GitHub issue [#5](https://github.com/mikeycdavis/EngineeringStandards/issues/5)
 - **Evidence:** opened 2026-08-11; measured and closed 2026-08-24. The recorded gap was accurate at
   `develop`: the resolver in [`scripts/standards.mjs`](../../scripts/standards.mjs) built
@@ -868,7 +878,7 @@ that approval deliberately does not cover.
 
   All eleven were written before `scripts/tracking.mjs` existed and were run against a missing
   module first.
-- **Verification:** `npm test`; 358 tests, 0 failures at `d53a627`. The `ST-999` assertion still
+- **Verification:** `npm test`; 361 tests, 0 failures, 0 skipped at `85787e6`. The `ST-999` assertion still
   produces exactly one finding, and `node scripts/standards.mjs audit .` on this repository now
   reports fourteen unverifiable delegations where it previously reported none.
 - **Dependencies:** the discrepancy categories in [`03`](03-standards-audit-cli.md) — satisfied; this

--- a/scripts/links.mjs
+++ b/scripts/links.mjs
@@ -78,8 +78,23 @@ import path from "node:path";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-/** Directories no scan descends into. */
-const SKIP = new Set([".git", "node_modules", "fixtures", ".vs", "dist", "coverage"]);
+/** Directories no scan descends into, beside every dot-prefixed entry. */
+const SKIP = new Set(["node_modules", "fixtures", "dist", "coverage"]);
+
+/**
+ * Dot-prefixed entries are out of scope, and this is a scope decision rather than an error swallow.
+ *
+ * The repository already uses dot-prefixing to mean *not a file this project audits*.
+ * `test/invocation-ownership.test.mjs` relies on it: its negative control is written to
+ * `scripts/.shared-cache-control.mjs` and removed in a `finally`, dot-prefixed precisely so nothing
+ * treats it as a source file. This scan did treat it as one — the test runner runs files
+ * concurrently, so between listing `scripts/` and reading it the control was deleted, and the scan
+ * died on ENOENT. It passed locally and lost the race in CI, which is the worst way for it to fail.
+ *
+ * Skipping the convention the repository already keeps costs nothing measurable: no `.md` or `.mjs`
+ * file under a dot name or a dot directory is in scope today, so the link count is unchanged.
+ */
+const hidden = (name) => name.startsWith(".");
 
 /** A Markdown inline link whose target is relative — not a URL, not a bare fragment. */
 const LINK = /\]\((?!https?:|mailto:|#)([^)\s]+)\)/g;
@@ -145,6 +160,7 @@ async function sources(root) {
   const walk = async (dir) => {
     for (const entry of (await readdir(dir, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
       const full = path.join(dir, entry.name);
+      if (hidden(entry.name)) continue;
       if (entry.isDirectory()) {
         if (!SKIP.has(entry.name)) await walk(full);
       } else if (entry.name.endsWith(".md") || entry.name.endsWith(".mjs")) {
@@ -197,9 +213,20 @@ export async function checkLinks(root = ROOT) {
 
   let checked = 0;
   const broken = [];
+  const unread = [];
 
   for (const file of files) {
-    const text = await readFile(path.join(root, file), "utf8");
+    // A file can disappear between being listed and being opened. Reported rather than skipped and
+    // rather than fatal: this check's whole claim is that every link resolves, and a file it could
+    // not open is one it did not check — the same distinction the evidence surface draws between a
+    // file that was searched and one that was never read (Standard 44 R12).
+    let text;
+    try {
+      text = await readFile(path.join(root, file), "utf8");
+    } catch (error) {
+      unread.push({ file, reason: error.code ?? String(error) });
+      continue;
+    }
     const destination = layout.destinationOf.get(file);
     const rule = destination ? "template" : "ordinary";
     // A template is read where init put it, so its links resolve from there. Everything else
@@ -226,7 +253,7 @@ export async function checkLinks(root = ROOT) {
     }
   }
 
-  return { checked, broken, files: files.length };
+  return { checked, broken, unread, files: files.length };
 }
 
 async function main(argv) {
@@ -237,6 +264,7 @@ async function main(argv) {
     console.log(JSON.stringify(result, null, 2));
   } else if (result.broken.length === 0) {
     console.log(`OK — ${result.checked} relative links across ${result.files} files all resolve.`);
+    for (const u of result.unread) console.log(`  (not read: ${u.file} — ${u.reason})`);
   } else {
     console.log(`${result.broken.length} of ${result.checked} relative links do not resolve:\n`);
     for (const b of result.broken) {
@@ -245,6 +273,9 @@ async function main(argv) {
       console.log(`    resolved ${b.resolved}  (${b.rule} rule)\n`);
     }
   }
+  // Unread files do not fail the run on their own — nothing about them says a link is broken — but
+  // they are never silent, because a clean result over files nobody opened is the shape this
+  // repository names most often.
   return result.broken.length === 0 ? 0 : 1;
 }
 

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -22,6 +22,7 @@ import { loadCatalog, assertBindings, coverage } from "./catalog.mjs";
 import { evaluate, envelope } from "./compliance.mjs";
 import { plan as planInit, apply as applyInit, render as renderInit } from "./init.mjs";
 import { parseYaml } from "./yaml.mjs";
+import { discoverBacklog, resolveTracked, OUTCOME } from "./tracking.mjs";
 import { validate } from "./jsonschema.mjs";
 import {
   classifyFreshness,
@@ -1578,8 +1579,15 @@ async function detectPlanDiscrepancies(files, contents, run) {
   if (executable.length === 0) return;
 
   const dangling = [];
+  const unverifiable = [];
   const missingDeliverables = [];
   const incomplete = [];
+
+  // Discovered once per run, not per item: the backlog a repository has does not change between two
+  // plan items, and asking the filesystem the same question forty times would be forty chances for
+  // two items to get different answers. Discovery reads the repository rather than a policy, so
+  // `audit` — which takes no policy at all (ADR 0004) — reaches the same result as `validate`.
+  const backlog = discoverBacklog(root);
 
   for (const item of executable) {
     for (const field of PLAN_FIELDS) {
@@ -1594,18 +1602,36 @@ async function detectPlanDiscrepancies(files, contents, run) {
     //
     // `Tracked by` is a separate field: a reference to another system is not a status (Standard 8
     // R2). The legacy `Status: tracked as <id>` form is still read so older plans keep working.
-    const legacyTracked = String(item.fields.get("Status") ?? "").match(/tracked as\s+([A-Z]{2}-\d+)/i);
-    const trackedBy = (item.fields.get("Tracked by") ?? item.fields.get("TrackedBy") ?? "").match(/([A-Z]{2}-\d+)/i);
-    const tracked = trackedBy ?? legacyTracked;
-    if (tracked) {
-      const id = tracked[1].toUpperCase();
-      const itemPath = path.join(root, "artifacts/backlog/items", `${id}.md`);
-      if (!existsSync(itemPath)) {
-        dangling.push(`${item.file} :: ${item.title} -> ${id}`);
+    const legacyTracked = String(item.fields.get("Status") ?? "").match(/tracked as\s+(.+)$/i);
+    const declared = String(
+      item.fields.get("Tracked by") ?? item.fields.get("TrackedBy") ?? (legacyTracked ? legacyTracked[1] : ""),
+    ).trim();
+
+    if (declared) {
+      // Three outcomes, not a boolean. `scripts/tracking.mjs` separates *the authority was asked and
+      // does not have this* from *there was no authority to ask*, which the previous existsSync
+      // check collapsed into one branch — and which is the difference between a defect in the plan
+      // and a limit on what this run could establish (Standard 44 R12).
+      const ref = resolveTracked(declared, { root, backlog });
+
+      if (ref.outcome === OUTCOME.missing) {
+        dangling.push(`${item.file} :: ${item.title} -> ${ref.id} (${ref.reason})`);
         continue;
       }
-      const backlogText = (await readText(itemPath)).text;
-      status = canonicalStatus((backlogText.match(/^status:\s*(\S+)/im) ?? [, "unknown"])[1]);
+
+      if (ref.outcome === OUTCOME.unverifiable) {
+        // Recorded, and deliberately NOT resolved into a status. The plan says this item's liveness
+        // lives elsewhere; this run did not go there. Falling through to the item's own Status — as
+        // the previous implementation silently did for every reference it could not parse — turns
+        // "I did not ask" into "the authority agrees".
+        unverifiable.push(
+          `${item.file} :: ${item.title} -> ${declared} (${ref.reason}); the item's own ` +
+            `Status ${canonicalStatus(item.fields.get("Status"))} is a cached copy this run did not validate`,
+        );
+      } else {
+        const backlogText = (await readText(ref.path)).text;
+        status = canonicalStatus((backlogText.match(/^status:\s*(\S+)/im) ?? [, "unknown"])[1]);
+      }
     }
 
     if (status !== "COMPLETE") continue;
@@ -1632,6 +1658,30 @@ async function detectPlanDiscrepancies(files, contents, run) {
       message:
         `${dangling.length} plan item(s) delegate status to a backlog id that does not exist. ` +
         "Untracked work is presented as tracked.",
+      standardRef: R.plan,
+    });
+  }
+  if (unverifiable.length) {
+    // Carries NO `rule`, and that is the load-bearing part of this finding rather than an omission.
+    //
+    // A finding bound to `planning.plan-code-consistency` fails that rule outright, whatever its own
+    // severity. Binding this one would mean a repository is non-compliant with "a completed plan
+    // item's deliverables exist" because it tracks work in GitHub issues — converting a limit on
+    // what the run could reach into a claim that the plan is inconsistent, which is precisely the
+    // inversion this finding exists to stop. Not-knowing is reported as not-knowing and scores
+    // nothing, in either direction (Standard 44 R12, ADR 0008).
+    //
+    // A new catalog rule would be the other way to carry it, and that is a versioning decision with
+    // adopter consequences rather than a detail of this fix. Recorded as available and not taken.
+    addFinding({
+      id: "delegated-liveness-unverifiable",
+      category: "Plan/code discrepancies",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: unverifiable,
+      message:
+        `${unverifiable.length} plan item(s) delegate status to an authority this run did not consult. ` +
+        "Their own Status is a cached copy, and this run neither confirms nor contradicts it.",
       standardRef: R.plan,
     });
   }

--- a/scripts/tracking.mjs
+++ b/scripts/tracking.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Resolve a plan item's delegated-liveness reference, and say which of three things happened.
+ *
+ * WHY THIS EXISTS. `detectPlanDiscrepancies` built one path — `artifacts/backlog/items/<ID>.md` —
+ * and asked one question of it: does the file exist. That made a storage layout part of the
+ * validation semantics, and it answered a three-valued question with a boolean, so *reached the
+ * authority and found nothing* and *never reached an authority at all* arrived at the same branch.
+ *
+ * The second half is the quiet one, and it is live in this repository. Its plan delegates liveness
+ * to GitHub issues; those references match no backlog-id pattern, so the reference was dropped and
+ * the item fell through to its own cached status. The audit then reported a clean plan while more
+ * than a dozen items pointed at an authority it had never contacted. Silence read as agreement.
+ *
+ * THREE OUTCOMES, NAMED, WITH NO FOURTH.
+ *
+ *   resolved      An authority was found and answered. Its status is the item's real status.
+ *   missing       An authority was found and does NOT contain this id. A defect in the plan.
+ *   unverifiable  No authority this run can consult. Not a defect, and NOT a pass.
+ *
+ * The distinction between the last two is the whole point (Standard 44 R12): a run that cannot
+ * reach an authority must say so, never convert not-knowing into a fact about the project. Reporting
+ * an external reference as `missing` would accuse the plan of a dangling pointer on the strength of
+ * not having looked; reporting it as resolved would be worse.
+ *
+ * DISCOVERY, NOT CONFIGURATION — AND THIS IS DELIBERATE AGAINST THE ISSUE THAT ASKED FOR IT.
+ * Issue #5 proposes declaring a backlog root in `project-policy.yml`. That is the option
+ * [ADR 0008](../artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)
+ * already rejected by name: detectors also serve `audit`, which takes no policy at all
+ * ([ADR 0004](../artifacts/adr/0004-audit-and-validate-are-separate-commands.md)), so sourcing
+ * evidence discovery from configuration would give the two commands different answers about what a
+ * repository contains. Layouts are therefore discovered from the repository, which both commands see
+ * identically — the same shape `adrDirs` already uses in `scripts/standards.mjs` for the same
+ * problem, where three conventional ADR locations are accepted rather than one being imposed.
+ *
+ * WHY AN ID-SHAPED REFERENCE IS NOT ALWAYS LOCAL. A Jira key is written `PROJ-1234` and a backlog id
+ * is written `ST-014`; syntax cannot separate them. What separates them is whether a local authority
+ * exists to consult. With a backlog discovered, an id it does not contain is `missing` — the
+ * authority was asked. With none discovered, the same string is `unverifiable`, because reporting it
+ * absent from a backlog that does not exist would be asserting something nothing checked.
+ *
+ * The consequence is worth stating plainly: a project using Jira keys AND keeping a local backlog
+ * will see its Jira references reported `missing`. That is honest rather than ideal — the local
+ * authority genuinely was consulted and genuinely does not contain them — and the fix is an adapter
+ * contract for reachable external systems, which is a larger decision than this seam.
+ *
+ * No third-party dependencies, matching scripts/standards.mjs.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The three things that can happen to a reference. Exported as a frozen vocabulary rather than bare
+ * strings so a caller cannot invent a fourth outcome by typo and have it silently mean "not
+ * resolved" — which is how the boolean version of this failed.
+ */
+export const OUTCOME = Object.freeze({
+  resolved: "resolved",
+  missing: "missing",
+  unverifiable: "unverifiable",
+});
+
+/**
+ * Conventional backlog layouts, in the order they are searched.
+ *
+ * Ordered most specific first: `artifacts/backlog/items` is what the `backlog` skill writes and what
+ * the hardcoded path assumed, so the existing default is found before any alternative and its
+ * behaviour cannot change. The bare directories come last because a repository with
+ * `backlog/items/` also has `backlog/`, and the item files live in the deeper one.
+ */
+export const BACKLOG_LAYOUTS = Object.freeze([
+  "artifacts/backlog/items",
+  "docs/backlog/items",
+  "backlog/items",
+  "artifacts/backlog",
+  "backlog",
+]);
+
+/** A backlog item id: two or more letters, a hyphen, digits. `ST-014`, `EP-7`, `PROJ-1234`. */
+const ID = /\b([A-Z]{2,})-(\d+)\b/;
+
+/** Systems whose name in the reference is enough to know this run cannot reach them. */
+const EXTERNAL_SYSTEMS = [
+  [/\bgithub\b/i, "GitHub"],
+  [/\bgitlab\b/i, "GitLab"],
+  [/\bjira\b/i, "Jira"],
+  [/\blinear\b/i, "Linear"],
+  [/\bbitbucket\b/i, "Bitbucket"],
+  [/\bazure\s*devops\b|\bado\b/i, "Azure DevOps"],
+];
+
+/**
+ * Which kind of reference this is, decided from the text alone.
+ *
+ * Deliberately independent of the filesystem. If classification consulted the repository, two
+ * commands reading the same plan could disagree about what a reference even IS before either had
+ * resolved anything, and the seam would have reintroduced the divergence it exists to prevent.
+ */
+export function classifyReference(raw) {
+  const text = String(raw ?? "").trim();
+  if (!text) return { kind: "unrecognised", id: null, system: null };
+
+  // A URL is conclusive: whatever it points at, it is not a file in this repository.
+  const url = text.match(/https?:\/\/([^/\s)]+)/i);
+  if (url) {
+    const named = EXTERNAL_SYSTEMS.find(([re]) => re.test(text) || re.test(url[1]));
+    return { kind: "external", id: null, system: named ? named[1] : url[1] };
+  }
+
+  const named = EXTERNAL_SYSTEMS.find(([re]) => re.test(text));
+  if (named) return { kind: "external", id: null, system: named[1] };
+
+  // `#5` is an issue number in every tracker that uses them and is never a backlog id.
+  if (/#\d+/.test(text)) return { kind: "external", id: null, system: "issue tracker" };
+
+  const id = text.match(ID);
+  if (id) return { kind: "local-id", id: `${id[1].toUpperCase()}-${id[2]}`, system: null };
+
+  return { kind: "unrecognised", id: null, system: null };
+}
+
+/**
+ * Find the repository's backlog, if it has one.
+ *
+ * A layout counts only when it actually contains an id-shaped file. An empty `backlog/` directory is
+ * not an authority, and treating it as one would turn every reference into `missing` — the wall of
+ * red this item exists to remove, produced by a different route.
+ *
+ * `searched` is returned whether or not anything was found, because a discovery that cannot say
+ * where it looked is indistinguishable from one that looked nowhere.
+ */
+export function discoverBacklog(root) {
+  for (const dir of BACKLOG_LAYOUTS) {
+    const full = path.join(root, dir);
+    if (!existsSync(full)) continue;
+    let entries;
+    try {
+      entries = readdirSync(full);
+    } catch {
+      continue; // unreadable is not "absent", but it is equally not an authority this run can use
+    }
+    if (entries.some((f) => f.endsWith(".md") && ID.test(path.basename(f, ".md")))) {
+      return { dir, searched: [...BACKLOG_LAYOUTS] };
+    }
+  }
+  return { dir: null, searched: [...BACKLOG_LAYOUTS] };
+}
+
+/**
+ * Resolve one reference against a discovered backlog.
+ *
+ * Returns `{ outcome, id, system, path, reason }`. `path` is set only for `resolved`, and the file
+ * is deliberately NOT read here: the caller owns reading, so the item passes through the same read
+ * accounting as every other file the run opens and cannot slip past the evidence budget.
+ */
+export function resolveTracked(raw, { root, backlog }) {
+  const { kind, id, system } = classifyReference(raw);
+
+  if (kind === "external") {
+    return {
+      outcome: OUTCOME.unverifiable,
+      id: null,
+      system,
+      path: null,
+      reason: `the reference names ${system}, which this run does not contact`,
+    };
+  }
+
+  if (kind === "unrecognised") {
+    return {
+      outcome: OUTCOME.unverifiable,
+      id: null,
+      system: null,
+      path: null,
+      reason: "the reference names no system this run can resolve",
+    };
+  }
+
+  if (!backlog.dir) {
+    // Id-shaped, and nothing to ask. Saying `missing` here would assert absence from an authority
+    // that does not exist; the honest answer is that no authority was available.
+    return {
+      outcome: OUTCOME.unverifiable,
+      id,
+      system: null,
+      path: null,
+      reason: `no backlog was found in this repository (searched ${backlog.searched.join(", ")})`,
+    };
+  }
+
+  const file = path.join(root, backlog.dir, `${id}.md`);
+  if (!existsSync(file)) {
+    return {
+      outcome: OUTCOME.missing,
+      id,
+      system: null,
+      path: null,
+      reason: `${backlog.dir} exists and does not contain ${id}.md`,
+    };
+  }
+
+  return { outcome: OUTCOME.resolved, id, system: null, path: file, reason: null };
+}

--- a/test/links.test.mjs
+++ b/test/links.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -239,6 +239,64 @@ test("a deliberately broken ordinary relative link is caught", async () => {
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+// --- Files that are not there when the scan reaches them ----------------------------------------
+
+test("a dot-prefixed file beside real sources is not scanned", async () => {
+  // The failure this exists for. `test/invocation-ownership.test.mjs` writes its negative control to
+  // `scripts/.shared-cache-control.mjs` and removes it in a `finally`, dot-prefixed precisely so
+  // nothing treats it as a source file. This scan did, the runner deleted it between the listing and
+  // the read, and the check died on ENOENT — passing locally and losing the race in CI.
+  //
+  // Dot-prefixing is a convention the repository already keeps; honouring it costs no coverage,
+  // which the repository-wide count above holds.
+  const root = await scratch({
+    "scripts/real.mjs": " * see [a doc](../docs/gone.md)\n",
+    "scripts/.shared-cache-control.mjs": " * see [b doc](../docs/also-gone.md)\n",
+    "docs/.draft.md": "[c](nowhere.md)\n",
+  });
+  try {
+    const { broken } = await checkLinks(root);
+    assert.deepEqual(
+      broken.map((b) => b.file),
+      ["scripts/real.mjs"],
+      "only the undotted file may be scanned",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a file that cannot be opened is reported as unread rather than crashing the scan", async (t) => {
+  // The general case behind that specific one: listing and reading are two moments, and a file can
+  // stop existing in between. Neither fatal nor silent — a clean result over files nobody opened is
+  // the shape this repository names most often, so the file is named and the run continues.
+  const root = await scratch({ "docs/real.md": "# real\n", "docs/index.md": "[ok](real.md)\n" });
+  try {
+    try {
+      await symlink(path.join(root, "docs/absent-target.md"), path.join(root, "docs/dangling.md"));
+    } catch {
+      // Windows refuses symlink creation without privilege, the same reason the installed-bin cases
+      // in test/invocation-ownership.test.mjs skip. Skipped with a reason rather than passing
+      // quietly, because a check that silently does nothing is what this file exists to prevent.
+      t.skip("this host refuses symlink creation; the unread path runs on the Linux image");
+      return;
+    }
+    const { broken, unread, checked } = await checkLinks(root);
+    assert.deepEqual(broken, [], "an unreadable file is not a broken link");
+    assert.deepEqual(unread.map((u) => u.file), ["docs/dangling.md"]);
+    assert.equal(checked, 1, "the readable file must still have been checked");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a healthy repository reports nothing unread", async () => {
+  // The other half of the pair: `unread` must be part of the answer even when it is empty, or the
+  // field would only ever appear in the failing case and nothing would notice it going missing.
+  const { unread } = await checkLinks(ROOT);
+  assert.deepEqual(unread, []);
 });
 
 // --- Scope of the scan --------------------------------------------------------------------------

--- a/test/tracking.test.mjs
+++ b/test/tracking.test.mjs
@@ -1,0 +1,196 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { discoverBacklog, classifyReference, resolveTracked, OUTCOME, BACKLOG_LAYOUTS } from "../scripts/tracking.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** A miniature repository containing only what a resolution question needs. */
+async function scratch(files = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "tracking-"));
+  for (const [rel, text] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, text, "utf8");
+  }
+  return root;
+}
+
+const resolveIn = (root, raw) => resolveTracked(raw, { root, backlog: discoverBacklog(root) });
+
+// --- 1 & 2. Discovery replaces the hardcoded path, and finds more than one layout ---------------
+
+test("the conventional layout resolves, exactly as it did when the path was hardcoded", async () => {
+  // Issue #5's second acceptance criterion in miniature: the default must not move. Everything else
+  // here is new behaviour; this is the one that must be indistinguishable from what shipped.
+  const root = await scratch({ "artifacts/backlog/items/ST-001.md": "---\nstatus: done\n---\n" });
+  try {
+    const r = resolveIn(root, "ST-001");
+    assert.equal(r.outcome, OUTCOME.resolved);
+    assert.equal(r.id, "ST-001");
+    assert.equal(r.path, path.join(root, "artifacts/backlog/items/ST-001.md"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an alternative supported layout resolves, with no policy consulted", async () => {
+  // The defect issue #5 was opened for. A project that keeps its backlog somewhere else got every
+  // tracked item reported dangling — a wall of red saying "untracked work presented as tracked"
+  // about work that was tracked. Discovery is a repository fact, so `audit`, which takes no policy
+  // at all (ADR 0004), reaches the same answer as `validate`.
+  const root = await scratch({ "backlog/items/ST-007.md": "---\nstatus: in-progress\n---\n" });
+  try {
+    const backlog = discoverBacklog(root);
+    assert.equal(backlog.dir, "backlog/items");
+    const r = resolveTracked("ST-007", { root, backlog });
+    assert.equal(r.outcome, OUTCOME.resolved);
+    assert.equal(r.path, path.join(root, "backlog/items/ST-007.md"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("discovery reports where it looked, and every declared layout is a real candidate", () => {
+  // A discovery that cannot say what it searched is indistinguishable from one that searched
+  // nothing, which is the shape Standard 44 R12 exists to forbid.
+  const backlog = discoverBacklog(ROOT);
+  assert.deepEqual(backlog.searched, BACKLOG_LAYOUTS);
+  assert.equal(backlog.dir, null, "this repository has no backlog; discovery must say so plainly");
+});
+
+// --- 3. Present backlog, absent item -------------------------------------------------------------
+
+test("an id-shaped reference the discovered backlog does not contain is missing, not unverifiable", async () => {
+  // The distinction the three outcomes exist to draw. A backlog WAS found, so the authority was
+  // consulted and gave an answer: the item is not there. That is a defect in the plan, and
+  // downgrading it to "cannot tell" would be the regression this item's first criterion forbids.
+  const root = await scratch({ "artifacts/backlog/items/ST-001.md": "---\nstatus: done\n---\n" });
+  try {
+    const r = resolveIn(root, "ST-999");
+    assert.equal(r.outcome, OUTCOME.missing);
+    assert.equal(r.id, "ST-999");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- 4 & 5. References to an authority this run did not consult ----------------------------------
+
+test("a GitHub issue reference is unverifiable — neither valid nor dangling", async () => {
+  // Today this matches no pattern, so the reference is dropped and the item falls through to its own
+  // cached status. That silently converts "I did not ask the authority" into "the authority agrees",
+  // which is the quiet direction and the worse one.
+  const root = await scratch({ "artifacts/backlog/items/ST-001.md": "---\nstatus: done\n---\n" });
+  try {
+    const r = resolveIn(root, "GitHub issue [#5](https://github.com/mikeycdavis/EngineeringStandards/issues/5)");
+    assert.equal(r.outcome, OUTCOME.unverifiable, "an external reference must not be reported as missing");
+    assert.equal(r.system, "GitHub");
+    assert.ok(r.reason.length > 0, "an unverifiable result must say what it could not reach");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an unrecognised or Jira-style reference is unverifiable when no backlog was discovered", async () => {
+  // `PROJ-1234` is shaped exactly like a backlog id, so syntax alone cannot separate a Jira key from
+  // a local item. What separates them is whether a local authority exists to consult: with none
+  // discovered, reporting `missing` would assert the item is absent from a backlog that does not
+  // exist. Not knowing is represented as not knowing (Standard 44 R12).
+  const root = await scratch({ "README.md": "# no backlog here\n" });
+  try {
+    assert.equal(resolveIn(root, "PROJ-1234").outcome, OUTCOME.unverifiable);
+    assert.equal(resolveIn(root, "tracked in the spreadsheet").outcome, OUTCOME.unverifiable);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the seam locates the item and deliberately does not read it", async () => {
+  // The read stays with the caller so a backlog item passes through the same read accounting as
+  // every other file the run opens. A seam that opened files itself would be a second, unbudgeted
+  // way into the repository — the evidence-surface hole issue #7 closed, reopened one module along.
+  const root = await scratch({ "artifacts/backlog/items/ST-001.md": "---\nstatus: done\n---\n" });
+  try {
+    const r = resolveIn(root, "ST-001");
+    assert.equal(r.outcome, OUTCOME.resolved);
+    assert.ok(r.path, "a resolved reference must say where the item is");
+    assert.ok(!("status" in r), "the seam must not report a status it would have had to read");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("classification separates the two kinds of reference before anything is resolved", () => {
+  // The seam's own contract, tested without a filesystem: what KIND of thing this is must not
+  // depend on what happens to be on disk, or the two commands could classify differently.
+  assert.equal(classifyReference("ST-014").kind, "local-id");
+  assert.equal(classifyReference("**Tracked by:** ST-014").kind, "local-id");
+  assert.equal(classifyReference("GitHub issue [#5](https://github.com/x/y/issues/5)").kind, "external");
+  assert.equal(classifyReference("[PR #15](https://github.com/x/y/pull/15)").kind, "external");
+  assert.equal(classifyReference("JIRA-1 in Jira").kind, "external");
+  assert.equal(classifyReference("someone's notebook").kind, "unrecognised");
+});
+
+test("the outcome vocabulary is explicit rather than a nullable success", () => {
+  // Issue #5's defect is not only the hardcoded path — it is that the resolver answered a
+  // three-valued question with a boolean, so "could not reach" and "reached and found nothing"
+  // arrived at the same branch. Three named outcomes, and no fourth.
+  assert.deepEqual(Object.keys(OUTCOME).sort(), ["missing", "resolved", "unverifiable"]);
+  for (const v of Object.values(OUTCOME)) assert.equal(typeof v, "string");
+});
+
+
+// --- 6 & 7. Against this repository, through both commands --------------------------------------
+
+/** Run a CLI command against this repository and return its parsed report. */
+function cli(command) {
+  const r = spawnSync(process.execPath, [path.join(ROOT, "scripts/standards.mjs"), command, ROOT, "--json"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return JSON.parse(r.stdout);
+}
+
+const unverifiableIn = (report) =>
+  (report.findings ?? []).find((f) => f.id === "delegated-liveness-unverifiable") ?? null;
+
+test("this repository's externally tracked items produce evidence rather than silence", () => {
+  // The defect, measured on the repository that has it. This plan delegates liveness to GitHub
+  // issues; before this change those references matched no pattern, were dropped, and the audit
+  // reported a clean plan over items whose authority it had never contacted. Zero findings was the
+  // wrong answer, and it was indistinguishable from the right one.
+  const finding = unverifiableIn(cli("audit"));
+  assert.ok(finding, "the audit must report the references it could not resolve");
+  assert.ok(finding.evidence.length > 0);
+  assert.match(finding.message, /\d+ plan item\(s\) delegate status to an authority this run did not consult/);
+
+  // Every piece of evidence names the item, what it points at, and why that could not be reached.
+  for (const line of finding.evidence) {
+    assert.match(line, /^artifacts\/project-plan-breakdown\/.+ :: .+ -> /, `unreadable evidence: ${line}`);
+    assert.match(line, /the reference names .+, which this run does not contact/);
+    assert.match(line, /cached copy this run did not validate/);
+  }
+
+  // And it is a report, not a verdict: bound to no rule, so a repository is not made non-compliant
+  // for tracking work somewhere this run cannot read.
+  assert.equal(finding.rule ?? null, null, "an unconsulted authority must not fail a compliance rule");
+  assert.equal(finding.severity, "warning");
+});
+
+test("audit and validate resolve the same references identically", () => {
+  // The property the seam exists to guarantee, asserted end to end rather than argued from the fact
+  // that both call one function. Discovery reads the repository and never a policy, so the command
+  // that HAS no policy (ADR 0004) cannot see a different repository than the one that does.
+  const fromAudit = unverifiableIn(cli("audit"));
+  const fromValidate = unverifiableIn(cli("validate"));
+
+  assert.ok(fromAudit && fromValidate, "both commands must report the same detector's finding");
+  assert.deepEqual(fromValidate.evidence, fromAudit.evidence);
+  assert.equal(fromValidate.message, fromAudit.message);
+  assert.equal(fromValidate.severity, fromAudit.severity);
+});


### PR DESCRIPTION
**Issue #5 reports one defect. The measurement found two, and the unreported one is worse — and live in this repository.**

## The reported axis

`detectPlanDiscrepancies` built one path, `artifacts/backlog/items/<ID>.md`, and asked whether the file existed. A project keeping its backlog anywhere else had **every** tracked item reported dangling: a wall of red asserting *untracked work is presented as tracked* about work that was tracked.

## The unreported axis

The resolver answered a three-valued question with a boolean. *The authority was found and does not contain this id* and *there was no authority to ask* arrived at the same branch — and a reference it could not parse at all, a GitHub issue or a Jira key, matched nothing, was dropped, and left the item falling through to its own cached `Status`.

**Silence read as agreement, and this repository was carrying it.** It has no `artifacts/backlog/` at all, and **fourteen** plan items across sections 03, 04, 06, 07 and 08 carry `Tracked by: GitHub issue …`. At `be30c081`:

```
node scripts/standards.mjs audit .
  → 3 findings, all informational
```

A clean plan, reported over fourteen items whose authority the run had never contacted — and indistinguishable from a correct clean result. That is the trap section `03` already names one level up, in its own words: an implementation that *"returns zero findings on precisely the repositories that follow the standard most completely."*

## Three outcomes, and no fourth

`scripts/tracking.mjs`:

| Outcome | Meaning |
|---|---|
| `resolved` | An authority was found and answered. Its status is the item's real status. |
| `missing` | An authority was found and does **not** contain this id. A defect in the plan — unchanged severity, unchanged behaviour. |
| `unverifiable` | No authority this run can consult. Not a defect, and **not a pass**. |

## Discovery, not configuration — deliberately against what the issue asked for

Issue #5's *Expected direction* proposes declaring a backlog root in `project-policy.yml`. **ADR 0008 rejects that option by name:**

> Detectors also serve `audit`, which takes no policy at all (ADR 0004). Sourcing evidence discovery from configuration would give the two commands different answers about what a repository contains.

`detectPlanDiscrepancies` is an audit detector, so the objection applies exactly. Layouts are discovered from the repository instead — the shape `adrDirs` already uses one function along for the same problem, where three ADR locations are accepted rather than one imposed.

Recorded in §08 rather than routed around silently. An issue's proposed mechanism being overruled by a standing decision is a thing to write down; a reader finding discovery where the issue promised configuration should not have to reconstruct why.

## An id-shaped reference is not always local

`PROJ-1234` and `ST-014` are the same shape, so syntax cannot separate a Jira key from a backlog id. What separates them is whether a local authority exists to consult:

- backlog discovered, id absent → **`missing`** (the authority was asked and answered)
- no backlog discovered → **`unverifiable`** (reporting it absent from a backlog that does not exist would assert something nothing checked)

The residual case is stated rather than hidden: a project using Jira keys *and* keeping a local backlog will see its Jira references reported `missing`. That is honest — the local authority genuinely was consulted — and the fix is an adapter contract for reachable external systems, a larger decision than this seam.

## The `unverifiable` finding carries no `rule`, and that is load-bearing

A finding bound to `planning.plan-code-consistency` fails that rule outright, whatever its own severity. Binding this one would make a repository non-compliant with *a completed plan item's deliverables exist* **because it tracks work in GitHub issues** — converting a limit on what the run could reach into a claim that the plan is inconsistent, which is the exact inversion the finding exists to stop.

So it is reported at `warning`, bound to no rule, and scores nothing in either direction. A new catalog rule is the other way to carry it, and that is a versioning decision with adopter consequences rather than a detail of this fix: **recorded as available and not taken.**

## Verification

Full repository gate at exact head `ef87565`: `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — **all six passed, 358 tests, 0 failures.**

`validate` at this content is **unchanged from `develop`** at `be30c081`: 23 passed, 4 failed, 23 skipped, the four failures being the four standing recorded human rejections, with **no rule changing status or assurance**. No attestation went stale.

Eleven falsifiers, **written before `scripts/tracking.mjs` existed** and run against a missing module first:

- `the conventional layout resolves, exactly as it did when the path was hardcoded`
- `an alternative supported layout resolves, with no policy consulted`
- `an id-shaped reference the discovered backlog does not contain is missing, not unverifiable`
- `a GitHub issue reference is unverifiable — neither valid nor dangling`
- `an unrecognised or Jira-style reference is unverifiable when no backlog was discovered`
- `this repository's externally tracked items produce evidence rather than silence` — against the repository that had the defect
- `audit and validate resolve the same references identically` — runs both commands and compares the finding's evidence, message and severity, so ADR 0004's separation is asserted end to end rather than argued from both calling one function
- `the seam locates the item and deliberately does not read it` — reading stays with the caller, so a backlog item passes through the same read accounting as every other file the run opens rather than becoming a second, unbudgeted way in
- plus discovery reporting where it looked, classification independent of the filesystem, and the outcome vocabulary having no fourth member

**All 60 tests in `test/audit.test.mjs` pass untouched**, including the four driving the `delegated` fixture — `ST-999` still produces exactly one finding at severity `error`. That is acceptance criteria 1 and 2.

`validate` will be red on the four standing human rejections, as on `develop`'s own tip. That is expected repository state, not a PR defect, and nothing here touches `project-policy.yml`.

Closes #5
