### PR TITLE
A surface that named what it dropped and still called itself whole

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -8,8 +8,8 @@ Before the plan repair, eleven GitHub issues, four recorded rule rejections, and
 deferred design questions existed as a parallel obligation system that no plan item claimed. A plan
 that omits its own open work will always report itself complete.
 
-**Every open GitHub issue is claimed by exactly one plan item.** Fifteen are open. Nine are claimed
-here — #1, #4, #6, #7, #8, #19, #21, #32, #38 — and the other six are claimed where their subject
+**Every open GitHub issue is claimed by exactly one plan item.** Fourteen are open. Eight are
+claimed here — #1, #4, #6, #8, #19, #21, #32, #38 — and the other six are claimed where their subject
 lives: [#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
 [#3](06-must-never-standards.md) by the detectors, and
 [#2, #9 and #16](07-distributed-validation-and-ci.md) by the adoption path. None is rejected as
@@ -31,6 +31,13 @@ The counts in this paragraph previously read "seven here, four elsewhere" agains
 while naming five elsewhere. Six were claimed here and five elsewhere. Corrected above rather than
 left, because this paragraph is the only place the claim invariant is asserted, and an invariant
 whose own arithmetic does not hold cannot be used to check anything.
+
+**Amended again 2026-08-25:** **#7** closed on owner review of its seven-criterion contract, so it
+leaves both the open set and *claimed here*, taking fifteen/nine to fourteen/eight. Six elsewhere is
+unchanged. Written here rather than only in the item below, because this paragraph has now drifted
+silently three times, each time because a movement was recorded where the work happened and not
+where the count is asserted. The count is a shared counter with no owner, and every item that opens
+or closes has to touch it.
 
 **Amended 2026-08-24, from two drafts that were each wrong in a different direction.** Three
 independent movements landed against this paragraph within two days, and neither draft saw all of
@@ -395,11 +402,38 @@ that approval deliberately does not cover.
 
 ### Fix the audit's project-level exclusions
 
-- **Status:** IN_REVIEW — **the seventh criterion is met at `f564d6c`; whether that closes this
+- **Status:** COMPLETE — **closed 2026-08-25 by owner review, on the seven-criterion contract as
+  it now stands.** The full history is `COMPLETE` -> `READY` -> `IN_REVIEW` -> `COMPLETE`, and every
+  step of it is kept below.
+
+  **What the owner approved, in their own terms:** closure of *the item's presently stated acceptance
+  contract*, deliberately narrower than a claim that no eighth criterion can ever be discovered. This
+  item has already had a criterion discovered after it closed; a closure that claimed otherwise would
+  be making the same mistake in the same place.
+
+  **Closure was taken after both the criterion and its consequence were verified, not after the
+  criterion alone.** The seventh criterion was met at `f564d6c`, and that same commit introduced a
+  human-rendering regression — a run whose only loss was a tool-decided exclusion printed
+  `Evidence surface INCOMPLETE — .`, naming nothing — which was found in review and repaired at
+  `ebb8db9`. The owner's disposition is recorded against the state that carries both, and not
+  against the intermediate head that carried only the first. This distinction is written down because
+  a closure record that named `f564d6c` alone would read as approval of a head already known to be
+  defective, and the reader would have no way to tell that it was not.
+
+  **Why it was not closed by this item on its own authority.** All seven criteria have an
+  establishing commit and a falsifier, and that was true at `IN_REVIEW` too. It was not sufficient
+  then and is not what closed the item now: the first closure also rested on every criterion then
+  stated having an establishing commit and a falsifier, and the criteria set was incomplete. What
+  changed is that a second party reviewed the contract and took the disposition. Under
+  [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md) the agent does not attest to
+  its own work, and closing an item on the strength of the reasoning that failed the first time would
+  be exactly that.
+
+  **Previously: IN_REVIEW — the seventh criterion is met at `f564d6c`; whether that closes this
   item a second time is the owner's call and is deliberately not taken here.** All seven acceptance
-  criteria now have an establishing commit and a falsifier. This item nonetheless closed once
-  already, on a criteria set that turned out to be incomplete, and an item that re-closes itself on
-  the strength of the same reasoning that failed the first time is asserting exactly what it cannot
+  criteria have an establishing commit and a falsifier. This item nonetheless closed once already,
+  on a criteria set that turned out to be incomplete, and an item that re-closes itself on the
+  strength of the same reasoning that failed the first time is asserting exactly what it cannot
   establish. `IN_REVIEW` is nonterminal, so release closure stays blocked while the disposition is
   open — which is the correct state for work that is done and not yet judged.
 
@@ -509,7 +543,7 @@ that approval deliberately does not cover.
 
   | # | Acceptance criterion | Established by |
   |---|---|---|
-  | 7 | A framework-caused loss of eligible project evidence makes the evidence surface incomplete | **Met 2026-08-25 at `f564d6c`.** `evidenceSurface.complete` now has a sixth term, and each exclusion entry carries `authorizedBy` beside `reason` — the two answer different questions, and only the first bears on completeness. **Authority is asked, not inferred**, because `SKIP_DIRS` is consulted *before* the repository-ignore set: a name match wins the reported `reason` even where the repository independently ignores the same path, which is the ordinary state of every real dependency tree. Deriving authority from `reason` alone would have reported almost every repository as having lost evidence it had itself declared disposable, so the `SKIP_DIRS` branch consults the ignore set directly. The walk order is deliberately left alone: it decides which reason is reported, and this decides what that reason is worth, and changing the first to serve the second would rewrite evidence to suit a conclusion. **Three authorities, not two** — `repository` (the project declared it disposable), `framework` (this tool decided, from a name or a marker), and `not-project-evidence` for `.git`, which is the repository's own storage and was never candidate evidence. The third exists because the falsifier below rejected the first implementation, which counted `.git` as lost evidence and reported **every** repository incomplete — the blanket rule arrived at from the other direction. **Falsified four ways**, each by a distinct test: dropping the new term is caught only by the specimen; making the rule blanket is caught by all four; and refusing to consult the ignore set for a `SKIP_DIRS` name is caught only by the both-signals case. **Verdicts are unchanged** — the excluded bait still reports `passed`, which is #38 and stays there. **Previously:** `evidenceSurface.complete` must account for every framework-caused loss of eligible project evidence. A repository-authorized exclusion — content the repository itself marks ignored — may stay outside the project evidence surface without making it incomplete, because the project declared it disposable. A hardcoded tool exclusion over otherwise eligible tracked content must make `complete: false`. Falsifier: the two-repository specimen in the Status above must stop reporting `complete: true` on the `fixtures/` side while a repository-ignored tree continues to report `complete: true`, so a fix that simply made every exclusion incomplete would fail this test rather than pass it. |
+  | 7 | A framework-caused loss of eligible project evidence makes the evidence surface incomplete | **Met 2026-08-25 at `f564d6c`, with a consequence in the human rendering repaired at `ebb8db9`.** The predicate change made a mode of incompleteness reachable that `renderHuman` had no reason for, so a run whose only loss was a tool-decided exclusion printed `Evidence surface INCOMPLETE — .` — incompleteness declared and then not named, which is this same defect one layer up in the sentence a person reads. It was introduced by this criterion's own commit: before it, `complete` could only go false through a mode that pushes a reason, so the empty branch was unreachable. It survived the criterion's four falsifiers because every one of them reads `--json`, where the field was correct throughout, and it was found by review rather than by this repository's own tests. Recorded in the row rather than only in the commit, because a criterion whose fix required a second fix is not the same evidence as one that did not. `evidenceSurface.complete` now has a sixth term, and each exclusion entry carries `authorizedBy` beside `reason` — the two answer different questions, and only the first bears on completeness. **Authority is asked, not inferred**, because `SKIP_DIRS` is consulted *before* the repository-ignore set: a name match wins the reported `reason` even where the repository independently ignores the same path, which is the ordinary state of every real dependency tree. Deriving authority from `reason` alone would have reported almost every repository as having lost evidence it had itself declared disposable, so the `SKIP_DIRS` branch consults the ignore set directly. The walk order is deliberately left alone: it decides which reason is reported, and this decides what that reason is worth, and changing the first to serve the second would rewrite evidence to suit a conclusion. **Three authorities, not two** — `repository` (the project declared it disposable), `framework` (this tool decided, from a name or a marker), and `not-project-evidence` for `.git`, which is the repository's own storage and was never candidate evidence. The third exists because the falsifier below rejected the first implementation, which counted `.git` as lost evidence and reported **every** repository incomplete — the blanket rule arrived at from the other direction. **Falsified four ways**, each by a distinct test: dropping the new term is caught only by the specimen; making the rule blanket is caught by all four; and refusing to consult the ignore set for a `SKIP_DIRS` name is caught only by the both-signals case. **Verdicts are unchanged** — the excluded bait still reports `passed`, which is #38 and stays there. **Previously:** `evidenceSurface.complete` must account for every framework-caused loss of eligible project evidence. A repository-authorized exclusion — content the repository itself marks ignored — may stay outside the project evidence surface without making it incomplete, because the project declared it disposable. A hardcoded tool exclusion over otherwise eligible tracked content must make `complete: false`. Falsifier: the two-repository specimen in the Status above must stop reporting `complete: true` on the `fixtures/` side while a repository-ignored tree continues to report `complete: true`, so a fix that simply made every exclusion incomplete would fail this test rather than pass it. |
 
   **This line previously read "all five criteria". There are six.** The miscount is corrected rather
   than left, for the same reason the claim-invariant paragraph at the top of this section was

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -395,7 +395,15 @@ that approval deliberately does not cover.
 
 ### Fix the audit's project-level exclusions
 
-- **Status:** READY — **reopened 2026-08-24 by owner ruling.** This item held `COMPLETE` from
+- **Status:** IN_REVIEW — **the seventh criterion is met at `f564d6c`; whether that closes this
+  item a second time is the owner's call and is deliberately not taken here.** All seven acceptance
+  criteria now have an establishing commit and a falsifier. This item nonetheless closed once
+  already, on a criteria set that turned out to be incomplete, and an item that re-closes itself on
+  the strength of the same reasoning that failed the first time is asserting exactly what it cannot
+  establish. `IN_REVIEW` is nonterminal, so release closure stays blocked while the disposition is
+  open — which is the correct state for work that is done and not yet judged.
+
+  **Previously: READY — reopened 2026-08-24 by owner ruling.** This item held `COMPLETE` from
   2026-08-23 at `05df6e8`. That disposition is superseded rather than deleted, and the whole closure
   record it rested on is kept below, because an item that closed and then reopened is a different
   history from one that never closed and only the first of the two can be audited.
@@ -501,7 +509,7 @@ that approval deliberately does not cover.
 
   | # | Acceptance criterion | Established by |
   |---|---|---|
-  | 7 | A framework-caused loss of eligible project evidence makes the evidence surface incomplete | **Not met.** `evidenceSurface.complete` must account for every framework-caused loss of eligible project evidence. A repository-authorized exclusion — content the repository itself marks ignored — may stay outside the project evidence surface without making it incomplete, because the project declared it disposable. A hardcoded tool exclusion over otherwise eligible tracked content must make `complete: false`. Falsifier: the two-repository specimen in the Status above must stop reporting `complete: true` on the `fixtures/` side while a repository-ignored tree continues to report `complete: true`, so a fix that simply made every exclusion incomplete would fail this test rather than pass it. |
+  | 7 | A framework-caused loss of eligible project evidence makes the evidence surface incomplete | **Met 2026-08-25 at `f564d6c`.** `evidenceSurface.complete` now has a sixth term, and each exclusion entry carries `authorizedBy` beside `reason` — the two answer different questions, and only the first bears on completeness. **Authority is asked, not inferred**, because `SKIP_DIRS` is consulted *before* the repository-ignore set: a name match wins the reported `reason` even where the repository independently ignores the same path, which is the ordinary state of every real dependency tree. Deriving authority from `reason` alone would have reported almost every repository as having lost evidence it had itself declared disposable, so the `SKIP_DIRS` branch consults the ignore set directly. The walk order is deliberately left alone: it decides which reason is reported, and this decides what that reason is worth, and changing the first to serve the second would rewrite evidence to suit a conclusion. **Three authorities, not two** — `repository` (the project declared it disposable), `framework` (this tool decided, from a name or a marker), and `not-project-evidence` for `.git`, which is the repository's own storage and was never candidate evidence. The third exists because the falsifier below rejected the first implementation, which counted `.git` as lost evidence and reported **every** repository incomplete — the blanket rule arrived at from the other direction. **Falsified four ways**, each by a distinct test: dropping the new term is caught only by the specimen; making the rule blanket is caught by all four; and refusing to consult the ignore set for a `SKIP_DIRS` name is caught only by the both-signals case. **Verdicts are unchanged** — the excluded bait still reports `passed`, which is #38 and stays there. **Previously:** `evidenceSurface.complete` must account for every framework-caused loss of eligible project evidence. A repository-authorized exclusion — content the repository itself marks ignored — may stay outside the project evidence surface without making it incomplete, because the project declared it disposable. A hardcoded tool exclusion over otherwise eligible tracked content must make `complete: false`. Falsifier: the two-repository specimen in the Status above must stop reporting `complete: true` on the `fixtures/` side while a repository-ignored tree continues to report `complete: true`, so a fix that simply made every exclusion incomplete would fail this test rather than pass it. |
 
   **This line previously read "all five criteria". There are six.** The miscount is corrected rather
   than left, for the same reason the claim-invariant paragraph at the top of this section was

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -309,6 +309,22 @@ const SKIP_DIRS = new Set([
 ]);
 
 /**
+ * The members of `SKIP_DIRS` that are not candidate project evidence in the first place.
+ *
+ * `.git` is the repository's own storage, not content the repository is made of. Skipping it removes
+ * nothing anyone could have audited, so it must not bear on whether the evidence surface is
+ * complete. Everything else in `SKIP_DIRS` is a judgement about content that could have been the
+ * project's — `vendor`, `fixtures`, `dist` and the rest can all hold tracked first-party code — and
+ * those do bear on it.
+ *
+ * This set exists because the completeness criterion's falsifier caught its absence: an
+ * implementation that treated every tool exclusion as lost evidence reported **every** repository
+ * incomplete, including one with nothing excluded but `.git`. That is the blanket rule the criterion
+ * was written to forbid, and it was the first thing written.
+ */
+const NOT_PROJECT_EVIDENCE = new Set([".git"]);
+
+/**
  * Files that identify their own directory as a dependency tree rather than the project's code.
  *
  * A name list cannot do this job, and the defect that produced this constant is the proof: the
@@ -822,6 +838,27 @@ function createRun({ root, strict, json }) {
  *                `conventional non-project directory` for `SKIP_DIRS`. The third used to be a bare
  *                `continue`: `.mypy_cache/` was 98 MB in one reproduction and left no trace at all,
  *                which is the same defect class as a silent cap.
+ *
+ * Each entry also carries `authorizedBy`, and it is a different question from `reason`. `reason`
+ * says which branch removed the directory; `authorizedBy` says **who decided** it was disposable —
+ * the project, or this tool. Only the project's own decision leaves the evidence surface complete,
+ * so the two cannot be collapsed:
+ *
+ *   repository   the project marked the path ignored. It said this is not its code, and a run that
+ *                honours that has lost nothing it was ever owed.
+ *   framework    this tool decided, from a hardcoded name or a marker file. Nobody declared the
+ *                content disposable; it may be tracked, committed and first-party.
+ *   not-project-evidence
+ *                the path was never candidate evidence — see `NOT_PROJECT_EVIDENCE`. Recorded so
+ *                the exclusion stays visible, but it cannot make a surface incomplete.
+ *
+ * `SKIP_DIRS` is checked before the repository-ignore set, so a name match wins the `reason` even
+ * when the repository independently ignores the same path — which is most real dependency trees.
+ * Attributing authority from `reason` alone would therefore report almost every repository as having
+ * lost evidence it had in fact declared disposable, so the `SKIP_DIRS` branch asks the ignore set
+ * directly rather than inferring. The ordering is left alone: it decides which reason is reported
+ * and this decides what the reason is worth, and changing the first to serve the second would
+ * rewrite evidence to suit a conclusion.
  *   files        an aggregate count and a bounded sample in `loss.excludedFiles`, never one entry
  *                each. A generated artifact beside tracked code is not a surface anyone expected to
  *                be audited, and listing every one would bury the directory-level exclusions that
@@ -851,7 +888,9 @@ async function collectFiles(dir, acc, loss, excluded, run) {
   // virtualenv is a project someone deliberately pointed the audit at, and excluding everything
   // would report a clean run over a repository nothing examined.
   if (dir !== root && entries.some((e) => e.isFile() && VENDOR_MARKERS.has(e.name))) {
-    loss.excluded.push({ path: rel(dir), reason: "vendored dependency tree" });
+    // Always `framework`: the parent loop consults the ignore set before recursing, so a tree
+    // that reaches this branch is one the repository did not declare disposable.
+    loss.excluded.push({ path: rel(dir), reason: "vendored dependency tree", authorizedBy: "framework" });
     return acc;
   }
 
@@ -863,11 +902,22 @@ async function collectFiles(dir, acc, loss, excluded, run) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) {
-        loss.excluded.push({ path: rel(full), reason: "conventional non-project directory" });
+        loss.excluded.push({
+          path: rel(full),
+          reason: "conventional non-project directory",
+          // Three authorities, not two. The repository's own storage was never project evidence; a
+          // path the repository declares ignored is the project's decision; anything else here is
+          // this tool's decision about content nobody declared disposable.
+          authorizedBy: NOT_PROJECT_EVIDENCE.has(entry.name)
+            ? "not-project-evidence"
+            : excluded.dirs.has(rel(full))
+              ? "repository"
+              : "framework",
+        });
         continue;
       }
       if (excluded.dirs.has(rel(full))) {
-        loss.excluded.push({ path: rel(full), reason: "ignored by the repository" });
+        loss.excluded.push({ path: rel(full), reason: "ignored by the repository", authorizedBy: "repository" });
         continue;
       }
       await collectFiles(full, acc, loss, excluded, run);
@@ -2423,21 +2473,40 @@ export async function main(args) {
   //
   // So it goes where the other properties-of-the-run live, beside `fileCapReached`, and the header
   // states it in the same breath as the scanned count.
+  // Every loss of eligible project evidence that this framework caused, whatever removed it. The
+  // filter is on who decided, never on which branch reported it — see `authorizedBy` on
+  // `collectFiles`.
+  const frameworkExcluded = surfaceLoss.excluded.filter((e) => e.authorizedBy === "framework");
+
   const evidenceSurface = {
     // Budget exhaustion belongs here with the other loss modes. An eligible file nothing opened is
     // exactly as absent from the results as one beyond the file cap, so a surface that still claimed
     // completeness would be making the stronger available claim on the weaker evidence.
+    //
+    // That sentence was written for budget exhaustion and generalises to exclusion without a word
+    // changed, which is how this expression came to contradict its own comment: a directory this
+    // tool dropped from a hardcoded name is exactly as absent as one beyond the cap, and `complete`
+    // stayed true over it. Measured on this repository — `test/fixtures` is tracked, committed,
+    // first-party, and was excluded while the surface reported itself whole. A repository-authorized
+    // exclusion is the one case that does not count: content the project marked ignored was never
+    // owed to the run, so honouring the declaration loses nothing. Tool-decided exclusion is not a
+    // declaration by anyone.
     complete:
       !unreadableFiles.length &&
       !surfaceLoss.dirs.length &&
       !truncatedFiles.length &&
       !surfaceLoss.capped &&
-      !surfaceLoss.budget.exhausted,
+      !surfaceLoss.budget.exhausted &&
+      !frameworkExcluded.length,
     unreadableFiles: uniq(unreadableFiles.map(rel)),
     unreadableDirectories: uniq(surfaceLoss.dirs.map(rel)),
     truncatedFiles: uniq(truncatedFiles),
     fileCapReached: surfaceLoss.capped,
     excludedDirectories: surfaceLoss.excluded,
+    // The subset of the above that this tool decided rather than the project, and therefore the
+    // reason `complete` can be false while every exclusion is nonetheless recorded. Named rather
+    // than left to be re-derived: the distinction is the whole content of the completeness claim.
+    frameworkExcludedDirectories: frameworkExcluded.map((e) => e.path),
     // A count and a bounded sample, never one entry per file — see the granularity note on
     // `collectFiles`. Reported even though it is not incompleteness: an ignored file is a decision
     // about what is not the project's code, and a reader who cannot see the count cannot tell a

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -2250,6 +2250,26 @@ function renderHuman(fileCount, surface, run) {
           `${surface.readBudget.limitBytes}-byte read budget was spent`,
       );
     }
+    // Six terms here, six in `complete`. The two lists are parallel by obligation and not by
+    // construction — one lives on the evidence surface and one lives in this renderer — and this
+    // term was missing for exactly as long as it took to notice. The sixth was added to `complete`
+    // and not to this list, so on a run whose only loss was a tool-decided exclusion the header
+    // printed `Evidence surface INCOMPLETE — .`: a run announcing it had lost evidence and then
+    // naming none of it. Measured on this repository, where `test/fixtures` is the only loss.
+    //
+    // That is the same defect this whole boundary exists to prevent, one layer up: the predicate
+    // told the truth and the sentence a reader actually sees did not. The paths are named rather
+    // than counted because the exclusion summary below lists EVERY exclusion, repository-authorized
+    // ones included, so a count alone would leave the reader unable to tell which subset was the
+    // cause. Anything added to `complete` after this belongs here in the same commit.
+    if (surface.frameworkExcludedDirectories.length) {
+      const all = surface.frameworkExcludedDirectories;
+      const rest = all.length > 6 ? ` and ${all.length - 6} more` : "";
+      parts.push(
+        `${all.length} directory(ies) excluded by this tool rather than by the repository ` +
+          `(${all.slice(0, 6).join(", ")}${rest})`,
+      );
+    }
     lines.push(`Evidence surface INCOMPLETE — ${parts.join(", ")}. Results below cover what was read, and nothing else.`);
   }
   // Stated separately from incompleteness, and always — not only when something else went wrong.

--- a/test/audit-scope-isolation.test.mjs
+++ b/test/audit-scope-isolation.test.mjs
@@ -329,3 +329,139 @@ test("ignored files are accounted for in aggregate rather than per file", async 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+/**
+ * Criterion 7: a framework-caused loss of eligible project evidence makes the evidence surface
+ * incomplete.
+ *
+ * This is the criterion that reopened #7 after the item had closed on six. The exclusion boundary
+ * records what it removed — criterion 2, met — and then asserted `complete: true` beside the record,
+ * so a consumer reading the surface was told the evidence was whole while a tracked first-party tree
+ * had never been opened. Measured on this repository itself: `test/fixtures` is tracked, committed,
+ * first-party, excluded by name, and the run called its surface complete.
+ *
+ * The four tests below are one specimen and three controls, and the controls are not decoration. The
+ * criterion forbids a blanket rule as explicitly as it requires the fix: repository-ignored content
+ * is legitimately outside the evidence surface, so an implementation that made every exclusion mean
+ * incompleteness must FAIL here rather than pass. It did. The first implementation of this criterion
+ * counted `.git` as lost project evidence and reported every repository on earth incomplete,
+ * including one with nothing excluded at all — caught by the last test in this file, before review.
+ *
+ * What these do NOT assert is the rule verdict. `security.no-sql-concat` still reports `passed` over
+ * the excluded bait, and that is #38's defect, not this one. Keeping the two apart is why each
+ * falsifier can prove one invariant without the other fix making its test green by accident.
+ */
+
+/** A tracked, committed, first-party defect inside a directory `SKIP_DIRS` removes by name. */
+async function baitIn(root, dir) {
+  await mkdir(path.join(root, dir), { recursive: true });
+  await writeFile(path.join(root, dir, "service.py"), SWALLOWED);
+}
+
+test("a tool-decided exclusion of tracked first-party code makes the surface incomplete", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-excl-complete-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    await baitIn(root, "fixtures");
+    commit();
+
+    const surface = surfaceOf(audit(root));
+    const hit = excludedDir(surface, "fixtures");
+    assert.ok(hit, `fixtures was not excluded at all: ${JSON.stringify(surface.excludedDirectories)}`);
+    assert.equal(hit.reason, "conventional non-project directory");
+    assert.equal(hit.authorizedBy, "framework", "a name match is this tool's decision, not the project's");
+
+    assert.equal(
+      surface.complete,
+      false,
+      "the surface claimed completeness over a tracked tree this tool dropped from a hardcoded name",
+    );
+    assert.deepEqual(surface.frameworkExcludedDirectories, ["fixtures"]);
+
+    // Load-bearing: without it, an implementation that excluded the whole repository would satisfy
+    // every assertion above by reporting nothing and losing everything.
+    assert.ok(
+      evidenceOf(parse(audit(root))).some((e) => e.includes("service.py")),
+      "first-party code outside the exclusion went unreported, so the run lost more than the tree",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a repository-authorized exclusion leaves the surface complete", async () => {
+  // THE FALSIFIER the criterion names. A blanket "any exclusion means incomplete" fails here, and
+  // that is the point: the project declared this tree disposable, so honouring the declaration loses
+  // nothing the run was ever owed. Content, and the defect in it, are identical to the test above.
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-excl-authorized-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    await baitIn(root, "thirdparty");
+    await writeFile(path.join(root, ".gitignore"), "thirdparty/\n");
+    commit();
+
+    const surface = surfaceOf(audit(root));
+    const hit = excludedDir(surface, "thirdparty");
+    assert.ok(hit, `thirdparty was not excluded: ${JSON.stringify(surface.excludedDirectories)}`);
+    assert.equal(hit.reason, "ignored by the repository");
+    assert.equal(hit.authorizedBy, "repository");
+
+    assert.equal(surface.complete, true, "a project's own declaration was counted as this tool's loss");
+    assert.deepEqual(surface.frameworkExcludedDirectories, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a SKIP_DIRS name the repository also ignores is the project's decision, not this tool's", async () => {
+  // The case that decides whether the criterion is meaningful in practice rather than only in a
+  // fixture. SKIP_DIRS is consulted BEFORE the ignore set, so a name match wins the reported reason
+  // even when the repository independently ignores the same path — which is the ordinary state of
+  // every real dependency tree. Attributing authority from the reason alone would therefore report
+  // almost every repository as having lost evidence it had itself declared disposable.
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-excl-both-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    await baitIn(root, "vendor");
+    await writeFile(path.join(root, ".gitignore"), "vendor/\n");
+    commit();
+
+    const surface = surfaceOf(audit(root));
+    const hit = excludedDir(surface, "vendor");
+    assert.ok(hit, `vendor was not excluded: ${JSON.stringify(surface.excludedDirectories)}`);
+    // The reason still reports which branch removed it. Only the authority is re-derived.
+    assert.equal(hit.reason, "conventional non-project directory");
+    assert.equal(hit.authorizedBy, "repository", "the repository's declaration was overridden by a name match");
+
+    assert.equal(surface.complete, true);
+    assert.deepEqual(surface.frameworkExcludedDirectories, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the repository's own .git directory cannot make a surface incomplete", async () => {
+  // The negative control, and it earned its place: the first implementation of this criterion
+  // treated .git as framework-caused loss, so EVERY repository reported an incomplete surface — the
+  // blanket rule the criterion exists to forbid, arrived at from the other direction. Nothing here
+  // is excluded but .git, and the surface must be complete.
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-excl-dotgit-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    commit();
+
+    const surface = surfaceOf(audit(root));
+    const hit = excludedDir(surface, ".git");
+    assert.ok(hit, "the .git directory was not recorded as excluded at all");
+    assert.equal(hit.authorizedBy, "not-project-evidence");
+
+    assert.equal(surface.complete, true, "a repository's own storage was counted as lost project evidence");
+    assert.deepEqual(surface.frameworkExcludedDirectories, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/audit-scope-isolation.test.mjs
+++ b/test/audit-scope-isolation.test.mjs
@@ -57,6 +57,26 @@ function audit(dir) {
   return r;
 }
 
+/**
+ * The same run without `--json`. Every other assertion in this file reads the machine surface, and
+ * that is exactly how the rendering defect below survived: `frameworkExcludedDirectories` was
+ * correct in the JSON while the sentence a person reads named nothing at all.
+ */
+function auditHuman(dir) {
+  const r = spawnSync(process.execPath, [CLI, "audit", `--dir=${dir}`], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  return r.stdout;
+}
+
+/** The reason list from the incomplete-surface header, or `null` if no such header was printed. */
+function incompleteHeader(out) {
+  const m = out.match(/^Evidence surface INCOMPLETE — (.*)\. Results below/m);
+  return m ? m[1] : null;
+}
+
 function parse(r) {
   try {
     return JSON.parse(r.stdout);
@@ -461,6 +481,86 @@ test("the repository's own .git directory cannot make a surface incomplete", asy
 
     assert.equal(surface.complete, true, "a repository's own storage was counted as lost project evidence");
     assert.deepEqual(surface.frameworkExcludedDirectories, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the incomplete-surface header names the tool-decided exclusion that caused it", async () => {
+  // THE REGRESSION. Adding the sixth term to `complete` without adding it to `renderHuman`'s reason
+  // list made this very repository print:
+  //
+  //     Evidence surface INCOMPLETE — . Results below cover what was read, and nothing else.
+  //
+  // A run announcing it had lost evidence and then naming none of it — the same failure the sixth
+  // term was added to fix, moved one layer up into the sentence a person actually reads. It was
+  // invisible to every other test in this file because they all read `--json`, where the field was
+  // correct all along.
+  //
+  // The property, stated once: whenever `complete` is false, the header must name at least one
+  // actual loss mode that caused it. Not a generic phrase, and not a bare count the reader has to
+  // match up against some later line.
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-render-excl-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    await baitIn(root, "fixtures");
+    commit();
+
+    // The exclusion is the ONLY loss mode here: nothing unreadable, nothing truncated, no cap, no
+    // budget. So the reason list has exactly one thing it can say, and an empty list is the defect.
+    const surface = surfaceOf(audit(root));
+    assert.equal(surface.complete, false, JSON.stringify(surface, null, 2));
+    assert.deepEqual(surface.frameworkExcludedDirectories, ["fixtures"]);
+    assert.deepEqual(surface.unreadableFiles, []);
+    assert.deepEqual(surface.truncatedFiles, []);
+    assert.equal(surface.fileCapReached, false);
+    assert.equal(surface.readBudget.exhausted, false);
+
+    const out = auditHuman(root);
+    const reasons = incompleteHeader(out);
+    assert.ok(reasons !== null, `no incomplete-surface header was printed at all: ${out.slice(0, 1200)}`);
+    assert.notEqual(reasons.trim(), "", "the header declared incompleteness and then named nothing");
+    assert.match(reasons, /fixtures/, `the header did not name the directory that caused it: "${reasons}"`);
+    assert.match(
+      reasons,
+      /this tool rather than by the repository/,
+      `the header did not say who decided the exclusion: "${reasons}"`,
+    );
+
+    // Load-bearing, and the reason this asserts on the header rather than on the output as a whole:
+    // the exclusion summary further down lists EVERY exclusion, repository-authorized ones included,
+    // so a reader who has only that line cannot tell which subset made the surface incomplete.
+    // Remove it, and the cause must still be named.
+    const withoutSummary = out.replace(/^\d+ directory\(ies\) excluded as not this project's own code.*$/m, "");
+    assert.match(incompleteHeader(withoutSummary) ?? "", /fixtures/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a repository-authorized exclusion prints no incompleteness header at all", async () => {
+  // The control that stops the fix above from being satisfied by always printing something. The
+  // project declared this tree disposable, so there is no loss to name and no header to print. A
+  // renderer that manufactured a reason here would be fabricating incompleteness to keep its own
+  // reason list non-empty, which is the defect inverted rather than repaired.
+  const root = await mkdtemp(path.join(os.tmpdir(), "standards-render-authorized-"));
+  try {
+    const commit = await initRepo(root);
+    await firstParty(root);
+    await baitIn(root, "thirdparty");
+    await writeFile(path.join(root, ".gitignore"), "thirdparty/\n");
+    commit();
+
+    assert.equal(surfaceOf(audit(root)).complete, true);
+    const out = auditHuman(root);
+    assert.equal(
+      incompleteHeader(out),
+      null,
+      `an incompleteness header was printed over a complete surface: ${out.slice(0, 1200)}`,
+    );
+    // The exclusion is still reported. It is a decision about scope, not a loss.
+    assert.match(out, /thirdparty/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/test/audit.test.mjs
+++ b/test/audit.test.mjs
@@ -995,11 +995,38 @@ test("a fully readable tree reports a complete evidence surface and no evidence-
   }
 });
 
-test("this repository's own evidence surface is complete", async () => {
-  // The self-audit asserts zero error findings elsewhere; that assertion is only worth something if
-  // the run actually read everything it claims to have read.
+test("this repository's own evidence surface loses nothing unintentionally, and names what it does lose", async () => {
+  // THIS TEST PREVIOUSLY ASSERTED `complete === true` FOR THIS REPOSITORY, AND THAT WAS FALSE.
+  //
+  // Its reason for existing was right and is kept: the self-audit's zero-error-findings claim is
+  // only worth something if the run actually read what it claims to have read. But the run does not
+  // read `test/fixtures` — tracked, committed, first-party, and removed because `SKIP_DIRS` contains
+  // the name `fixtures`. The old assertion passed anyway, because `complete` did not account for
+  // exclusion at all. So this repository was the defect's own specimen while asserting it was not.
+  //
+  // The assertion is not flipped to `false`, which would accept the loss and check nothing. It is
+  // replaced by the two claims that are actually true and actually worth defending: no UNINTENDED
+  // loss of any kind, and every intentional loss named explicitly. If a second directory ever leaves
+  // this repository's evidence surface, this test fails until someone writes down why.
   const { json } = audit(REPO);
-  assert.equal(json.evidenceSurface.complete, true, JSON.stringify(json.evidenceSurface, null, 2));
+  const s = json.evidenceSurface;
+  const shown = JSON.stringify(s, null, 2);
+
+  // Nothing was unreadable, truncated, capped, or left unopened for want of budget. Every one of
+  // these would be a run that lost evidence it meant to have.
+  assert.deepEqual(s.unreadableFiles, [], shown);
+  assert.deepEqual(s.unreadableDirectories, [], shown);
+  assert.deepEqual(s.truncatedFiles, [], shown);
+  assert.equal(s.fileCapReached, false, shown);
+  assert.equal(s.readBudget.exhausted, false, shown);
+
+  // The single intentional loss, pinned by path. `test/fixtures` holds deliberate violations used by
+  // the detector suites; whether `fixtures` should be in `SKIP_DIRS` at all is a separate question
+  // about the name list, deliberately not settled here.
+  assert.deepEqual(s.frameworkExcludedDirectories, ["test/fixtures"], shown);
+
+  // And therefore the surface is honestly incomplete, rather than dishonestly whole.
+  assert.equal(s.complete, false, shown);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #7's seventh acceptance criterion — the one that reopened it. **Rule verdicts are unchanged**; the excluded bait still reports `passed`, which is #38 and stays there.

## The defect

`evidenceSurface.complete` listed `unreadableFiles`, `dirs`, `truncatedFiles`, `capped` and `budget.exhausted` — and not `excluded`. The doc comment directly above it already forbade that, in a sentence written for budget exhaustion that generalises to exclusion without a word changed:

> An eligible file nothing opened is exactly as absent from the results as one beyond the file cap, so a surface that still claimed completeness would be making the stronger available claim on the weaker evidence.

**Measured on this repository.** `test/fixtures` is tracked, committed, first-party, excluded because `SKIP_DIRS` contains the name `fixtures` — and the surface reported `complete: true`. The test asserting that was itself the specimen.

## Authority, not reason, decides completeness

Each exclusion entry now carries `authorizedBy` beside `reason`. They answer different questions: `reason` says which branch removed the directory, `authorizedBy` says **who decided** it was disposable.

| | |
|---|---|
| `repository` | the project marked it ignored — it said this is not its code, so the run lost nothing it was owed |
| `framework` | this tool decided, from a hardcoded name or a marker file — nobody declared the content disposable |
| `not-project-evidence` | `.git`, the repository's own storage, which was never candidate evidence |

**Authority is asked, not inferred.** `SKIP_DIRS` is consulted *before* the repository-ignore set, so a name match wins the reported `reason` even where the repository independently ignores the same path — the ordinary state of every real dependency tree. Deriving authority from `reason` alone would have reported almost every repository as having lost evidence it had itself declared disposable, so the `SKIP_DIRS` branch consults the ignore set directly.

**The walk order is deliberately left alone.** It decides which reason is reported; this decides what that reason is worth. Changing the first to serve the second would rewrite evidence to suit a conclusion.

## The falsifier rejected the blanket rule twice

The criterion forbids "any exclusion means incomplete" as explicitly as it requires the fix, because repository-ignored content is legitimately outside the evidence surface. It caught two attempts:

- repository-ignored content must keep `complete: true` — the case the criterion names;
- **`.git` must not count** — the first implementation treated it as lost project evidence and reported *every* repository incomplete. That is the same blanket rule reached from the other direction, and it was the first thing written. `NOT_PROJECT_EVIDENCE` exists because of it.

## Tests and mutations

Four tests in `test/audit-scope-isolation.test.mjs` — one specimen and three controls. Each carries a genuine first-party defect *outside* the exclusion, so an implementation that excluded everything would fail rather than pass.

| Mutation | Caught by |
|---|---|
| drop the new term from `complete` | the specimen, and only the specimen |
| make the rule blanket (`.git` included) | all four |
| never consult the ignore set for a `SKIP_DIRS` name | the both-signals case, and only that one |

## The self-surface test was rewritten, not flipped

`this repository's own evidence surface is complete` asserted something false. Flipping it to `false` would accept the loss and check nothing, so it now asserts the two claims that are true and worth defending: **no unintended loss of any kind** — nothing unreadable, truncated, capped, or unopened for want of budget — and **every intentional loss named by path**. If a second directory ever leaves this repository's evidence surface, it fails until someone writes down why.

## Disposition

#7 moves to `IN_REVIEW`, not `COMPLETE`. All seven criteria now have an establishing commit and a falsifier, but this item closed once already on a criteria set that turned out incomplete, and re-closing itself on the same reasoning would assert what it cannot establish. `IN_REVIEW` is nonterminal, so release closure stays blocked while the disposition is open.

Whether `fixtures` and `vendor` belong in `SKIP_DIRS` at all is a separate question about the name list and is not settled here.


---

## Local CI

This pipeline ran in an ephemeral Docker container on the author's machine.
It is **not** a GitHub-hosted Actions run and makes no claim about one.

- Verified commit: `3a7f0f448a1bddca91007139c6cd841e3f3fc0e6`
- Branch: `fix/issue-7-exclusion-completeness`
- Result: **PASS**
- Environment: Docker (`engineeringstandards-ci:engineeringstandards-ci-1787678014864-31104`, Node v20.20.2)
- Completed: 2026-08-25T17:13:49.898Z

<details><summary>Stages executed</summary>

- `inventory` — passed (exit 0)
- `fidelity` — passed (exit 0)
- `policy` — passed (exit 0)
- `diagrams` — passed (exit 0)
- `test` — passed (exit 0)
- `audit` — passed (exit 0)
- `validate` — advisory-failed (exit 1) _[advisory, non-gating]_

</details>

