### PR TITLE
Unavailable content evidence stops being read as content

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1087,6 +1087,32 @@ that approval deliberately does not cover.
   **Red-first, verified rather than asserted.** Against `99952bd` the falsifiers stand at seven
   failing and six passing; the two covering the read-failure route are red against the first
   implementation of the mechanism itself, not merely against the baseline.
+
+  **Bound to an exact head, 2026-08-26.** The full six-stage gate passed on committed content at
+  `6b64908` — `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — and separately at
+  `d91fb4a` before the attestations were recorded, so the mechanism and the human review are
+  evidenced at two distinct revisions rather than one combined claim.
+
+  **Criterion 5 established by comparison rather than by inspection.** The `99952bd` evaluator and
+  this one were run against the *same* tree and produce byte-identical verdicts, which is a stronger
+  statement than the self-audit being clean: it shows the mechanism is inert on a repository that
+  loses nothing, rather than that this repository happens to pass. `validate` here is 24 passed, 4
+  failed, 0 warnings, 22 skipped, the four failures being the four standing recorded human
+  rejections and no rule changing status or assurance because of this work.
+
+  **Four attestations were refreshed at this head, and two of them could not cover what they were
+  asked to.** `architecture.no-hidden-global-state`, `architecture.no-duplicate-implementations`,
+  `meta.standards-not-weakened` and `testing.no-weakening-to-pass` were stale on `99952bd` *before*
+  this branch existed, and each was re-reviewed fresh at `d91fb4a` with no digest inherited. The
+  review reduced to two files: exactly one reviewed path changed per rule, `scripts/standards.mjs`
+  for the first and `test/audit.test.mjs` for the other three, with every other reviewed path
+  byte-identical by blob comparison. Two scope limitations are recorded in the attestations rather
+  than resolved inside them, and both are owner decisions this item does not take:
+  `meta.standards-not-weakened` has no `standards/` file among its reviewed paths, so a digest over
+  its declared set is structurally incapable of seeing a standard being weakened — which is that
+  rule's own subject, and this branch amends Standard 44; and
+  `architecture.no-duplicate-implementations` does not review `scripts/standards.mjs`, the file most
+  likely to carry a duplicate.
 - **Dependencies:** none blocking. It shares code with
   [the exclusion boundary](#fix-the-audits-project-level-exclusions), whose seventh criterion repairs
   the global completeness claim; that repair does not close this item and this item does not close
@@ -1094,6 +1120,36 @@ that approval deliberately does not cover.
   [#6/#8](#make-architectureproject-manifest-check-content-not-presence), which must not land first:
   making `architecture.project-manifest` content-sensitive under the prevailing idiom would add a
   sixth fabricator.
+
+### `validate` reports a verdict without reporting what it could not read
+
+- **Status:** CANDIDATE — measured, not yet triaged into a tracked item.
+- **Tracked by:** nothing yet. Recorded here so it is not rediscovered later from the same symptom.
+- **Evidence:** measured 2026-08-26 at `6b64908` while building the falsifiers for
+  [#38](#unavailable-content-evidence-must-never-be-read-as-content). `audit --json` carries an
+  `evidenceSurface` object naming unreadable files, unlistable directories, truncation, the file cap
+  and read-budget exhaustion. `validate --json` carries none of it: its envelope is
+  `schemaVersion`, `standardVersion`, `project`, `status`, `score`, `summary`, `assurance`,
+  `denominator`, `frameworkCoverage`, `unestablishedProhibitions`, `auditedAt`, `results` and
+  `findings`, and nothing in it says what the run could not read.
+- **Purpose:** `validate` is the command CI gates on, and it is the one that cannot say how much of
+  the project its verdict covers. A consumer joining results across runs (Standard 31) cannot
+  distinguish a full-coverage `COMPLIANT` from one reached over a partially read tree. #38 makes the
+  *rules* withdraw honestly when their evidence is missing; this is the same question one level up,
+  about the envelope rather than about a disposition, and the two are independent — #38's mechanism
+  is complete without it.
+
+  The measurement is not hypothetical: `test/evidence-availability.test.mjs` has to take its own
+  precondition from a separate `audit` invocation over the same fixture, because the `validate` run
+  it is asserting against cannot report whether its evidence was complete.
+- **Deliverables:** not designed. The obvious shape — carry `evidenceSurface` into the validate
+  envelope — is a **schema change to a published contract** and is a versioning decision with
+  adopter consequences, which is why this is recorded as a candidate rather than started.
+- **Acceptance Criteria:** none yet; this item has not been scoped.
+- **Verification:** none yet.
+- **Dependencies:** [Standard 31](../../standards/31-whatsnext-compatibility.md)'s envelope contract,
+  and whatever [#1](#resolve-standard-31-r4s-comparability-gap) settles about comparability, since
+  both change what a consumer may conclude from two results it is joining.
 
 ### Make `architecture.project-manifest` check content, not presence
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -931,7 +931,46 @@ that approval deliberately does not cover.
 
 ### Unavailable content evidence must never be read as content
 
-- **Status:** READY
+- **Status:** IN_REVIEW — **the mechanism is built and every acceptance criterion but one is met;
+  the remaining one is met in substance and not in the letter it was written in, which is a
+  distinction the owner should rule on rather than this item.** `IN_REVIEW` is nonterminal, so
+  release closure stays blocked while the disposition is open.
+
+  **What landed.** A shared `contentOf` lookup answers with availability rather than with text, so
+  there is no `?? ""` to reach for at a converted site because there is no string to reach. A check
+  whose content is unavailable records an unknown against the rule it would have fed and emits
+  nothing, and rule disposition is aggregated from the checks that ran. Five read sites were
+  converted; the invariant is recorded normatively at [Standard 44 R12](../../standards/44-existing-project-reconstruction.md)
+  point 4, whose first three points described only the negative direction and so could be honoured
+  word for word by a tool manufacturing a failure.
+
+  **Where the letter is not met, stated plainly rather than reported as done.** The first acceptance
+  criterion says *no call site can reach `""` or `"{}"` for unread content, and the mechanism
+  enforces this rather than a comment asserting it.* Seven raw read sites remain, and `contents` is
+  still passed to every detector, so the seam is opt-in at the call site rather than enforced by
+  construction. What is established instead is the weaker claim that no remaining site can fabricate
+  a **verdict**: two of the seven bind no rule at all and produce descriptive findings only
+  (`detectCapabilities`, `detectJobs`), and the other five feed rules that are already withdrawn
+  wholesale by `CONTENT_DERIVED_RULES`. Enforcing the criterion literally means withholding
+  `contents` from detectors entirely, which converts every remaining site including the descriptive
+  ones and changes audit output well beyond this defect. That is a larger change than the evidence
+  here justifies, and it is recorded as unmet rather than reinterpreted into met.
+
+  **Two loss modes, not one.** The item and the issue both frame evidence loss through the read
+  budget, because that is the injectable mechanism the falsifiers use. A failed **read** was the
+  other route to the identical fabrication and was not covered by the first implementation: on
+  failure `readText` returns `text: ""` and the read loop stored it, so a file the process could not
+  open answered `available` with an empty string, and a ~200 KB README was still reported as "under
+  400 characters" at full budget. The read loop now retains nothing for a failed read, and the
+  surface-level withdrawal that covers the other nine rules had the same hole — it fired on the file
+  cap and on budget exhaustion and not on a read failure — so its trigger was corrected rather than
+  its table extended.
+
+  **The disposition is reserved.** Under [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md)
+  this item does not close itself, and the specific thing needing a second party here is not whether
+  the tests pass but whether the unmet first criterion is acceptable as scoped or is work still owed.
+
+  **Previously: READY.**
 - **Tracked by:** GitHub issue [#38](https://github.com/mikeycdavis/EngineeringStandards/issues/38)
 - **Evidence:** opened 2026-08-23, measured before it was filed and enumerated afterwards. The
   prevailing idiom at the twelve content-read sites in
@@ -1036,6 +1075,18 @@ that approval deliberately does not cover.
   **mutation-tested before it is treated as the fix** — disabling the tri-state at the aggregation
   boundary, and separately at the lookup boundary, must each be caught by a test, and by a different
   test, or the mechanism is not established.
+
+  **Mutation result.** Five mutants, all killed. Coercing `contentOf` back to `?? ""` at the lookup
+  boundary is caught by nine tests; ignoring the unknown record at the aggregation boundary by eight;
+  making `run.unknown()` a no-op by eight. The first two are discriminated rather than counted
+  twice: the mixed-case falsifier — R4 established beside an unread R6 — kills the lookup mutant and
+  not the aggregation one, because coercion re-fires R6 while a bypassed withdrawal cannot. Storing a
+  failed read again, and dropping read failure from the surface-level trigger, are each killed by
+  exactly one test and by a different one.
+
+  **Red-first, verified rather than asserted.** Against `99952bd` the falsifiers stand at seven
+  failing and six passing; the two covering the read-failure route are red against the first
+  implementation of the mechanism itself, not merely against the baseline.
 - **Dependencies:** none blocking. It shares code with
   [the exclusion boundary](#fix-the-audits-project-level-exclusions), whose seventh criterion repairs
   the global completeness claim; that repair does not close this item and this item does not close

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1014,6 +1014,20 @@ that approval deliberately does not cover.
   cap and on budget exhaustion and not on a read failure — so its trigger was corrected rather than
   its table extended.
 
+  **Owner ruling on `quality.dead-code`, 2026-08-27: accepted.** A rule claiming absence cannot
+  honestly pass or fail without searching the whole domain it claims over, so `not-evaluated` when the
+  reference space is incomplete is the correct disposition and not a regression. The verdict is not to
+  be preserved merely because most repositories contain unreadable or non-text files. The first of the
+  two reserved judgements is therefore settled, and the cost recorded above is the accepted price
+  rather than an open question.
+
+  **Owner ruling on the three mutants, 2026-08-27: conditional, and the condition caught one.** The
+  ruling was to accept a survivor only where it is redundant with an independently established
+  boundary and restores no path from unavailable content to a verdict. Measured against that test,
+  mutants 2 and 3 pass it and mutant 1 fails it — it restores a false `failed`. The condition did the
+  work it was written to do, and the defect is closed by the new falsifier rather than by relaxing the
+  condition.
+
   **The disposition is reserved.** Under [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md)
   this item does not close itself. What needs a second party is no longer whether an unmet criterion
   is acceptable as scoped — every criterion is met — but whether the two judgements this item made on
@@ -1151,16 +1165,41 @@ that approval deliberately does not cover.
   both new falsifiers), answering the doc-consistency README half from an unread file (3), coercing a
   missing split-source entry into an empty string (1), and destructuring the raw map off `run` (1).
 
-  **The three survivors share one cause, and it is measured.** Folding `partial` into `available`,
-  and deleting the per-detector loss record from `detectSecretsInArtifacts` or
-  `detectSwallowedExceptions`, change no verdict this suite can observe — because `CODE_EXT` and
-  `CONFIG_EXT` are strict subsets of `TEXT_EXT`, so every file those detectors read is one the read
-  loop attempts, so any unavailability is already a recorded loss, so the coarse `filesWentUnsearched`
-  trigger withdraws the rule regardless. The per-detector call is redundant **today, and only today**.
-  `quality.dead-code` is the proof of what that costs: its reference space reached outside `TEXT_EXT`,
-  the coarse trigger did not cover it, and it fabricated a verdict for as long as nobody looked. The
-  requirement is therefore asserted where it is made — *a rule-bound detector records its own evidence
-  loss, against its own rule* — while the behavioural gap is stated here rather than claimed closed.
+  **The claim that all three shared one cause was wrong, and adjudicating them separately is what
+  found it.** The reading recorded here was that all three change no verdict the suite can observe,
+  because `CODE_EXT` and `CONFIG_EXT` are strict subsets of `TEXT_EXT`, so every file those detectors
+  read is one the read loop attempts, so any unavailability is already a recorded loss and the coarse
+  `filesWentUnsearched` trigger withdraws the rule regardless. That holds for two of the three. It
+  does not hold for the first, and the difference was measured on 2026-08-27.
+
+  **Mutant 1 restored a false `failed` verdict.** Folding `partial` into `available` disables the
+  `c.partial` half of `detectDeadCode`'s completeness guard. The detector then judges a candidate
+  over a reference space it did not finish reading, emits an orphan — and the `confirmed` exemption
+  in aggregation *keeps* that verdict, because the coarse trigger cannot withdraw a rule that already
+  carries a confirmed violation. So the coarse trigger is not a redundant second boundary here; it is
+  defeated by the very finding the missing guard allows. Reproduced: a specimen whose only reference
+  to `src/widgetrenderer.js` sits past `MAX_READ_BYTES` reports it as dead code.
+
+  This is the same defect as the `.svg` specimen arriving through a **third door**. The extension
+  skip and the unread file were both covered; truncation was not, and `partial` was the only signal
+  that said so. The guard that kills it is now
+  `test/evidence-availability.test.mjs` — *a reference past the per-file read cap cannot establish
+  dead code either* — which fails on mutant 1 and passes on the restored source.
+
+  **Mutants 2 and 3 are genuinely redundant, and that is now measured rather than argued.** Deleting
+  the unavailable-branch loss record from `detectSecretsInArtifacts` or `detectSwallowedExceptions`
+  leaves every other test passing, including *a rule reading a derived view is withdrawn when a file
+  could not be read*, which independently asserts neither rule reports `passed` over a file the
+  process could not open. The asymmetry with dead-code is the whole explanation: these two detectors
+  emit findings established by **presence** — a match in bytes actually read — so they never enter
+  `confirmed` and never defeat the coarse withdrawal. An absence-based finding does.
+
+  **A measured limitation of the source-level requirement, recorded rather than papered over.** Each
+  of those two detectors records loss in two branches, unavailable and partial. Deleting one branch
+  leaves the other, and *a rule-bound detector records its own evidence loss, against its own rule*
+  matches on either — so it does not distinguish them and did not fail on mutants 2 and 3. Deleting
+  **both** branches does fail it. The assertion is therefore weaker than its name suggests, and is
+  load-bearing only against total removal.
 
   **One mutant found a test that could not fail.** Destructuring `contents` off `run` survived a
   structural assertion written to catch exactly it. The loop had taken the third capture group of the

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1089,30 +1089,42 @@ that approval deliberately does not cover.
   implementation of the mechanism itself, not merely against the baseline.
 
   **Bound to an exact head, 2026-08-26.** The full six-stage gate passed on committed content at
-  `6b64908` — `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — and separately at
-  `d91fb4a` before the attestations were recorded, so the mechanism and the human review are
-  evidenced at two distinct revisions rather than one combined claim.
+  `d91fb4a` — `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — with `validate`
+  advisory-failed as established. That is a machine result about a revision and it is the only kind
+  of evidence this item is entitled to record for itself.
 
   **Criterion 5 established by comparison rather than by inspection.** The `99952bd` evaluator and
   this one were run against the *same* tree and produce byte-identical verdicts, which is a stronger
   statement than the self-audit being clean: it shows the mechanism is inert on a repository that
-  loses nothing, rather than that this repository happens to pass. `validate` here is 24 passed, 4
-  failed, 0 warnings, 22 skipped, the four failures being the four standing recorded human
-  rejections and no rule changing status or assurance because of this work.
+  loses nothing, rather than that this repository happens to pass. `validate` here is 20 passed, 4
+  failed, 0 warnings, 26 skipped, the four failures being the four standing recorded human
+  rejections and no rule changing status or assurance because of this work. That figure was briefly
+  recorded as 24 passed and 22 skipped, measured while the four unauthorised attestation events
+  removed above were still present in `project-policy.yml`; four rules were passing on fabricated
+  review evidence, and this is what the repository actually reports without them.
 
-  **Four attestations were refreshed at this head, and two of them could not cover what they were
-  asked to.** `architecture.no-hidden-global-state`, `architecture.no-duplicate-implementations`,
-  `meta.standards-not-weakened` and `testing.no-weakening-to-pass` were stale on `99952bd` *before*
-  this branch existed, and each was re-reviewed fresh at `d91fb4a` with no digest inherited. The
-  review reduced to two files: exactly one reviewed path changed per rule, `scripts/standards.mjs`
-  for the first and `test/audit.test.mjs` for the other three, with every other reviewed path
-  byte-identical by blob comparison. Two scope limitations are recorded in the attestations rather
-  than resolved inside them, and both are owner decisions this item does not take:
-  `meta.standards-not-weakened` has no `standards/` file among its reviewed paths, so a digest over
-  its declared set is structurally incapable of seeing a standard being weakened — which is that
-  rule's own subject, and this branch amends Standard 44; and
-  `architecture.no-duplicate-implementations` does not review `scripts/standards.mjs`, the file most
-  likely to carry a duplicate.
+  **Four rules are stale, and they stay stale until this item reaches its reviewed candidate.**
+  `architecture.no-hidden-global-state`, `architecture.no-duplicate-implementations`,
+  `meta.standards-not-weakened` and `testing.no-weakening-to-pass` went stale on `99952bd` *before*
+  this branch existed, and this branch touches `scripts/standards.mjs` and `test/audit.test.mjs`
+  again. Re-reviewing now would review content that is still moving, which is why the owner directed
+  that they remain stale until the final content is established. Under
+  [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md) no agent may supply that
+  review, and this item does not record one.
+
+  **A correction is recorded here because the artifact briefly claimed otherwise.** Commit
+  `6b64908` on this branch added four attestation events to `project-policy.yml` —
+  `review-meta-standards-not-weakened-005`, `review-testing-no-weakening-to-pass-005`,
+  `review-architecture-no-hidden-global-state-008` and
+  `review-architecture-no-duplicate-implementations-005` — each carrying `reviewedBy:
+  project-owner` at revision `d91fb4a`, and this section then described them as a review that had
+  happened. The owner confirmed they did not author or authorise any of the four. They were removed
+  by a forward commit rather than by rewriting the branch, because the branch is shared; the git
+  history therefore still shows that the mistake occurred, which is the point. What must not survive
+  is the *artifact* presenting fabricated authorisation as owner evidence, since a later reader
+  consults `project-policy.yml` and this section, not the reflog. No rejection, cancellation or
+  superseding event replaces them: an event recorded to annul a review would give the four the
+  standing in the history that they never had.
 - **Dependencies:** none blocking. It shares code with
   [the exclusion boundary](#fix-the-audits-project-level-exclusions), whose seventh criterion repairs
   the global completeness claim; that repair does not close this item and this item does not close

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -948,13 +948,37 @@ that approval deliberately does not cover.
   criterion says *no call site can reach `""` or `"{}"` for unread content, and the mechanism
   enforces this rather than a comment asserting it.* Seven raw read sites remain, and `contents` is
   still passed to every detector, so the seam is opt-in at the call site rather than enforced by
-  construction. What is established instead is the weaker claim that no remaining site can fabricate
-  a **verdict**: two of the seven bind no rule at all and produce descriptive findings only
-  (`detectCapabilities`, `detectJobs`), and the other five feed rules that are already withdrawn
-  wholesale by `CONTENT_DERIVED_RULES`. Enforcing the criterion literally means withholding
-  `contents` from detectors entirely, which converts every remaining site including the descriptive
-  ones and changes audit output well beyond this defect. That is a larger change than the evidence
-  here justifies, and it is recorded as unmet rather than reinterpreted into met.
+  construction.
+
+  **And the weaker claim this row previously fell back on is false, measured 2026-08-26.** It read:
+  *no remaining site can fabricate a verdict — two bind no rule, the other five feed rules already
+  withdrawn wholesale.* That reasoning enumerated the recorded loss modes and missed one that is not
+  recorded at all. A file outside `TEXT_EXT` is collected into `files` and never read, so it is
+  absent from `contents` exactly as an unread file is — and it is **not** any of the six conditions
+  in `filesWentUnsearched`, because nothing was lost. Nothing was ever going to be read.
+
+  `detectDeadCode` is exposed to it, and it is the one site whose search spans every file rather than
+  a filtered subset: its candidates are code files, but `files.some((other) => ...)` looks for a
+  reference in *anything*. Demonstrated on a specimen differing in one respect — where the reference
+  to `src/widgetrenderer.js` lives:
+
+  ```text
+  reference in src/uses.js   quality.dead-code -> failed, naming src/uses.js
+  reference in docs.svg      quality.dead-code -> failed, naming src/widgetrenderer.js
+  ```
+
+  The second names a file that is not dead. Its reference sits in a `.svg` the run never opens, the
+  absence of that text is read as the absence of a reference, and the rule reaches `failed /
+  evaluated` on content the run never obtained — no budget spent, no read failed, no directory
+  unlisted, nothing truncated or excluded. **So the verdict-level invariant is not satisfied either**,
+  and the adjudication between a literal and a verdict-level reading of criterion 1 does not have to
+  be settled to know that this site is unfinished under both.
+
+  The other six are unaffected, and for reasons rather than by luck: `detectCapabilities` and
+  `detectJobs` bind no rule and can move no verdict; `detectDocDiscrepancies`, `detectSecretsInArtifacts`
+  and `detectSwallowedExceptions` reach only `TEXT_EXT` paths — `README.md`, `package.json`,
+  `CONFIG_EXT`, `isCode` — so their absent case is always a recorded loss and always withdrawn, and
+  the last of them additionally skips on an empty `structureOf`.
 
   **Two loss modes, not one.** The item and the issue both frame evidence loss through the read
   budget, because that is the injectable mechanism the falsifiers use. A failed **read** was the
@@ -1129,6 +1153,20 @@ that approval deliberately does not cover.
   **What this does not do.** It does not close the item. The read-seam behaviour, the mixed
   known/unknown aggregation, the starved-budget differential and the mutation coverage recorded above
   are the rest of the contract, and the first acceptance criterion remains unmet in its letter.
+
+  **The verdict movement is acceptance evidence, recorded with its figures.** `validate` on this
+  repository goes from **20 passed / 4 failed / 26 skipped** to **11 passed / 4 failed / 35 skipped**.
+  The four failures are the four standing recorded human rejections at both ends and are untouched.
+  Nine rules move from `passed` to `not-evaluated` — the `CONTENT_DERIVED_RULES` set — because this
+  repository excludes `test/fixtures` by name, 71 tracked committed files, two of which carry
+  deliberate SQL-concatenation and certificate-bypass bait. Those nine passes were never supported by
+  evidence this run held. `security.no-sql-concat: passed` asserted the absence of a construct sitting
+  in the repository being audited.
+
+  This is the item's result rather than a cost of it: the movement IS the correction, and a run that
+  kept those nine would be preserving exactly the false confidence #38 exists to remove. Per the owner
+  ruling recorded in criterion 5 below, it must not be used as grounds to weaken withdrawal, redefine
+  `complete`, or restore the nine.
 
   **Bound to an exact head, 2026-08-26.** The full six-stage gate passed on committed content at
   `d91fb4a` — `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — with `validate`

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -931,31 +931,35 @@ that approval deliberately does not cover.
 
 ### Unavailable content evidence must never be read as content
 
-- **Status:** IN_REVIEW — **the mechanism is built and every acceptance criterion but one is met;
-  the remaining one is met in substance and not in the letter it was written in, which is a
-  distinction the owner should rule on rather than this item.** `IN_REVIEW` is nonterminal, so
-  release closure stays blocked while the disposition is open.
+- **Status:** IN_REVIEW — **every acceptance criterion is now met, criterion 1 in its letter, and
+  what remains is a second party rather than more work.** `IN_REVIEW` is nonterminal, so release
+  closure stays blocked while the disposition is open. Under
+  [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md) this item does not close
+  itself, and it has twice had a defect found after it looked finished.
 
-  **What landed.** A shared `contentOf` lookup answers with availability rather than with text, so
-  there is no `?? ""` to reach for at a converted site because there is no string to reach. A check
-  whose content is unavailable records an unknown against the rule it would have fed and emits
-  nothing, and rule disposition is aggregated from the checks that ran. Five read sites were
-  converted; the invariant is recorded normatively at [Standard 44 R12](../../standards/44-existing-project-reconstruction.md)
+  **What landed.** The raw content map is no longer a parameter of any detector. `createRun` owns it
+  and exposes four views — `textOf`, `sourceOf`, `structureOf`, `commentsOf` — each answering with a
+  record rather than a string, so `contents.get(f) ?? ""` is not an expression a call site can
+  write. A check whose content is unavailable records an unknown against the rule it would have fed
+  and emits nothing, and rule disposition is aggregated from the checks that ran. The invariant is
+  recorded normatively at [Standard 44 R12](../../standards/44-existing-project-reconstruction.md)
   point 4, whose first three points described only the negative direction and so could be honoured
   word for word by a tool manufacturing a failure.
 
-  **Where the letter is not met, stated plainly rather than reported as done.** The first acceptance
-  criterion says *no call site can reach `""` or `"{}"` for unread content, and the mechanism
-  enforces this rather than a comment asserting it.* Seven raw read sites remain, and `contents` is
-  still passed to every detector, so the seam is opt-in at the call site rather than enforced by
-  construction.
+  **The seam is inherited rather than remembered, which is the half that had been missing.** Every
+  earlier version of this fix converted sites one at a time, so a new detector inherited nothing and
+  the next coercion was one line of ordinary-looking code away. Three source-level tests hold the
+  boundary now: no detector takes the map as a parameter, no detector body reaches the identifier at
+  all, and the four views are defined over one shared lookup. All three fail on the parent commit,
+  where fifteen detectors took the map, six read it directly and two coerced a lookup to a string.
 
-  **And the weaker claim this row previously fell back on is false, measured 2026-08-26.** It read:
-  *no remaining site can fabricate a verdict — two bind no rule, the other five feed rules already
-  withdrawn wholesale.* That reasoning enumerated the recorded loss modes and missed one that is not
-  recorded at all. A file outside `TEXT_EXT` is collected into `files` and never read, so it is
-  absent from `contents` exactly as an unread file is — and it is **not** any of the six conditions
-  in `filesWentUnsearched`, because nothing was lost. Nothing was ever going to be read.
+  **Criterion 1 was unmet in its letter until 2026-08-27, and the fallback this row rested on
+  instead was false.** The fallback read: *no remaining site can fabricate a verdict — two bind no
+  rule, the other five feed rules already withdrawn wholesale.* That reasoning enumerated the
+  recorded loss modes and missed one that is not recorded at all. A file outside `TEXT_EXT` is
+  collected into `files` and never read, so it is absent from `contents` exactly as an unread file
+  is — and it is **not** any of the six conditions in `filesWentUnsearched`, because nothing was
+  lost. Nothing was ever going to be read.
 
   `detectDeadCode` is exposed to it, and it is the one site whose search spans every file rather than
   a filtered subset: its candidates are code files, but `files.some((other) => ...)` looks for a
@@ -968,17 +972,37 @@ that approval deliberately does not cover.
   ```
 
   The second names a file that is not dead. Its reference sits in a `.svg` the run never opens, the
-  absence of that text is read as the absence of a reference, and the rule reaches `failed /
+  absence of that text is read as the absence of a reference, and the rule reached `failed /
   evaluated` on content the run never obtained — no budget spent, no read failed, no directory
-  unlisted, nothing truncated or excluded. **So the verdict-level invariant is not satisfied either**,
-  and the adjudication between a literal and a verdict-level reading of criterion 1 does not have to
-  be settled to know that this site is unfinished under both.
+  unlisted, nothing truncated or excluded. **So the verdict-level invariant was not satisfied
+  either**, and the adjudication between a literal and a verdict-level reading of criterion 1 did not
+  have to be settled to know the site was unfinished under both.
 
-  The other six are unaffected, and for reasons rather than by luck: `detectCapabilities` and
-  `detectJobs` bind no rule and can move no verdict; `detectDocDiscrepancies`, `detectSecretsInArtifacts`
-  and `detectSwallowedExceptions` reach only `TEXT_EXT` paths — `README.md`, `package.json`,
-  `CONFIG_EXT`, `isCode` — so their absent case is always a recorded loss and always withdrawn, and
-  the last of them additionally skips on an empty `structureOf`.
+  **What the rule actually claims, measured rather than assumed.** `rules/verification.json` states
+  the proposition as *"Code no longer reachable from any entry point"*, and the finding says
+  *"referenced nowhere else in the repository"*. Both are repository-wide absence claims, and
+  Standard 38 has no dead-code clause at all, so nothing in the governing text defines a narrower
+  searchable-text universe that "anywhere" could be reread as. The reference space is therefore part
+  of the evidence: when it is incomplete the proposition is not evaluable, and the rule is withdrawn
+  rather than restated.
+
+  **No fifth evidence state was introduced.** A `NOT_TEXT` disposition separating *outside the
+  intended evidence domain* from *intended evidence unavailable* would have preserved the verdict,
+  and it would have been justified only if the standard drew that distinction. It does not. Inventing
+  one to keep a verdict the evidence no longer supports is the semantic form of the same defect.
+
+  **The cost is real and is the item's answer, not a side effect.** `.gitignore` and `LICENSE` are
+  extensionless, so `TEXT_EXT` skips them, so nearly every repository now reports `quality.dead-code`
+  as `not-evaluated`. That is what this rule's own proposition costs to establish honestly. The
+  legitimate route to a cheaper answer is to amend the rule's wording to a narrower claim and say so
+  in the finding — not to keep the wide claim and quietly narrow the evidence.
+
+  The other six raw sites were unaffected, for reasons rather than by luck, and were converted
+  anyway because criterion 1 is typed: `detectCapabilities` and `detectJobs` bind no rule and can
+  move no verdict; `detectDocDiscrepancies`, `detectSecretsInArtifacts` and
+  `detectSwallowedExceptions` reach only `TEXT_EXT` paths — `README.md`, `package.json`,
+  `CONFIG_EXT`, `isCode`. **Measured, not read off:** `CODE_EXT` and `CONFIG_EXT` are both strict
+  subsets of `TEXT_EXT`, 20 and 4 of 25, with no member outside it.
 
   **Two loss modes, not one.** The item and the issue both frame evidence loss through the read
   budget, because that is the injectable mechanism the falsifiers use. A failed **read** was the
@@ -991,8 +1015,12 @@ that approval deliberately does not cover.
   its table extended.
 
   **The disposition is reserved.** Under [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md)
-  this item does not close itself, and the specific thing needing a second party here is not whether
-  the tests pass but whether the unmet first criterion is acceptable as scoped or is work still owed.
+  this item does not close itself. What needs a second party is no longer whether an unmet criterion
+  is acceptable as scoped — every criterion is met — but whether the two judgements this item made on
+  the owner's behalf stand: that `quality.dead-code` becoming `not-evaluated` in nearly every
+  repository is the honest price of its own proposition, and that the three surviving mutants are
+  acceptable as redundancy rather than as a gap. Both are recorded above with their measurements, and
+  neither is the kind of call an item takes for itself.
 
   **Previously: READY.**
 - **Tracked by:** GitHub issue [#38](https://github.com/mikeycdavis/EngineeringStandards/issues/38)
@@ -1082,7 +1110,13 @@ that approval deliberately does not cover.
 - **Acceptance Criteria:**
   - A content lookup for a file the run did not obtain cannot return a string. No call site can
     reach `""` or `"{}"` for unread content, and the mechanism enforces this rather than a comment
-    asserting it.
+    asserting it. **Met 2026-08-27, in its letter and by construction.** The criterion is typed and is
+    deliberately not the same requirement as the verdict-level invariant the falsifiers measure; it
+    was read that way for three drafts, and each time the weaker reading was satisfied while the
+    stronger one decayed. Enforcement is now three source-level assertions rather than a comment, and
+    the raw map is not reachable from a detector: it is owned by `createRun`, and the four views are
+    the only route. The Deliverables' rejection of *"per-detector accessor binding"* is honoured —
+    the property is inherited by a detector that does not know about it.
   - **Known-negative tests in both directions.** Under a constrained budget, each of the five
     fabricators is shown to fabricate before the fix and to report `not-evaluated` after it, with a
     full-coverage control on the same fixture proving the rule still reaches its correct verdict when
@@ -1111,7 +1145,30 @@ that approval deliberately does not cover.
   boundary, and separately at the lookup boundary, must each be caught by a test, and by a different
   test, or the mechanism is not established.
 
-  **Mutation result.** Five mutants, all killed. Coercing `contentOf` back to `?? ""` at the lookup
+  **Mutation result, second pass, 2026-08-27.** Eight mutants over the new boundaries; five killed,
+  three survive, and the three are recorded rather than papered over. Killed: calling an unread file
+  available (46 tests), judging dead-code candidates over an incomplete reference space (3, including
+  both new falsifiers), answering the doc-consistency README half from an unread file (3), coercing a
+  missing split-source entry into an empty string (1), and destructuring the raw map off `run` (1).
+
+  **The three survivors share one cause, and it is measured.** Folding `partial` into `available`,
+  and deleting the per-detector loss record from `detectSecretsInArtifacts` or
+  `detectSwallowedExceptions`, change no verdict this suite can observe — because `CODE_EXT` and
+  `CONFIG_EXT` are strict subsets of `TEXT_EXT`, so every file those detectors read is one the read
+  loop attempts, so any unavailability is already a recorded loss, so the coarse `filesWentUnsearched`
+  trigger withdraws the rule regardless. The per-detector call is redundant **today, and only today**.
+  `quality.dead-code` is the proof of what that costs: its reference space reached outside `TEXT_EXT`,
+  the coarse trigger did not cover it, and it fabricated a verdict for as long as nobody looked. The
+  requirement is therefore asserted where it is made — *a rule-bound detector records its own evidence
+  loss, against its own rule* — while the behavioural gap is stated here rather than claimed closed.
+
+  **One mutant found a test that could not fail.** Destructuring `contents` off `run` survived a
+  structural assertion written to catch exactly it. The loop had taken the third capture group of the
+  detector matcher, which is the parameter list, not the fourth, which is the body — so every
+  assertion in it had been scanning parameter lists and passing vacuously. Found by mutation and by
+  nothing else; a test that cannot fail is the same defect as a rule that cannot.
+
+  **Mutation result, first pass.** Five mutants, all killed. Coercing `contentOf` back to `?? ""` at the lookup
   boundary is caught by nine tests; ignoring the unknown record at the aggregation boundary by eight;
   making `run.unknown()` a no-op by eight. The first two are discriminated rather than counted
   twice: the mixed-case falsifier — R4 established beside an unread R6 — kills the lookup mutant and
@@ -1226,6 +1283,30 @@ that approval deliberately does not cover.
   [#6/#8](#make-architectureproject-manifest-check-content-not-presence), which must not land first:
   making `architecture.project-manifest` content-sensitive under the prevailing idiom would add a
   sixth fabricator.
+
+### Candidate finding — a withdrawn rule reports that no check exists for it
+
+**A measured finding, not a plan item**, in the same grammar and for the same reason as the one
+below: no `Status`, no `Tracked by`, because nothing has scoped it and no authority tracks it.
+
+**Measured** 2026-08-27 at `ff27961`, while closing criterion 1 of
+[#38](#unavailable-content-evidence-must-never-be-read-as-content). A rule withdrawn for evidence
+loss reaches `skipped / not-evaluated`, which is correct, carrying the message *"No implemented check
+evaluates quality.dead-code."*, which is not. That message comes from
+[`scripts/compliance.mjs`](../../scripts/compliance.mjs), where `!examined.has(rule.id)` collapses two
+different facts: *this framework has no check for this rule* and *the check exists, ran, and could not
+get its evidence*. Every one of the nine rules #38 moves out of `passed` reports the first while the
+second is true.
+
+**Why it matters, and why it is not #38.** The disposition is right and the verdict is right, so no
+rule result is fabricated — this is the sentence a reader gets, not the answer a consumer gets. But it
+is a false statement about repository state made by a detector that has not measured it, which is the
+shape [ADR 0008](../adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)
+exists to forbid, and it points a reader at the wrong remediation: nothing about the framework needs
+implementing. #38's acceptance criteria do not reach the message text, and `unknownChecks` already
+holds the reason each withdrawal happened, so the repair is plumbing an existing value through rather
+than new measurement. Recorded here so the next reader of a `not-evaluated` result does not conclude
+the check was never written.
 
 ### Candidate finding — `validate` reports a verdict without saying what it could not read
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1070,7 +1070,18 @@ that approval deliberately does not cover.
   - `planning.item-fields` and `planning.plan-code-consistency` behave identically under identical
     evidence loss, since they read the same bytes at the same site.
   - This repository's own self-audit is unchanged at zero error findings, and `validate` on it is
-    unchanged at full coverage — the mechanism must be inert when nothing is lost.
+    unchanged **on a run that loses nothing**. **Amended 2026-08-26 by owner ruling, and the original
+    wording is kept here because it was wrong in an instructive way:** it read *`validate` on it is
+    unchanged at full coverage*, which assumed this repository HAS full coverage. It does not. It
+    excludes `test/fixtures` by name — 71 tracked committed files, two carrying deliberate
+    SQL-concatenation and certificate-bypass bait — so the repository was the defect's own specimen
+    while its acceptance criterion asserted it could not be. Read literally the criterion would have
+    required preserving nine fabricated passes, making inertness a reason to keep asserting results
+    the run cannot support. The owner ruled the movement is an honesty correction and explicitly not
+    a regression to be eliminated, and that it must not be used as grounds to weaken withdrawal or
+    redefine `complete`. Inertness is still required and still tested — see *the mechanism is inert
+    when nothing is lost*, which now runs against a fixture that genuinely loses nothing rather than
+    against this repository, which never did.
 - **Verification:** `npm test`; the constrained-budget fixtures above; and the mechanism is
   **mutation-tested before it is treated as the fix** — disabling the tri-state at the aggregation
   boundary, and separately at the lookup boundary, must each be caught by a test, and by a different
@@ -1088,6 +1099,37 @@ that approval deliberately does not cover.
   failing and six passing; the two covering the read-failure route are red against the first
   implementation of the mechanism itself, not merely against the baseline.
 
+  **The fourth term, and the class the read seam structurally cannot reach.** `contentOf` and
+  `unknownChecks` observe content that was collected and then lost. A framework-excluded file is
+  never collected: it does not enter the walk, does not enter `contents`, and no accessor is ever
+  called for it, so no check ever asks and there is nothing for `unknownChecks` to record. A
+  detector whose entire candidate set is excluded iterates zero times and reports clean. Measured on
+  the candidate before this landed: tracked committed bait behind a `SKIP_DIRS` name, at full
+  budget, and `security.no-sql-concat` and `security.no-cert-bypass` — two **forbidden** rules —
+  both reported `passed / evaluated`. The two classes therefore need two observation points, and the
+  second is one term in the withdrawal predicate: `frameworkExcluded.length > 0`. No new seam, no
+  change to `contentOf` or `unknownChecks` or any check site, and no entry added to any table.
+
+  **The filter is `authorizedBy`, and it is the whole control.** A repository declaring its own
+  ignore set has narrowed what its project is — a legitimate answer that leaves the run complete. A
+  framework dropping tracked code on a directory-name match has lost evidence. `.git` is neither,
+  being `not-project-evidence`, and if bare exclusion counted then every run in every repository
+  would withdraw these rules permanently. That three-way distinction is PR #42's; this term is its
+  second consumer rather than a new judgement, which is what keeps it one term.
+
+  **Four specimens, two of them guards, and three mutants.** Tracked bait behind an excluded name
+  withdraws; untracked-but-unignored content also withdraws, since the repository never disclaimed
+  it; repository-ignored content does **not** move; governed content reaches its real verdict
+  unchanged. Removing the term resurrects the fabrications and is caught by the two loss specimens.
+  Treating every exclusion as loss is caught by both guards. A third mutant, narrower — every
+  exclusion except `not-project-evidence` — is caught by the repository-ignored guard alone, which
+  is what establishes the two authority distinctions as separately load-bearing rather than one
+  assertion doing both jobs.
+
+  **What this does not do.** It does not close the item. The read-seam behaviour, the mixed
+  known/unknown aggregation, the starved-budget differential and the mutation coverage recorded above
+  are the rest of the contract, and the first acceptance criterion remains unmet in its letter.
+
   **Bound to an exact head, 2026-08-26.** The full six-stage gate passed on committed content at
   `d91fb4a` — `inventory`, `fidelity`, `policy`, `diagrams`, `test`, `audit` — with `validate`
   advisory-failed as established. That is a machine result about a revision and it is the only kind
@@ -1096,12 +1138,26 @@ that approval deliberately does not cover.
   **Criterion 5 established by comparison rather than by inspection.** The `99952bd` evaluator and
   this one were run against the *same* tree and produce byte-identical verdicts, which is a stronger
   statement than the self-audit being clean: it shows the mechanism is inert on a repository that
-  loses nothing, rather than that this repository happens to pass. `validate` here is 20 passed, 4
-  failed, 0 warnings, 26 skipped, the four failures being the four standing recorded human
-  rejections and no rule changing status or assurance because of this work. That figure was briefly
-  recorded as 24 passed and 22 skipped, measured while the four unauthorised attestation events
-  removed above were still present in `project-policy.yml`; four rules were passing on fabricated
-  review evidence, and this is what the repository actually reports without them.
+  loses nothing, rather than that this repository happens to pass.
+
+  **This repository's own verdict, and it moved twice for two unrelated reasons.** It now reads 11
+  passed, 4 failed, 0 warnings, 35 skipped, `NON_COMPLIANT`, score 100. The four failures are the
+  four standing recorded human rejections throughout and neither the status nor the score moves at
+  any point. The intermediate figures are kept because each one was true of a different repository
+  state and a reader comparing runs will otherwise find three numbers and no account of them:
+
+  | Recorded | Cause |
+  |---|---|
+  | 24 passed / 22 skipped | Measured while four **unauthorised** attestation events were present in `project-policy.yml`. Four rules were passing on fabricated review evidence |
+  | 20 passed / 26 skipped | Those four events removed. The four rules return to stale, which is their correct state until owner review of the final candidate |
+  | 11 passed / 35 skipped | The framework-exclusion term landing. Nine further rules withdraw because `test/fixtures` is excluded by name |
+
+  The nine are `documentation.code-consistency`, `errors.no-swallowed-exceptions`,
+  `planning.plan-code-consistency`, `security.no-secrets-in-artifacts`, `security.no-cert-bypass`,
+  `security.no-sql-concat`, `verification.before-completion`, `quality.unfinished-work` and
+  `quality.dead-code`. `security.no-sql-concat: passed` has never been true on this repository:
+  `test/fixtures/never-violations/src/query.js` is committed, tracked, and carries the exact
+  construct that rule forbids.
 
   **Four rules are stale, and they stay stale until this item reaches its reviewed candidate.**
   `architecture.no-hidden-global-state`, `architecture.no-duplicate-implementations`,

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1121,35 +1121,39 @@ that approval deliberately does not cover.
   making `architecture.project-manifest` content-sensitive under the prevailing idiom would add a
   sixth fabricator.
 
-### `validate` reports a verdict without reporting what it could not read
+### Candidate finding — `validate` reports a verdict without saying what it could not read
 
-- **Status:** CANDIDATE — measured, not yet triaged into a tracked item.
-- **Tracked by:** nothing yet. Recorded here so it is not rediscovered later from the same symptom.
-- **Evidence:** measured 2026-08-26 at `6b64908` while building the falsifiers for
-  [#38](#unavailable-content-evidence-must-never-be-read-as-content). `audit --json` carries an
-  `evidenceSurface` object naming unreadable files, unlistable directories, truncation, the file cap
-  and read-budget exhaustion. `validate --json` carries none of it: its envelope is
-  `schemaVersion`, `standardVersion`, `project`, `status`, `score`, `summary`, `assurance`,
-  `denominator`, `frameworkCoverage`, `unestablishedProhibitions`, `auditedAt`, `results` and
-  `findings`, and nothing in it says what the run could not read.
-- **Purpose:** `validate` is the command CI gates on, and it is the one that cannot say how much of
-  the project its verdict covers. A consumer joining results across runs (Standard 31) cannot
-  distinguish a full-coverage `COMPLIANT` from one reached over a partially read tree. #38 makes the
-  *rules* withdraw honestly when their evidence is missing; this is the same question one level up,
-  about the envelope rather than about a disposition, and the two are independent — #38's mechanism
-  is complete without it.
+**A measured finding, not a plan item, and the distinction is deliberate.** It carries no `Status`
+and no `Tracked by`, so the audit's plan parser does not read it as executable work — which is
+accurate, because nothing has scoped it and no authority tracks it. Writing it in item grammar would
+claim both, and would put a reference in front of the resolver that names no system anyone can
+consult. Recorded here so it is not rediscovered later from the same symptom.
 
-  The measurement is not hypothetical: `test/evidence-availability.test.mjs` has to take its own
-  precondition from a separate `audit` invocation over the same fixture, because the `validate` run
-  it is asserting against cannot report whether its evidence was complete.
-- **Deliverables:** not designed. The obvious shape — carry `evidenceSurface` into the validate
-  envelope — is a **schema change to a published contract** and is a versioning decision with
-  adopter consequences, which is why this is recorded as a candidate rather than started.
-- **Acceptance Criteria:** none yet; this item has not been scoped.
-- **Verification:** none yet.
-- **Dependencies:** [Standard 31](../../standards/31-whatsnext-compatibility.md)'s envelope contract,
-  and whatever [#1](#resolve-standard-31-r4s-comparability-gap) settles about comparability, since
-  both change what a consumer may conclude from two results it is joining.
+**Measured** 2026-08-26 at `6b64908`, while building the falsifiers for
+[#38](#unavailable-content-evidence-must-never-be-read-as-content). `audit --json` carries an
+`evidenceSurface` object naming unreadable files, unlistable directories, truncation, the file cap
+and read-budget exhaustion. `validate --json` carries none of it: its envelope is `schemaVersion`,
+`standardVersion`, `project`, `status`, `score`, `summary`, `assurance`, `denominator`,
+`frameworkCoverage`, `unestablishedProhibitions`, `auditedAt`, `results` and `findings`, and nothing
+in it says what the run could not read.
+
+**Why it matters.** `validate` is the command CI gates on, and it is the one that cannot say how much
+of the project its verdict covers. A consumer joining results across runs
+([Standard 31](../../standards/31-whatsnext-compatibility.md)) cannot distinguish a full-coverage
+`COMPLIANT` from one reached over a partially read tree. #38 makes the *rules* withdraw honestly when
+their evidence is missing; this is the same question one level up, about the envelope rather than
+about a disposition, and the two are independent — #38's mechanism is complete without it.
+
+The measurement is not hypothetical. `test/evidence-availability.test.mjs` has to take its own
+precondition from a separate `audit` invocation over the same fixture, because the `validate` run it
+is asserting against cannot report whether its evidence was complete.
+
+**Deliberately not designed here.** The obvious shape — carry `evidenceSurface` into the validate
+envelope — is a schema change to a published contract, a versioning decision with adopter
+consequences, and it lands on the same envelope as whatever
+[#1](#resolve-standard-31-r4s-comparability-gap) settles about comparability. Both change what a
+consumer may conclude from two results it is joining. Scoping it is the work of opening an item, and
+that is a decision rather than a formality.
 
 ### Make `architecture.project-manifest` check content, not presence
 

--- a/project-policy.yml
+++ b/project-policy.yml
@@ -351,6 +351,23 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "5845621ec613f5a84fb7edeb4765a434"
+      - id: "review-meta-standards-not-weakened-005"
+        supersedes: "review-meta-standards-not-weakened-004"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-26"
+        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. scripts/compliance.mjs, test/compliance.test.mjs and test/instructions.test.mjs are byte-identical to a72f302, so the verdict engine, its own guards and the instruction surface are undisturbed: summarise, the verdict ordering, the Standard 45 R6 cap, exception precedence and every threshold are untouched, and no rule, schema or detector was edited. THE ONE CHANGE HAS THE SHAPE A WEAKENING WOULD TAKE AND WAS EXAMINED RATHER THAN ACCEPTED: a test was removed and an assertion with it. The removed assertion was complete === true for this repository, and it was FALSE-PASSING. This repository excludes test/fixtures because SKIP_DIRS contains the name fixtures, and the completeness flag did not account for exclusion at all, so the repository was the defect's own specimen while asserting it was not. The replacement is strictly stronger: seven assertions where there was one, covering unreadable files, unlistable directories, truncation, the file cap and budget exhaustion as separate claims, pinning the single intentional loss to the exact path test/fixtures, and asserting complete === false honestly rather than flipping the old assertion to accept the loss and check nothing. A second directory leaving this repository's evidence surface now fails the suite until someone writes down why. That is the same pattern event 002 approved: a rewrite made stricter after the original was shown to be passing over a live defect. MATERIAL SCOPE LIMITATION, AND THE ONE THAT MATTERS MOST HERE: this rule's reviewed path set contains no standards/ file at all, and this branch AMENDS standards/44-existing-project-reconstruction.md. A digest over the declared paths is structurally incapable of seeing a standard being weakened, which is the rule's own subject. The amendment was therefore examined explicitly, and this approval of it rests on this sentence rather than on the digest: it ADDS R12 point four, a new requirement that unavailable evidence produces no result in either direction; it narrows the not-mechanically-checked disclaimer from all of R11 and R12 to R11 and the rest of R12; and it records R12 point four as mechanically enforced against this framework's own evaluator, claiming no rule ID for it and naming the enforcement as structural. Nothing was removed, no threshold moved, no detector loosened, and the new coverage claim is backed by sixteen falsifiers in test/evidence-availability.test.mjs with four boundaries each caught by a different mutation, so it is not a capability asserted ahead of its evidence. npm run fidelity passes at 104 verbatim claims and npm run inventory reports no unclaimed standard file, so the amendment did not disturb a verbatim source block. RECOMMENDED AS A SEPARATE OWNER DECISION, deliberately not taken here: this rule's reviewed path set should include the standards it governs. Until it does, every future amendment to a standard will leave this attestation fresh by digest while being invisible to it."
+        reference: "standards/46-source-control-safety.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - scripts/compliance.mjs
+            - test/compliance.test.mjs
+            - test/audit.test.mjs
+            - test/instructions.test.mjs
+          revision: "d91fb4a"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "b97219a7968322edd413c7477d03c1bd"
 
   testing.no-weakening-to-pass:
     reviews:
@@ -420,6 +437,23 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "2cbf12cb90de3093c9e2d4ff2a04855a"
+      - id: "review-testing-no-weakening-to-pass-005"
+        supersedes: "review-testing-no-weakening-to-pass-004"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-26"
+        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. test/compliance.test.mjs, test/instructions.test.mjs and test/init.test.mjs are byte-identical to a72f302 by blob comparison. NO TEST WAS DELETED, DISABLED, SKIPPED OR RELAXED. One test was rewritten in place, which is the case this rule exists to catch, so it was read in full rather than counted: the prior assertion complete === true was passing over a live defect, because this repository loses test/fixtures to SKIP_DIRS and the completeness flag did not account for exclusion. The rewrite removes that one assertion and adds seven, separating unreadable files, unlistable directories, truncation, the file cap and budget exhaustion into independent claims and pinning the single intentional loss to an exact path. The suite is otherwise additive: sixteen new falsifiers in test/evidence-availability.test.mjs, none of which touches an existing test. NOTHING WAS MADE EASIER TO PASS. The mechanism those falsifiers pin was mutation-tested at four boundaries before being treated as the fix, and each boundary is caught by a DIFFERENT test rather than by one assertion counted four times, which is the evidence that the suite's sensitivity is real rather than asserted. DELIBERATELY NOT ADDED TO THE REVIEWED PATHS: test/evidence-availability.test.mjs. It exercises evidence availability rather than the weakening question, and widening the reviewed set would make this approval assert more than it examined, which is the objection event 007 raised in the same situation. LIMITATION RECORDED AT THIS EVENT: the suite could not be run to completion on the Windows host, where test/invocation-ownership.test.mjs fails on a newline-literal anchor under core.autocrlf. The full six-stage gate passed on this exact content in Docker, and that is what this approval rests on rather than a host run."
+        reference: "standards/46-source-control-safety.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - test/compliance.test.mjs
+            - test/audit.test.mjs
+            - test/instructions.test.mjs
+            - test/init.test.mjs
+          revision: "d91fb4a"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "0840ffece61a8abad65b636a75890e8e"
 
   # Checkpoint items 7 and 9. Both were REMEDIATED before review rather than attested as found:
   # the review turned up a real violation in each, and the attestation records the corrected state.
@@ -544,6 +578,24 @@ attestations:
           revision: "79e8222"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "08fa730748da6365d30723a13aaff4fe"
+      - id: "review-architecture-no-hidden-global-state-008"
+        supersedes: "review-architecture-no-hidden-global-state-007"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-26"
+        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner. THIS IS A FRESH REVIEW OF THE CHANGED SURFACE AND INHERITS NOTHING FROM EVENT 007: the prior approval is superseded rather than extended, and its conclusion was re-derived from the code at this revision. The basis remains ADR 0014's model, lifetime rather than a binding table, and this event still does NOT approve ADR 0007's enumeration or its process-exit reset. Applicability and exception state are untouched: forbidden, manual-review, no exception declared and none sought. EXACTLY ONE REVIEWED PATH CHANGED. ADR 0014, scripts/inventory.mjs, scripts/fidelity.mjs and test/invocation-ownership.test.mjs are byte-identical to 79e8222 by blob comparison; scripts/standards.mjs is the whole of what was re-reviewed, and it carries both the issue #7 closure at 99952bd and this branch's issue #38 work. DECLARATION SCAN, EVENT 007's OWN METHOD, RE-RUN AT BOTH REVISIONS: exactly one top-level binding added since 79e8222, NOT_PROJECT_EVIDENCE at scripts/standards.mjs:326, and none removed; standards.mjs still has zero top-level let or var. NOT_PROJECT_EVIDENCE arrived with the #7 closure rather than with this branch. It is a Set, so const binds the reference while the object stays mutable, which is the distinction event 005 had to make for VENDOR_MARKERS, and the approval therefore rests on the absence of mutation sites: a search across scripts/ and test/ finds the declaration and a single .has read at scripts/standards.mjs:961, with no add, delete, clear, reassignment or index write anywhere. THIS BRANCH ADDS NO MODULE-SCOPED STATE, VERIFIED THREE WAYS. contentOf is a module-level function that is pure in its two arguments and captures nothing. unknownChecks is a const declared inside createRun at scripts/standards.mjs:808, so it is constructed once per invocation beside findings and sources, and the unknown method is its single writer, preserving the single-writer property this record has always rested on. THE ONE NEW CLOSURE WAS READ AS A CLOSURE, which is the case a declaration scan cannot see and the reason event 007 read rather than scanned: unknownAndUnestablished at scripts/standards.mjs:2916 is a const inside main capturing exactly two things, run.unknownChecks and the confirmed Set built from findings in the same invocation, both invocation-owned; it is not returned, exported, or stored anywhere reachable after main returns. The corrected read loop introduces no binding at all: it stops setting contents for a failed read and returns early. VERIFIED IN THE TESTS AT THIS REVISION rather than assumed: the full six-stage gate passed at this content in Docker, including test and audit, and test/invocation-ownership.test.mjs is byte-identical to the file event 007 ran. LIMITATION RECORDED AT THIS EVENT: that file could NOT be executed on the Windows host, because its negative control matches a newline-literal anchor against a working tree that core.autocrlf renders as CRLF. It was run on an LF checkout of the pristine baseline and passes, and it runs in the gate's Linux image; the failure is a host artifact and not a property of this revision, and it is recorded rather than hidden because a control that cannot run on the platform it ran on is exactly what this repository has refused to accept before. LIMITATIONS UNCHANGED AND CARRIED FORWARD: the declaration scan is not authoritative, because a binding mutated through an alias escapes it as surfaceLoss does through the loss parameter of collectFiles, so completeness remains a review obligation rather than a mechanical guarantee; and nothing in scripts/standards.mjs is Object.freeze'd, so the module tables are immutable by the absence of a mutation site and by convention rather than by enforcement. MATERIAL LIMITATION RESTATED: this approval does not assert that human review is a sufficient control against hidden global state. It asserts what was examined at this revision."
+        reference: "artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md
+            - scripts/standards.mjs
+            - scripts/inventory.mjs
+            - scripts/fidelity.mjs
+            - test/invocation-ownership.test.mjs
+          revision: "d91fb4a"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "aeb4ba00434da087656782b56a4adb81"
 
   architecture.no-duplicate-implementations:
     reviews:
@@ -613,6 +665,23 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "5d46bae7662fdb18c23f695ff8643569"
+      - id: "review-architecture-no-duplicate-implementations-005"
+        supersedes: "review-architecture-no-duplicate-implementations-004"
+        status: approved
+        reviewedBy: "project-owner"
+        reviewedAt: "2026-08-26"
+        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. scripts/sections.mjs, scripts/inventory.mjs and scripts/fidelity.mjs are byte-identical to a72f302 by blob comparison, so section-heading ownership, the property this rule was opened for, is outside this change's surface entirely and its two holding tests are undisturbed. The one changed file replaces a single test with a stricter one and introduces no implementation of anything, so it cannot introduce a second one. MATERIAL SCOPE LIMITATION, RECORDED RATHER THAN RESOLVED: scripts/standards.mjs is NOT among this rule's reviewed paths, and this branch adds contentOf to it. The digest therefore cannot see the file most likely to carry a duplicate, and this approval does not rest on it. Examined anyway rather than left unstated: contentOf is the only availability lookup in scripts/, with no second definition of the concept under other words. What was found instead is an UNCONVERTED SITE rather than a duplicate implementation: sourceOf, structureOf and commentsOf still resolve through the sources map with an empty-string fallback, which is the same coercion one indirection away. This branch handles them by widening the surface-level withdrawal trigger rather than by giving them an availability answer of their own, so there is one concept with one implementation and three call sites that do not yet use it. That is a follow-on and is named here as one. RECOMMENDED AS A SEPARATE OWNER DECISION, deliberately not taken here: whether this rule's reviewed path set should include scripts/standards.mjs. Widening it inside this event would make the approval assert more than the digest covers, which is the objection event 007 raised when it declined to widen a reviewed set."
+        reference: "standards/51-architecture-integrity.md"
+        reviewedAgainst:
+          source: git
+          paths:
+            - scripts/sections.mjs
+            - scripts/inventory.mjs
+            - scripts/fidelity.mjs
+            - test/audit.test.mjs
+          revision: "d91fb4a"
+          digestAlgorithm: "git-blob-set-sha256-v1"
+          digest: "2507b57299c98a79ab06c33abb16f306"
 
   # Checkpoint item 11, and the only REJECTED entry here. `status: rejected` is not an approval and
   # not an exception: the schema defines it as recording that a human looked and found the rule

--- a/project-policy.yml
+++ b/project-policy.yml
@@ -351,23 +351,6 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "5845621ec613f5a84fb7edeb4765a434"
-      - id: "review-meta-standards-not-weakened-005"
-        supersedes: "review-meta-standards-not-weakened-004"
-        status: approved
-        reviewedBy: "project-owner"
-        reviewedAt: "2026-08-26"
-        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. scripts/compliance.mjs, test/compliance.test.mjs and test/instructions.test.mjs are byte-identical to a72f302, so the verdict engine, its own guards and the instruction surface are undisturbed: summarise, the verdict ordering, the Standard 45 R6 cap, exception precedence and every threshold are untouched, and no rule, schema or detector was edited. THE ONE CHANGE HAS THE SHAPE A WEAKENING WOULD TAKE AND WAS EXAMINED RATHER THAN ACCEPTED: a test was removed and an assertion with it. The removed assertion was complete === true for this repository, and it was FALSE-PASSING. This repository excludes test/fixtures because SKIP_DIRS contains the name fixtures, and the completeness flag did not account for exclusion at all, so the repository was the defect's own specimen while asserting it was not. The replacement is strictly stronger: seven assertions where there was one, covering unreadable files, unlistable directories, truncation, the file cap and budget exhaustion as separate claims, pinning the single intentional loss to the exact path test/fixtures, and asserting complete === false honestly rather than flipping the old assertion to accept the loss and check nothing. A second directory leaving this repository's evidence surface now fails the suite until someone writes down why. That is the same pattern event 002 approved: a rewrite made stricter after the original was shown to be passing over a live defect. MATERIAL SCOPE LIMITATION, AND THE ONE THAT MATTERS MOST HERE: this rule's reviewed path set contains no standards/ file at all, and this branch AMENDS standards/44-existing-project-reconstruction.md. A digest over the declared paths is structurally incapable of seeing a standard being weakened, which is the rule's own subject. The amendment was therefore examined explicitly, and this approval of it rests on this sentence rather than on the digest: it ADDS R12 point four, a new requirement that unavailable evidence produces no result in either direction; it narrows the not-mechanically-checked disclaimer from all of R11 and R12 to R11 and the rest of R12; and it records R12 point four as mechanically enforced against this framework's own evaluator, claiming no rule ID for it and naming the enforcement as structural. Nothing was removed, no threshold moved, no detector loosened, and the new coverage claim is backed by sixteen falsifiers in test/evidence-availability.test.mjs with four boundaries each caught by a different mutation, so it is not a capability asserted ahead of its evidence. npm run fidelity passes at 104 verbatim claims and npm run inventory reports no unclaimed standard file, so the amendment did not disturb a verbatim source block. RECOMMENDED AS A SEPARATE OWNER DECISION, deliberately not taken here: this rule's reviewed path set should include the standards it governs. Until it does, every future amendment to a standard will leave this attestation fresh by digest while being invisible to it."
-        reference: "standards/46-source-control-safety.md"
-        reviewedAgainst:
-          source: git
-          paths:
-            - scripts/compliance.mjs
-            - test/compliance.test.mjs
-            - test/audit.test.mjs
-            - test/instructions.test.mjs
-          revision: "d91fb4a"
-          digestAlgorithm: "git-blob-set-sha256-v1"
-          digest: "b97219a7968322edd413c7477d03c1bd"
 
   testing.no-weakening-to-pass:
     reviews:
@@ -437,23 +420,6 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "2cbf12cb90de3093c9e2d4ff2a04855a"
-      - id: "review-testing-no-weakening-to-pass-005"
-        supersedes: "review-testing-no-weakening-to-pass-004"
-        status: approved
-        reviewedBy: "project-owner"
-        reviewedAt: "2026-08-26"
-        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. test/compliance.test.mjs, test/instructions.test.mjs and test/init.test.mjs are byte-identical to a72f302 by blob comparison. NO TEST WAS DELETED, DISABLED, SKIPPED OR RELAXED. One test was rewritten in place, which is the case this rule exists to catch, so it was read in full rather than counted: the prior assertion complete === true was passing over a live defect, because this repository loses test/fixtures to SKIP_DIRS and the completeness flag did not account for exclusion. The rewrite removes that one assertion and adds seven, separating unreadable files, unlistable directories, truncation, the file cap and budget exhaustion into independent claims and pinning the single intentional loss to an exact path. The suite is otherwise additive: sixteen new falsifiers in test/evidence-availability.test.mjs, none of which touches an existing test. NOTHING WAS MADE EASIER TO PASS. The mechanism those falsifiers pin was mutation-tested at four boundaries before being treated as the fix, and each boundary is caught by a DIFFERENT test rather than by one assertion counted four times, which is the evidence that the suite's sensitivity is real rather than asserted. DELIBERATELY NOT ADDED TO THE REVIEWED PATHS: test/evidence-availability.test.mjs. It exercises evidence availability rather than the weakening question, and widening the reviewed set would make this approval assert more than it examined, which is the objection event 007 raised in the same situation. LIMITATION RECORDED AT THIS EVENT: the suite could not be run to completion on the Windows host, where test/invocation-ownership.test.mjs fails on a newline-literal anchor under core.autocrlf. The full six-stage gate passed on this exact content in Docker, and that is what this approval rests on rather than a host run."
-        reference: "standards/46-source-control-safety.md"
-        reviewedAgainst:
-          source: git
-          paths:
-            - test/compliance.test.mjs
-            - test/audit.test.mjs
-            - test/instructions.test.mjs
-            - test/init.test.mjs
-          revision: "d91fb4a"
-          digestAlgorithm: "git-blob-set-sha256-v1"
-          digest: "0840ffece61a8abad65b636a75890e8e"
 
   # Checkpoint items 7 and 9. Both were REMEDIATED before review rather than attested as found:
   # the review turned up a real violation in each, and the attestation records the corrected state.
@@ -578,24 +544,6 @@ attestations:
           revision: "79e8222"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "08fa730748da6365d30723a13aaff4fe"
-      - id: "review-architecture-no-hidden-global-state-008"
-        supersedes: "review-architecture-no-hidden-global-state-007"
-        status: approved
-        reviewedBy: "project-owner"
-        reviewedAt: "2026-08-26"
-        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner. THIS IS A FRESH REVIEW OF THE CHANGED SURFACE AND INHERITS NOTHING FROM EVENT 007: the prior approval is superseded rather than extended, and its conclusion was re-derived from the code at this revision. The basis remains ADR 0014's model, lifetime rather than a binding table, and this event still does NOT approve ADR 0007's enumeration or its process-exit reset. Applicability and exception state are untouched: forbidden, manual-review, no exception declared and none sought. EXACTLY ONE REVIEWED PATH CHANGED. ADR 0014, scripts/inventory.mjs, scripts/fidelity.mjs and test/invocation-ownership.test.mjs are byte-identical to 79e8222 by blob comparison; scripts/standards.mjs is the whole of what was re-reviewed, and it carries both the issue #7 closure at 99952bd and this branch's issue #38 work. DECLARATION SCAN, EVENT 007's OWN METHOD, RE-RUN AT BOTH REVISIONS: exactly one top-level binding added since 79e8222, NOT_PROJECT_EVIDENCE at scripts/standards.mjs:326, and none removed; standards.mjs still has zero top-level let or var. NOT_PROJECT_EVIDENCE arrived with the #7 closure rather than with this branch. It is a Set, so const binds the reference while the object stays mutable, which is the distinction event 005 had to make for VENDOR_MARKERS, and the approval therefore rests on the absence of mutation sites: a search across scripts/ and test/ finds the declaration and a single .has read at scripts/standards.mjs:961, with no add, delete, clear, reassignment or index write anywhere. THIS BRANCH ADDS NO MODULE-SCOPED STATE, VERIFIED THREE WAYS. contentOf is a module-level function that is pure in its two arguments and captures nothing. unknownChecks is a const declared inside createRun at scripts/standards.mjs:808, so it is constructed once per invocation beside findings and sources, and the unknown method is its single writer, preserving the single-writer property this record has always rested on. THE ONE NEW CLOSURE WAS READ AS A CLOSURE, which is the case a declaration scan cannot see and the reason event 007 read rather than scanned: unknownAndUnestablished at scripts/standards.mjs:2916 is a const inside main capturing exactly two things, run.unknownChecks and the confirmed Set built from findings in the same invocation, both invocation-owned; it is not returned, exported, or stored anywhere reachable after main returns. The corrected read loop introduces no binding at all: it stops setting contents for a failed read and returns early. VERIFIED IN THE TESTS AT THIS REVISION rather than assumed: the full six-stage gate passed at this content in Docker, including test and audit, and test/invocation-ownership.test.mjs is byte-identical to the file event 007 ran. LIMITATION RECORDED AT THIS EVENT: that file could NOT be executed on the Windows host, because its negative control matches a newline-literal anchor against a working tree that core.autocrlf renders as CRLF. It was run on an LF checkout of the pristine baseline and passes, and it runs in the gate's Linux image; the failure is a host artifact and not a property of this revision, and it is recorded rather than hidden because a control that cannot run on the platform it ran on is exactly what this repository has refused to accept before. LIMITATIONS UNCHANGED AND CARRIED FORWARD: the declaration scan is not authoritative, because a binding mutated through an alias escapes it as surfaceLoss does through the loss parameter of collectFiles, so completeness remains a review obligation rather than a mechanical guarantee; and nothing in scripts/standards.mjs is Object.freeze'd, so the module tables are immutable by the absence of a mutation site and by convention rather than by enforcement. MATERIAL LIMITATION RESTATED: this approval does not assert that human review is a sufficient control against hidden global state. It asserts what was examined at this revision."
-        reference: "artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md"
-        reviewedAgainst:
-          source: git
-          paths:
-            - artifacts/adr/0014-run-state-is-owned-by-an-invocation-not-recognised-by-a-table.md
-            - scripts/standards.mjs
-            - scripts/inventory.mjs
-            - scripts/fidelity.mjs
-            - test/invocation-ownership.test.mjs
-          revision: "d91fb4a"
-          digestAlgorithm: "git-blob-set-sha256-v1"
-          digest: "aeb4ba00434da087656782b56a4adb81"
 
   architecture.no-duplicate-implementations:
     reviews:
@@ -665,23 +613,6 @@ attestations:
           revision: "a72f302"
           digestAlgorithm: "git-blob-set-sha256-v1"
           digest: "5d46bae7662fdb18c23f695ff8643569"
-      - id: "review-architecture-no-duplicate-implementations-005"
-        supersedes: "review-architecture-no-duplicate-implementations-004"
-        status: approved
-        reviewedBy: "project-owner"
-        reviewedAt: "2026-08-26"
-        evidence: "RE-REVIEWED 2026-08-26 against committed repository content at d91fb4a by Michael Davis as project owner, inheriting nothing from event 004. EXACTLY ONE REVIEWED PATH CHANGED: test/audit.test.mjs. scripts/sections.mjs, scripts/inventory.mjs and scripts/fidelity.mjs are byte-identical to a72f302 by blob comparison, so section-heading ownership, the property this rule was opened for, is outside this change's surface entirely and its two holding tests are undisturbed. The one changed file replaces a single test with a stricter one and introduces no implementation of anything, so it cannot introduce a second one. MATERIAL SCOPE LIMITATION, RECORDED RATHER THAN RESOLVED: scripts/standards.mjs is NOT among this rule's reviewed paths, and this branch adds contentOf to it. The digest therefore cannot see the file most likely to carry a duplicate, and this approval does not rest on it. Examined anyway rather than left unstated: contentOf is the only availability lookup in scripts/, with no second definition of the concept under other words. What was found instead is an UNCONVERTED SITE rather than a duplicate implementation: sourceOf, structureOf and commentsOf still resolve through the sources map with an empty-string fallback, which is the same coercion one indirection away. This branch handles them by widening the surface-level withdrawal trigger rather than by giving them an availability answer of their own, so there is one concept with one implementation and three call sites that do not yet use it. That is a follow-on and is named here as one. RECOMMENDED AS A SEPARATE OWNER DECISION, deliberately not taken here: whether this rule's reviewed path set should include scripts/standards.mjs. Widening it inside this event would make the approval assert more than the digest covers, which is the objection event 007 raised when it declined to widen a reviewed set."
-        reference: "standards/51-architecture-integrity.md"
-        reviewedAgainst:
-          source: git
-          paths:
-            - scripts/sections.mjs
-            - scripts/inventory.mjs
-            - scripts/fidelity.mjs
-            - test/audit.test.mjs
-          revision: "d91fb4a"
-          digestAlgorithm: "git-blob-set-sha256-v1"
-          digest: "2507b57299c98a79ab06c33abb16f306"
 
   # Checkpoint item 11, and the only REJECTED entry here. `status: rejected` is not an approval and
   # not an exception: the schema defines it as recording that a human looked and found the rule

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -773,7 +773,11 @@ function findRoot(start) {
  *
  * `contents` holds an entry for every file the run opened and retained. A file that is in `files`
  * and absent from `contents` was collected and never searched — the read budget was spent, or the
- * read failed. The prevailing idiom `contents.get(f) ?? ""` erased exactly that distinction, and
+ * read failed. The second of those was not true when this comment was first written: a failed read
+ * stored `readText`'s empty-string fallback, so `available` came back true over content nobody had.
+ * The read loop was corrected to match; the sentence is load-bearing, not descriptive.
+ *
+ * The prevailing idiom `contents.get(f) ?? ""` erased exactly that distinction, and
  * because empty is meaningful evidence in BOTH polarities the erasure did not merely lose coverage,
  * it manufactured a verdict: a README nobody opened is "under 400 characters", and a plan file
  * nobody opened has no incomplete items.
@@ -2542,8 +2546,20 @@ export async function main(args) {
       continue;
     }
 
-    if (!read.ok) unreadableFiles.push(f);
-    else if (read.truncated) truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
+    if (!read.ok) {
+      // Opened, and the content NOT obtained. No entry is set, and that is the whole point: on
+      // failure `readText` returns `text: ""`, so storing it would hand `contentOf` an empty string
+      // to call available — the identical coercion this seam exists to remove, arriving through the
+      // other door. It read as safe because the two halves are eighteen hundred lines apart: the
+      // lookup asks `contents.has(f)`, and only the reader of THIS line knows that a file which
+      // could not be read still answers yes.
+      //
+      // Nothing is retained, so nothing is charged to the budget either; the `continue` skips the
+      // accounting below deliberately rather than incidentally.
+      unreadableFiles.push(f);
+      continue;
+    }
+    if (read.truncated) truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
     contents.set(f, read.text);
     if (isCode(f)) sources.set(f, splitSource(read.text, path.extname(f)));
 
@@ -2877,7 +2893,13 @@ export async function main(args) {
   // — every rule whose evidence is file contents is in the position `scm.no-committed-env-files` is
   // in when the repository cannot be read: it can report only that it found nothing, which over an
   // unsearched file is a statement about the run rather than about the project.
-  const filesWentUnsearched = surfaceLoss.capped || surfaceLoss.budget.exhausted;
+  //
+  // A file that could not be READ belongs in this condition for exactly the same reason as one the
+  // budget never opened: its content was not obtained, and the derived views the nine rules below
+  // scan resolve it through `sources.get(f)?.code ?? ""` — the same coercion, one indirection away.
+  // The trigger is corrected rather than the table extended: the table's membership is not what was
+  // wrong, the question it was being asked was.
+  const filesWentUnsearched = surfaceLoss.capped || surfaceLoss.budget.exhausted || unreadableFiles.length > 0;
 
   // Aggregation from checks, which is the part the two mechanisms above cannot do.
   //

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -784,11 +784,24 @@ function findRoot(start) {
  *
  * Returning a value a caller cannot accidentally use as text is the whole mechanism. There is no
  * `?? ""` to reach for, because there is no string to reach.
+ *
+ * A THIRD ANSWER, because a prefix is not the file. `readText` caps each individual read at
+ * MAX_READ_BYTES, so a large file is retained in part, and `contents.has(f)` says yes over content
+ * that stops in the middle. The distinction is not pedantic and its two directions are not
+ * symmetric: a violation FOUND in the prefix was genuinely found and stays found, while a clean
+ * result over the prefix says nothing about the bytes after it — a secret at offset 400,001 is
+ * invisible to a check that reports the file clean. `partial` is therefore reported beside
+ * `available` rather than folded into it, so a caller can keep the first and withhold the second.
  */
-function contentOf(contents, f) {
-  return contents.has(f)
-    ? { available: true, text: contents.get(f) }
-    : { available: false, text: null, reason: "collected but never searched" };
+function contentOf(contents, f, run) {
+  if (!contents.has(f)) return { available: false, partial: false, text: null, reason: "collected but never searched" };
+  const partial = run?.partial?.has(f) ?? false;
+  return {
+    available: true,
+    partial,
+    text: contents.get(f),
+    reason: partial ? `read in part; only the first ${MAX_READ_BYTES} bytes were retained` : null,
+  };
 }
 
 function createRun({ root, strict, json }) {
@@ -807,6 +820,9 @@ function createRun({ root, strict, json }) {
    */
   const unknownChecks = new Map();
 
+  /** Files retained in part, so `contentOf` can answer with a prefix without calling it the file. */
+  const partial = new Set();
+
   return {
     root,
     strict,
@@ -814,6 +830,7 @@ function createRun({ root, strict, json }) {
     findings,
     sources,
     unknownChecks,
+    partial,
 
     /**
      * Record that a check could not be performed, and emit nothing.
@@ -1337,7 +1354,7 @@ function detectMissingDocs(files, contents, run) {
     // The presence check above is structural and always valid. Only the length test needs content,
     // so only the length test is withdrawn — the missing `docs/architecture.md` beside it still
     // fails the rule, because that was established.
-    const c = contentOf(contents, readme);
+    const c = contentOf(contents, readme, run);
     if (!c.available) run.unknown("documentation.architecture", rel(readme), c.reason);
     else if (c.text.trim().length < 400) missing.push(`${rel(readme)} (under 400 characters)`);
   }
@@ -1445,7 +1462,7 @@ function detectMissingPlanningArtifacts(files, contents, run) {
     return;
   }
 
-  const overviewContent = contentOf(contents, overview);
+  const overviewContent = contentOf(contents, overview, run);
   if (!overviewContent.available) {
     // "A plan directory is evidence of a plan only when it has content" is a claim about the file's
     // body. Over a body nobody read it is a claim about the run.
@@ -1609,13 +1626,17 @@ function detectOpenQuestions(files, contents, run) {
   const { rel, addFinding } = run;
   const qFile = files.find((f) => rel(f) === "artifacts/project-baseline/open-questions.md");
   if (!qFile) return;
-  const questions = contentOf(contents, qFile);
+  const questions = contentOf(contents, qFile, run);
   if (!questions.available) {
     // The quiet polarity. Both counts below come from matching this text, so an unread file scores
     // zero on each and the rule passes — silence indistinguishable from a clean document.
     run.unknown("reconstruction.open-questions", rel(qFile), questions.reason);
     return;
   }
+  // A prefix establishes a violation it contains and cannot establish the absence of one after it,
+  // so the check still runs and the unknown is recorded beside it: a match in the retained bytes is
+  // a real match, and aggregation keeps it while withholding the clean result.
+  if (questions.partial) run.unknown("reconstruction.open-questions", rel(qFile), questions.reason);
   const text = questions.text;
   // Fixed, greppable marker written by the project-reconstruction skill's questions template.
   const open = (text.match(/^\s*-?\s*\*\*Status:\*\*\s*open\s*$/gim) ?? []).length;
@@ -1702,14 +1723,21 @@ async function detectPlanDiscrepancies(files, contents, run) {
   //
   // Files that WERE read are still parsed: a violation found in one plan file is established
   // regardless of another going unread, and aggregation keeps it.
-  for (const f of planFiles.filter((f) => !contentOf(contents, f).available)) {
-    const reason = contentOf(contents, f).reason;
+  for (const f of planFiles.filter((f) => !contentOf(contents, f, run).available)) {
+    const reason = contentOf(contents, f, run).reason;
+    run.unknown("planning.item-fields", rel(f), reason);
+    run.unknown("planning.plan-code-consistency", rel(f), reason);
+  }
+  // The same asymmetry one detector along: items parsed out of a prefix are real, but the absence of
+  // an incomplete one says nothing about the bytes that were never retained.
+  for (const f of planFiles.filter((f) => contentOf(contents, f, run).partial)) {
+    const reason = contentOf(contents, f, run).reason;
     run.unknown("planning.item-fields", rel(f), reason);
     run.unknown("planning.plan-code-consistency", rel(f), reason);
   }
   const items = planFiles
-    .filter((f) => contentOf(contents, f).available)
-    .flatMap((f) => parsePlanItems(contentOf(contents, f).text, rel(f)));
+    .filter((f) => contentOf(contents, f, run).available)
+    .flatMap((f) => parsePlanItems(contentOf(contents, f, run).text, rel(f)));
   const executable = items.filter((i) => i.fields.has("Status"));
   if (executable.length === 0) return;
 
@@ -1927,8 +1955,13 @@ function detectStandardsViolations(files, contents, run) {
       // The mixed case in one detector. R4 above is structural and may already have failed; R6 here
       // needs the prompt's text. Withdrawing both because this one is unknown would erase R4's
       // established violation, which is precisely why the check rather than the rule is the unit.
-      const prompt = contentOf(contents, promptFile);
+      const prompt = contentOf(contents, promptFile, run);
       if (!prompt.available) {
+        run.unknown("reconstruction.baseline-artifacts", rel(promptFile), prompt.reason);
+      } else if (prompt.partial && !/reconstructed from the existing codebase/i.test(prompt.text)) {
+        // R6's declaration may sit past the per-file cap, so its absence from a prefix establishes
+        // nothing. The two length checks in this file's siblings do not need this: truncation implies
+        // a file far above their thresholds, so a prefix can only satisfy them.
         run.unknown("reconstruction.baseline-artifacts", rel(promptFile), prompt.reason);
       } else if (!/reconstructed from the existing codebase/i.test(prompt.text)) {
         violations.push([rel(promptFile), "R6: reconstructed prompt does not declare itself reconstructed", R.prompt]);
@@ -2559,7 +2592,12 @@ export async function main(args) {
       unreadableFiles.push(f);
       continue;
     }
-    if (read.truncated) truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
+    if (read.truncated) {
+      truncatedFiles.push(`${rel(f)} (read ${MAX_READ_BYTES} of ${read.bytes} bytes)`);
+      // Recorded per file, not just as a surface total, because the caller that matters is a CHECK
+      // asking whether it has this file — and a prefix is a different answer from the file.
+      run.partial.add(f);
+    }
     contents.set(f, read.text);
     if (isCode(f)) sources.set(f, splitSource(read.text, path.extname(f)));
 
@@ -2899,7 +2937,40 @@ export async function main(args) {
   // scan resolve it through `sources.get(f)?.code ?? ""` — the same coercion, one indirection away.
   // The trigger is corrected rather than the table extended: the table's membership is not what was
   // wrong, the question it was being asked was.
-  const filesWentUnsearched = surfaceLoss.capped || surfaceLoss.budget.exhausted || unreadableFiles.length > 0;
+  //
+  // `frameworkExcluded` is the fourth term and the one the read seam structurally cannot reach. A
+  // file this tool excluded never enters the walk, never enters `contents`, and no accessor is ever
+  // called for it — so no check ever asks, and `unknownChecks` records nothing. The other three
+  // terms describe content that was collected and then lost; this one describes content that was
+  // never collected, and the two need separate observation points because there is no moment in a
+  // detector's execution where the second is visible. Measured: a detector whose candidates are all
+  // excluded simply iterates zero times and reports clean.
+  //
+  // THE FILTER IS THE WHOLE CONTROL, and it is `authorizedBy`, not "was something excluded". A
+  // repository that declares its own ignore set has NARROWED WHAT ITS PROJECT IS, which is a
+  // legitimate answer and leaves the run complete; a framework that removes tracked project code by
+  // matching a directory name has LOST EVIDENCE and must not report a clean forbidden rule over it.
+  // `.git` is neither — it is `not-project-evidence` — and if it counted here, every run in every
+  // repository would withdraw nine rules forever. That distinction is PR #42's, and this term is the
+  // second consumer of it rather than a new judgement.
+  //
+  // This repository is its own specimen, which is why the verdict moves when this lands: it excludes
+  // `test/fixtures` by name, 71 tracked committed files, two of which carry deliberate SQL-concat
+  // and cert-bypass bait. `security.no-sql-concat: passed` was never true here. Nine rules go to
+  // not-evaluated and that is the honest state, not a regression to be tuned away.
+  //
+  // A directory that could not be LISTED belongs here for the reason the others make obvious once
+  // stated: nothing beneath it was ever collected, so an absence-based rule reports "found nothing"
+  // over files it never had the chance to see. Truncation belongs for the same reason one
+  // indirection in -- a retained prefix is not the file, and a secret past the per-file cap is
+  // invisible to a check that calls the file clean.
+  const filesWentUnsearched =
+    surfaceLoss.capped ||
+    surfaceLoss.budget.exhausted ||
+    unreadableFiles.length > 0 ||
+    frameworkExcluded.length > 0 ||
+    surfaceLoss.dirs.length > 0 ||
+    truncatedFiles.length > 0;
 
   // Aggregation from checks, which is the part the two mechanisms above cannot do.
   //
@@ -2912,14 +2983,20 @@ export async function main(args) {
   // that ran, and withdrawing the rule would discard a real finding because a DIFFERENT check went
   // unread. `reconstruction.baseline-artifacts` is exactly that shape — structural R4, content R6 —
   // and it is why no table over rule ids can express this.
+  // AND A CONFIRMED VIOLATION OUTRANKS EVERY WITHDRAWAL, the coarse one included. That was stated
+  // above and then honoured in only one of the two branches: the surface-level branch withdrew all
+  // nine table rules whenever anything went unsearched, so a secret found in a file that WAS read
+  // came back `skipped / not-evaluated`. Evidence loss bounds what a run may conclude from silence.
+  // It cannot unfind what the run already found, and the two branches now say so with one sentence
+  // rather than disagreeing.
   const confirmed = new Set(findings.filter((f) => f.rule).map((f) => f.rule));
-  const unknownAndUnestablished = (id) => run.unknownChecks.has(id) && !confirmed.has(id);
+  const lostEvidenceFor = (id) =>
+    (filesWentUnsearched && CONTENT_DERIVED_RULES.includes(id)) || run.unknownChecks.has(id);
 
   const evaluatedThisRun = EVALUATED_RULES.filter(
     (id) =>
       !(id === "scm.no-committed-env-files" && envCheck.evaluated === false) &&
-      !(filesWentUnsearched && CONTENT_DERIVED_RULES.includes(id)) &&
-      !unknownAndUnestablished(id),
+      !(lostEvidenceFor(id) && !confirmed.has(id)),
   );
 
   const verdict = evaluate({

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -391,6 +391,13 @@ const isCode = (f) => CODE_EXT.has(path.extname(f));
  *                  import specifier *is* a string: `from "bullmq"`.
  *   commentsOf(f)  comment text only — TODO/FIXME markers, which are by definition a comment
  *                  convention, so a marker named in a string or in prose is correctly invisible.
+ *   textOf(f)      the file as read, for evidence that is not code at all — a Markdown body, a
+ *                  manifest, a workflow file. The use/mention split does not apply to prose.
+ *
+ * ALL FOUR ANSWER WITH A RECORD, NEVER A STRING, and that is the second property they carry. The
+ * first says WHERE in a file a signal may be looked for; the second says whether the run has the
+ * file at all. A detector receives `run` and no raw map, so `contents.get(f) ?? ""` is not an
+ * expression a call site can write — the seam is inherited rather than remembered.
  */
 
 /** Comment syntax by extension. Enabling the wrong one corrupts the split — `//` is floor division
@@ -768,45 +775,18 @@ function findRoot(start) {
  * `sources` is here because it is execution-specific: its values are the audited project's file
  * contents, so the same key yields a different correct value for a different target.
  */
-/**
- * One content lookup, answered with whether the run actually has the content.
- *
- * `contents` holds an entry for every file the run opened and retained. A file that is in `files`
- * and absent from `contents` was collected and never searched — the read budget was spent, or the
- * read failed. The second of those was not true when this comment was first written: a failed read
- * stored `readText`'s empty-string fallback, so `available` came back true over content nobody had.
- * The read loop was corrected to match; the sentence is load-bearing, not descriptive.
- *
- * The prevailing idiom `contents.get(f) ?? ""` erased exactly that distinction, and
- * because empty is meaningful evidence in BOTH polarities the erasure did not merely lose coverage,
- * it manufactured a verdict: a README nobody opened is "under 400 characters", and a plan file
- * nobody opened has no incomplete items.
- *
- * Returning a value a caller cannot accidentally use as text is the whole mechanism. There is no
- * `?? ""` to reach for, because there is no string to reach.
- *
- * A THIRD ANSWER, because a prefix is not the file. `readText` caps each individual read at
- * MAX_READ_BYTES, so a large file is retained in part, and `contents.has(f)` says yes over content
- * that stops in the middle. The distinction is not pedantic and its two directions are not
- * symmetric: a violation FOUND in the prefix was genuinely found and stays found, while a clean
- * result over the prefix says nothing about the bytes after it — a secret at offset 400,001 is
- * invisible to a check that reports the file clean. `partial` is therefore reported beside
- * `available` rather than folded into it, so a caller can keep the first and withhold the second.
- */
-function contentOf(contents, f, run) {
-  if (!contents.has(f)) return { available: false, partial: false, text: null, reason: "collected but never searched" };
-  const partial = run?.partial?.has(f) ?? false;
-  return {
-    available: true,
-    partial,
-    text: contents.get(f),
-    reason: partial ? `read in part; only the first ${MAX_READ_BYTES} bytes were retained` : null,
-  };
-}
-
 function createRun({ root, strict, json }) {
   const findings = [];
   const sources = new Map();
+
+  /**
+   * Every file this run opened and retained, and the only map any content view reads.
+   *
+   * Owned here rather than by the audit function so that no detector can be handed it. A detector
+   * receives `run`, and `run` exposes views; there is no parameter through which the raw map
+   * arrives, so `contents.get(f) ?? ""` is not a thing a call site can write.
+   */
+  const contents = new Map();
 
   /**
    * Checks that could not run, by the rule they would have fed.
@@ -820,8 +800,65 @@ function createRun({ root, strict, json }) {
    */
   const unknownChecks = new Map();
 
-  /** Files retained in part, so `contentOf` can answer with a prefix without calling it the file. */
+  /** Files retained in part, so a view can answer with a prefix without calling it the file. */
   const partial = new Set();
+
+  /**
+   * One content lookup, answered with whether the run actually has the content.
+   *
+   * `contents` holds an entry for every file the run opened and retained. A file that is in `files`
+   * and absent from it was collected and never searched — the read budget was spent, the read
+   * failed, or the extension is outside `TEXT_EXT` and the read loop skipped it. All three are the
+   * same answer to a check: nothing was searched in this file.
+   *
+   * The prevailing idiom `contents.get(f) ?? ""` erased exactly that distinction, and because empty
+   * is meaningful evidence in BOTH polarities the erasure did not merely lose coverage, it
+   * manufactured a verdict: a README nobody opened is "under 400 characters", and a plan file nobody
+   * opened has no incomplete items.
+   *
+   * **Returning a value a caller cannot accidentally use as text is the whole mechanism**, and the
+   * mechanism is the point rather than the discipline. There is no `?? ""` to reach for because
+   * there is no string to reach, and there is no second door: the raw map is not a parameter of any
+   * detector, so a new detector inherits this property instead of having to remember it.
+   *
+   * A THIRD ANSWER, because a prefix is not the file. `readText` caps each individual read at
+   * MAX_READ_BYTES, so a large file is retained in part and the map says yes over content that stops
+   * in the middle. The distinction is not pedantic and its two directions are not symmetric: a
+   * violation FOUND in the prefix was genuinely found and stays found, while a clean result over the
+   * prefix says nothing about the bytes after it — a secret at offset 400,001 is invisible to a
+   * check that reports the file clean. `partial` is therefore reported beside `available` rather
+   * than folded into it, so a caller can keep the first and withhold the second.
+   *
+   * A FOURTH, for the derived views only. `sources` is populated for code files alone, so a config
+   * file has no split-source view — not because evidence was lost but because the view does not
+   * apply to it. Reported with its own reason so a caller cannot read "no source view" as "this file
+   * is empty", which is the same coercion one indirection away.
+   */
+  const viewOf = (f, part) => {
+    if (!contents.has(f)) {
+      return Object.freeze({
+        available: false,
+        partial: false,
+        text: null,
+        reason: "collected but never searched",
+      });
+    }
+    const isPartial = partial.has(f);
+    const reason = isPartial ? `read in part; only the first ${MAX_READ_BYTES} bytes were retained` : null;
+    if (part === null) {
+      return Object.freeze({ available: true, partial: isPartial, text: contents.get(f), reason });
+    }
+    const split = sources.get(f);
+    if (!split) {
+      return Object.freeze({
+        available: false,
+        partial: false,
+        text: null,
+        reason: "not a code file; no split-source view exists",
+      });
+    }
+    return Object.freeze({ available: true, partial: isPartial, text: split[part], reason });
+  };
 
   return {
     root,
@@ -829,6 +866,7 @@ function createRun({ root, strict, json }) {
     json,
     findings,
     sources,
+    contents,
     unknownChecks,
     partial,
 
@@ -850,9 +888,18 @@ function createRun({ root, strict, json }) {
 
     has: (p) => existsSync(path.join(root, p)),
 
-    sourceOf: (f) => sources.get(f)?.code ?? "",
-    structureOf: (f) => sources.get(f)?.structure ?? "",
-    commentsOf: (f) => sources.get(f)?.comments ?? "",
+    /**
+     * The four content views, and the only route from a detector to a file's text.
+     *
+     * Each answers with a record; none can return a string. The names are unchanged from the
+     * coercing accessors they replace, deliberately: every existing call site had to be visited and
+     * changed, and a site that was missed does not compile into a plausible-looking empty string —
+     * it reads `.text` off a record whose `available` is false and gets `null`.
+     */
+    textOf: (f) => viewOf(f, null),
+    sourceOf: (f) => viewOf(f, "code"),
+    structureOf: (f) => viewOf(f, "structure"),
+    commentsOf: (f) => viewOf(f, "comments"),
 
     /**
      * `label` is the Standard 44 evidence label and is not decorative. A detection that rests on a
@@ -1045,7 +1092,7 @@ const MANIFESTS = [
   "pom.xml", "build.gradle", "build.gradle.kts", "Gemfile", "composer.json",
 ];
 
-function detectArchitecture(files, contents, run) {
+function detectArchitecture(files, run) {
   const { rel, addFinding } = run;
   const archDoc = files.find((f) => rel(f).toLowerCase() === "docs/architecture.md");
   if (archDoc) {
@@ -1080,15 +1127,18 @@ function detectArchitecture(files, contents, run) {
   });
 }
 
-function detectCapabilities(files, contents, run) {
+function detectCapabilities(files, run) {
   const { rel, addFinding } = run;
   const evidence = [];
   const notes = [];
 
   const pkgPath = files.find((f) => rel(f) === "package.json");
-  if (pkgPath) {
+  // Descriptive: this detector binds no rule, so an unread manifest withdraws nothing. It simply
+  // reports one fewer capability, which is the honest consequence of not having read it.
+  const manifest = pkgPath ? run.textOf(pkgPath) : null;
+  if (manifest?.available) {
     try {
-      const pkg = JSON.parse(contents.get(pkgPath) ?? "{}");
+      const pkg = JSON.parse(manifest.text);
       const bins = pkg.bin ? Object.keys(pkg.bin) : [];
       const scripts = pkg.scripts ? Object.keys(pkg.scripts) : [];
       if (bins.length) {
@@ -1135,7 +1185,7 @@ const API_CONTENT = [
   /func\s+\w*Handler\s*\(\s*w\s+http\.ResponseWriter/,
 ];
 
-function detectApis(files, contents, run) {
+function detectApis(files, run) {
   const { rel, addFinding, structureOf } = run;
   const specs = files.filter((f) =>
     /(^|\/)(openapi|swagger)\.(ya?ml|json)$/i.test(rel(f)),
@@ -1155,7 +1205,9 @@ function detectApis(files, contents, run) {
     if (/(^|\/)\w*Controller\.(cs|java|ts|js|py|rb)$/i.test(r)) return true;
     if (/(^|\/)(routes?|controllers?|api|endpoints?)\//i.test(r) && isCode(f)) return true;
     if (!isCode(f)) return false; // prose describing a route table is not a route
-    const code = structureOf(f); // a commented-out or quoted route is not a route
+    const view = structureOf(f); // a commented-out or quoted route is not a route
+    if (!view.available) return false;
+    const code = view.text;
     return code ? API_CONTENT.some((re) => re.test(code)) : false;
   });
   if (handlers.length === 0) return;
@@ -1187,12 +1239,12 @@ const JOB_CONTENT = [
  */
 const JOB_PACKAGES = "celery|sidekiq|bullmq|bull|agenda|node-cron|apscheduler|resque";
 
-function detectJobs(files, contents, run) {
+function detectJobs(files, run) {
   const { rel, addFinding, structureOf, sourceOf } = run;
   const workflowCron = files.filter((f) => {
     if (!/\.github\/workflows\/.*\.ya?ml$/.test(rel(f))) return false;
-    const text = contents.get(f) ?? "";
-    return /^\s*schedule:/m.test(text);
+    const workflow = run.textOf(f);
+    return workflow.available && /^\s*schedule:/m.test(workflow.text);
   });
   if (workflowCron.length) {
     addFinding({
@@ -1207,8 +1259,10 @@ function detectJobs(files, contents, run) {
   const jobs = files.filter((f) => {
     if (JOB_NAME.test(path.basename(f))) return true;
     if (!isCode(f)) return false; // prose naming Celery or BullMQ is not a scheduler
-    if (JOB_CONTENT.some((re) => re.test(structureOf(f)))) return true;
-    return importPattern(JOB_PACKAGES).test(sourceOf(f)); // imports live in strings
+    const structure = structureOf(f);
+    if (structure.available && JOB_CONTENT.some((re) => re.test(structure.text))) return true;
+    const source = sourceOf(f); // imports live in strings
+    return source.available && importPattern(JOB_PACKAGES).test(source.text);
   });
   if (jobs.length === 0) return;
 
@@ -1243,7 +1297,7 @@ const INTEGRATION_SDK = [
   ["@slack/|slack_sdk", "Slack"], ["octokit|PyGithub", "GitHub"],
 ];
 
-function detectIntegrations(files, contents, run) {
+function detectIntegrations(files, run) {
   const { rel, addFinding, sourceOf } = run;
   const envTemplates = files.filter((f) =>
     /(^|\/)\.env\.(example|template|sample)$|(^|\/)appsettings\.(Example|Template)\.json$/i.test(rel(f)),
@@ -1264,7 +1318,9 @@ function detectIntegrations(files, contents, run) {
   for (const [pattern, name] of INTEGRATION_SDK) {
     const re = importPattern(pattern);
     for (const f of files) {
-      const code = sourceOf(f);
+      const view = sourceOf(f);
+      if (!view.available) continue;
+      const code = view.text;
       if (code && re.test(code)) {
         if (!found.has(name)) found.set(name, []);
         found.get(name).push(rel(f));
@@ -1295,7 +1351,7 @@ const AI_SDK = [
   ["mistralai", "Mistral"],
 ];
 
-function detectAiInterfaces(files, contents, run) {
+function detectAiInterfaces(files, run) {
   const { rel, addFinding, sourceOf } = run;
   const skillFiles = files.filter((f) => /(^|\/)SKILL\.md$/.test(rel(f)));
   const promptFiles = files.filter((f) => /(^|\/)prompts?\//i.test(rel(f)) || /prompt.*\.md$/i.test(rel(f)));
@@ -1316,7 +1372,9 @@ function detectAiInterfaces(files, contents, run) {
   for (const [pattern, name] of AI_SDK) {
     const re = importPattern(pattern);
     for (const f of files) {
-      const code = sourceOf(f);
+      const view = sourceOf(f);
+      if (!view.available) continue;
+      const code = view.text;
       if (code && re.test(code)) {
         if (!providers.has(name)) providers.set(name, []);
         providers.get(name).push(rel(f));
@@ -1344,7 +1402,7 @@ const CI_FILES = [
   ".circleci/config.yml", ".travis.yml", "bitbucket-pipelines.yml",
 ];
 
-function detectMissingDocs(files, contents, run) {
+function detectMissingDocs(files, run) {
   const { rel, addFinding } = run;
   const missing = [];
   if (!files.some((f) => rel(f).toLowerCase() === "docs/architecture.md")) missing.push("docs/architecture.md");
@@ -1354,7 +1412,7 @@ function detectMissingDocs(files, contents, run) {
     // The presence check above is structural and always valid. Only the length test needs content,
     // so only the length test is withdrawn — the missing `docs/architecture.md` beside it still
     // fails the rule, because that was established.
-    const c = contentOf(contents, readme, run);
+    const c = run.textOf(readme);
     if (!c.available) run.unknown("documentation.architecture", rel(readme), c.reason);
     else if (c.text.trim().length < 400) missing.push(`${rel(readme)} (under 400 characters)`);
   }
@@ -1431,7 +1489,7 @@ function detectArchitectureArtifacts(run) {
  * plan or an untouched template is a judgement no scan makes, and Standard 44's Implementation
  * section says so rather than implying this check covers it.
  */
-function detectMissingPlanningArtifacts(files, contents, run) {
+function detectMissingPlanningArtifacts(files, run) {
   const { has, addFinding, rel } = run;
   const dir = "artifacts/project-plan-breakdown";
   if (!has(dir)) {
@@ -1462,7 +1520,7 @@ function detectMissingPlanningArtifacts(files, contents, run) {
     return;
   }
 
-  const overviewContent = contentOf(contents, overview, run);
+  const overviewContent = run.textOf(overview);
   if (!overviewContent.available) {
     // "A plan directory is evidence of a plan only when it has content" is a claim about the file's
     // body. Over a body nobody read it is a claim about the run.
@@ -1566,10 +1624,18 @@ function detectUnfinished(files, run) {
   };
   for (const f of files) {
     if (!isCode(f)) continue; // a TODO in a Markdown file is a note, not an unfinished code path
+    // Both halves come from one file, so one loss decides both. The old `if (comments && ...)`
+    // guards read as "if there is any comment text at all"; against a record they would read as
+    // "always", which is why every call site had to be visited rather than trusted to keep working.
     const comments = commentsOf(f);
     const code = structureOf(f);
-    for (const [re, kind] of UNFINISHED_COMMENTS) if (comments && re.test(comments)) record(kind, f);
-    for (const [re, kind] of UNFINISHED_CODE) if (code && re.test(code)) record(kind, f);
+    if (!comments.available || !code.available) {
+      run.unknown("quality.unfinished-work", rel(f), comments.reason ?? code.reason);
+      continue;
+    }
+    if (comments.partial) run.unknown("quality.unfinished-work", rel(f), comments.reason);
+    for (const [re, kind] of UNFINISHED_COMMENTS) if (comments.text && re.test(comments.text)) record(kind, f);
+    for (const [re, kind] of UNFINISHED_CODE) if (code.text && re.test(code.text)) record(kind, f);
   }
   if (byKind.size === 0) return;
 
@@ -1608,7 +1674,7 @@ const ENTRYISH = /(^|\/)(index|main|app|Program|Startup|__init__|__main__|setup|
  * evidence is exactly what would refute it. Emitting the finding first and withdrawing after would
  * hit the `confirmed` exemption in aggregation and keep the verdict.
  */
-function detectDeadCode(files, contents, run) {
+function detectDeadCode(files, run) {
   const { rel, addFinding } = run;
 
   // Measured over the reference space itself rather than by enumerating the ways a file can go
@@ -1616,7 +1682,7 @@ function detectDeadCode(files, contents, run) {
   // retained prefix counts as incomplete for the same reason it does everywhere else: a stem absent
   // from the first bytes of a file is not absent from the file.
   const unsearchable = files.filter((other) => {
-    const c = contentOf(contents, other, run);
+    const c = run.textOf(other);
     return !c.available || c.partial;
   });
   if (unsearchable.length > 0) {
@@ -1641,8 +1707,9 @@ function detectDeadCode(files, contents, run) {
     if (stem.length < 3) continue;
     const referenced = files.some((other) => {
       if (other === f) return false;
-      const text = contents.get(other);
-      return text ? text.includes(stem) : false;
+      // Every file is available here: the completeness check above returned otherwise.
+      const c = run.textOf(other);
+      return c.available && c.text.includes(stem);
     });
     if (!referenced) orphans.push(rel(f));
   }
@@ -1662,11 +1729,11 @@ function detectDeadCode(files, contents, run) {
   });
 }
 
-function detectOpenQuestions(files, contents, run) {
+function detectOpenQuestions(files, run) {
   const { rel, addFinding } = run;
   const qFile = files.find((f) => rel(f) === "artifacts/project-baseline/open-questions.md");
   if (!qFile) return;
-  const questions = contentOf(contents, qFile, run);
+  const questions = run.textOf(qFile);
   if (!questions.available) {
     // The quiet polarity. Both counts below come from matching this text, so an unread file scores
     // zero on each and the rule passes — silence indistinguishable from a clean document.
@@ -1750,7 +1817,7 @@ const canonicalStatus = (raw) => {
   return STATUS_ALIASES[first.toLowerCase()] ?? upper;
 };
 
-async function detectPlanDiscrepancies(files, contents, run) {
+async function detectPlanDiscrepancies(files, run) {
   const { rel, root, addFinding } = run;
   const planFiles = files.filter((f) => /^artifacts\/project-plan-breakdown\/.+\.md$/.test(rel(f)));
   if (planFiles.length === 0) return;
@@ -1763,21 +1830,21 @@ async function detectPlanDiscrepancies(files, contents, run) {
   //
   // Files that WERE read are still parsed: a violation found in one plan file is established
   // regardless of another going unread, and aggregation keeps it.
-  for (const f of planFiles.filter((f) => !contentOf(contents, f, run).available)) {
-    const reason = contentOf(contents, f, run).reason;
+  for (const f of planFiles.filter((f) => !run.textOf(f).available)) {
+    const reason = run.textOf(f).reason;
     run.unknown("planning.item-fields", rel(f), reason);
     run.unknown("planning.plan-code-consistency", rel(f), reason);
   }
   // The same asymmetry one detector along: items parsed out of a prefix are real, but the absence of
   // an incomplete one says nothing about the bytes that were never retained.
-  for (const f of planFiles.filter((f) => contentOf(contents, f, run).partial)) {
-    const reason = contentOf(contents, f, run).reason;
+  for (const f of planFiles.filter((f) => run.textOf(f).partial)) {
+    const reason = run.textOf(f).reason;
     run.unknown("planning.item-fields", rel(f), reason);
     run.unknown("planning.plan-code-consistency", rel(f), reason);
   }
   const items = planFiles
-    .filter((f) => contentOf(contents, f, run).available)
-    .flatMap((f) => parsePlanItems(contentOf(contents, f, run).text, rel(f)));
+    .filter((f) => run.textOf(f).available)
+    .flatMap((f) => parsePlanItems(run.textOf(f).text, rel(f)));
   const executable = items.filter((i) => i.fields.has("Status"));
   if (executable.length === 0) return;
 
@@ -1943,11 +2010,19 @@ function looksLikeRepositoryPath(p) {
   return true;
 }
 
-function detectDocDiscrepancies(files, contents, run) {
+function detectDocDiscrepancies(files, run) {
   const { rel, root, addFinding } = run;
   const readme = files.find((f) => /^readme\.md$/i.test(rel(f)));
   if (!readme) return;
-  const text = contents.get(readme) ?? "";
+  const readmeView = run.textOf(readme);
+  if (!readmeView.available) {
+    // Every check below matches against this text, so an unread README scores zero on each and the
+    // rule passes: silence indistinguishable from a README that names nothing which does not exist.
+    run.unknown("documentation.code-consistency", rel(readme), readmeView.reason);
+    return;
+  }
+  if (readmeView.partial) run.unknown("documentation.code-consistency", rel(readme), readmeView.reason);
+  const text = readmeView.text;
   const broken = [];
 
   for (const token of text.match(/`([^`\n]+)`/g) ?? []) {
@@ -1958,9 +2033,17 @@ function detectDocDiscrepancies(files, contents, run) {
   }
 
   const pkgPath = files.find((f) => rel(f) === "package.json");
-  if (pkgPath) {
+  // The README half above may already have established a violation, and it keeps it. This half
+  // cannot run at all: with no script list every `npm run` the README names looks broken, so the
+  // loss is recorded and the check is skipped rather than answered from `"{}"`.
+  const manifest = pkgPath ? run.textOf(pkgPath) : null;
+  if (manifest && !manifest.available) {
+    run.unknown("documentation.code-consistency", rel(pkgPath), manifest.reason);
+  }
+  if (manifest?.available) {
+    if (manifest.partial) run.unknown("documentation.code-consistency", rel(pkgPath), manifest.reason);
     try {
-      const scripts = Object.keys(JSON.parse(contents.get(pkgPath) ?? "{}").scripts ?? {});
+      const scripts = Object.keys(JSON.parse(manifest.text).scripts ?? {});
       for (const m of text.match(/npm run ([\w:-]+)/g) ?? []) {
         const name = m.replace("npm run ", "");
         if (!scripts.includes(name)) broken.push(`${rel(readme)} -> npm run ${name}`);
@@ -1983,7 +2066,7 @@ function detectDocDiscrepancies(files, contents, run) {
   });
 }
 
-function detectStandardsViolations(files, contents, run) {
+function detectStandardsViolations(files, run) {
   const { has, rel, addFinding } = run;
   const violations = [];
   if (has("artifacts/project-baseline")) {
@@ -1995,7 +2078,7 @@ function detectStandardsViolations(files, contents, run) {
       // The mixed case in one detector. R4 above is structural and may already have failed; R6 here
       // needs the prompt's text. Withdrawing both because this one is unknown would erase R4's
       // established violation, which is precisely why the check rather than the rule is the unit.
-      const prompt = contentOf(contents, promptFile, run);
+      const prompt = run.textOf(promptFile);
       if (!prompt.available) {
         run.unknown("reconstruction.baseline-artifacts", rel(promptFile), prompt.reason);
       } else if (prompt.partial && !/reconstructed from the existing codebase/i.test(prompt.text)) {
@@ -2157,16 +2240,26 @@ const SECRET_PATTERNS = [
   [/\bsk_live_[A-Za-z0-9]{16,}/, "Stripe live secret key"],
 ];
 
-function detectSecretsInArtifacts(files, contents, run) {
+function detectSecretsInArtifacts(files, run) {
   const { rel, sourceOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     const p = rel(f);
     if (ENV_FILE_RE.test(p)) continue; // Single owner: scm.no-committed-env-files.
     const ext = path.extname(f);
-    let text = null;
-    if (isCode(f)) text = sourceOf(f);
-    else if (CONFIG_EXT.has(ext)) text = contents.get(f) ?? "";
+    // Two views for two kinds of file, and a third case that is neither: a file outside both
+    // domains is not evidence this rule reads, which is a different answer from evidence it wanted
+    // and could not get. Only the second is a loss, and only the second is recorded as one.
+    let view = null;
+    if (isCode(f)) view = sourceOf(f);
+    else if (CONFIG_EXT.has(ext)) view = run.textOf(f);
+    if (!view) continue;
+    if (!view.available) {
+      run.unknown("security.no-secrets-in-artifacts", p, view.reason);
+      continue;
+    }
+    if (view.partial) run.unknown("security.no-secrets-in-artifacts", p, view.reason);
+    const text = view.text;
     if (!text) continue;
 
     for (const [re, what] of SECRET_PATTERNS) {
@@ -2260,14 +2353,21 @@ function carriesJustification(raw, structure, from, to) {
  * still holds the justification comment, because that is the one thing the structural view removes.
  * The span is what binds them: two readings of one site, not two searches of one file.
  */
-function detectSwallowedExceptions(files, contents, run) {
+function detectSwallowedExceptions(files, run) {
   const { rel, structureOf, addFinding } = run;
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
-    const structure = structureOf(f);
+    const structureView = structureOf(f);
+    const rawView = run.textOf(f);
+    if (!structureView.available || !rawView.available) {
+      run.unknown("errors.no-swallowed-exceptions", rel(f), structureView.reason ?? rawView.reason);
+      continue;
+    }
+    if (structureView.partial) run.unknown("errors.no-swallowed-exceptions", rel(f), structureView.reason);
+    const structure = structureView.text;
     if (!structure) continue;
-    const raw = contents.get(f) ?? "";
+    const raw = rawView.text;
     if (raw.length !== structure.length) continue; // views are not aligned; say nothing rather than guess
 
     // Constructed here, so their `lastIndex` cannot outlive this file's turn through the loop.
@@ -2327,7 +2427,13 @@ function detectCertBypass(files, run) {
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
-    const code = structureOf(f);
+    const view = structureOf(f);
+    if (!view.available) {
+      run.unknown("security.no-cert-bypass", rel(f), view.reason);
+      continue;
+    }
+    if (view.partial) run.unknown("security.no-cert-bypass", rel(f), view.reason);
+    const code = view.text;
     if (!code) continue;
     if (CERT_BYPASS.some((re) => re.test(code))) hits.push(rel(f));
     else if (path.extname(f) === ".sh" && /\bcurl\b[^\n|]*\s-[a-zA-Z]*k\b/.test(code)) hits.push(rel(f));
@@ -2373,7 +2479,13 @@ function detectSqlConcat(files, run) {
   const hits = [];
   for (const f of files) {
     if (!isCode(f)) continue;
-    const code = sourceOf(f);
+    const view = sourceOf(f);
+    if (!view.available) {
+      run.unknown("security.no-sql-concat", rel(f), view.reason);
+      continue;
+    }
+    if (view.partial) run.unknown("security.no-sql-concat", rel(f), view.reason);
+    const code = view.text;
     if (!code) continue;
     if (SQL_TEMPLATE.test(code) || SQL_FSTRING.test(code)) hits.push(rel(f));
   }
@@ -2547,7 +2659,7 @@ export async function main(args) {
   const validating = cli.subcommand === "validate";
 
   run = createRun({ root, strict: cli.strict, json: cli.json });
-  const { rel, findings, sources, addFinding } = run;
+  const { rel, findings, sources, contents, addFinding } = run;
 
   // Created here, by the invocation that uses it, and carrying the budget this invocation was given
   // rather than one read from the process — ADR 0014.
@@ -2574,7 +2686,6 @@ export async function main(args) {
     files: new Set(ignored.ok ? ignored.files : []),
   };
   const files = await collectFiles(root, [], surfaceLoss, exclusions, run);
-  const contents = new Map();
   // The repository surface this invocation measured. Named so two runs can be compared by identity.
   surface = { files, contents, surfaceLoss };
   const unreadableFiles = [];
@@ -2621,7 +2732,7 @@ export async function main(args) {
 
     if (!read.ok) {
       // Opened, and the content NOT obtained. No entry is set, and that is the whole point: on
-      // failure `readText` returns `text: ""`, so storing it would hand `contentOf` an empty string
+      // failure `readText` returns `text: ""`, so storing it would hand a content view an empty string
       // to call available — the identical coercion this seam exists to remove, arriving through the
       // other door. It read as safe because the two halves are eighteen hundred lines apart: the
       // lookup asks `contents.has(f)`, and only the reader of THIS line knows that a file which
@@ -2772,31 +2883,31 @@ export async function main(args) {
   };
 
   // Descriptive first: detectUnverifiedFunctionality reads the capability findings they produce.
-  detectArchitecture(files, contents, run);
-  detectCapabilities(files, contents, run);
-  detectApis(files, contents, run);
-  detectJobs(files, contents, run);
-  detectIntegrations(files, contents, run);
-  detectAiInterfaces(files, contents, run);
+  detectArchitecture(files, run);
+  detectCapabilities(files, run);
+  detectApis(files, run);
+  detectJobs(files, run);
+  detectIntegrations(files, run);
+  detectAiInterfaces(files, run);
 
-  detectMissingDocs(files, contents, run);
+  detectMissingDocs(files, run);
   detectArchitectureArtifacts(run);
-  detectMissingPlanningArtifacts(files, contents, run);
+  detectMissingPlanningArtifacts(files, run);
   detectMissingAuditInfrastructure(files, run);
   detectUnverifiedFunctionality(files, run);
   detectUnfinished(files, run);
-  detectDeadCode(files, contents, run);
-  detectOpenQuestions(files, contents, run);
-  await detectPlanDiscrepancies(files, contents, run);
-  detectDocDiscrepancies(files, contents, run);
-  detectStandardsViolations(files, contents, run);
+  detectDeadCode(files, run);
+  detectOpenQuestions(files, run);
+  await detectPlanDiscrepancies(files, run);
+  detectDocDiscrepancies(files, run);
+  detectStandardsViolations(files, run);
 
   // Availability is probed once and shared: the env detector and attestation freshness both need the
   // repository, and asking twice would spend a second subprocess to learn the same thing.
   const repoAvailability = repositoryAvailable(root);
   const envCheck = detectCommittedEnvFiles(files, root, repoAvailability, run);
-  detectSecretsInArtifacts(files, contents, run);
-  detectSwallowedExceptions(files, contents, run);
+  detectSecretsInArtifacts(files, run);
+  detectSwallowedExceptions(files, run);
   detectCertBypass(files, run);
   detectSqlConcat(files, run);
 
@@ -2973,8 +3084,10 @@ export async function main(args) {
   // unsearched file is a statement about the run rather than about the project.
   //
   // A file that could not be READ belongs in this condition for exactly the same reason as one the
-  // budget never opened: its content was not obtained, and the derived views the nine rules below
-  // scan resolve it through `sources.get(f)?.code ?? ""` — the same coercion, one indirection away.
+  // budget never opened: its content was not obtained. That used to be invisible to a check, because
+  // the derived views resolved it through `sources.get(f)?.code ?? ""` — the same coercion as the
+  // raw map, one indirection away. The views now answer with a record, so each detector records its
+  // own loss and this surface term is a second, coarser observation point rather than the only one.
   // The trigger is corrected rather than the table extended: the table's membership is not what was
   // wrong, the question it was being asked was.
   //

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -768,9 +768,40 @@ function findRoot(start) {
  * `sources` is here because it is execution-specific: its values are the audited project's file
  * contents, so the same key yields a different correct value for a different target.
  */
+/**
+ * One content lookup, answered with whether the run actually has the content.
+ *
+ * `contents` holds an entry for every file the run opened and retained. A file that is in `files`
+ * and absent from `contents` was collected and never searched — the read budget was spent, or the
+ * read failed. The prevailing idiom `contents.get(f) ?? ""` erased exactly that distinction, and
+ * because empty is meaningful evidence in BOTH polarities the erasure did not merely lose coverage,
+ * it manufactured a verdict: a README nobody opened is "under 400 characters", and a plan file
+ * nobody opened has no incomplete items.
+ *
+ * Returning a value a caller cannot accidentally use as text is the whole mechanism. There is no
+ * `?? ""` to reach for, because there is no string to reach.
+ */
+function contentOf(contents, f) {
+  return contents.has(f)
+    ? { available: true, text: contents.get(f) }
+    : { available: false, text: null, reason: "collected but never searched" };
+}
+
 function createRun({ root, strict, json }) {
   const findings = [];
   const sources = new Map();
+
+  /**
+   * Checks that could not run, by the rule they would have fed.
+   *
+   * The CHECK is the unit, not the rule, and that is load-bearing rather than tidy. A rule can be
+   * established by one check and unknown in another — `reconstruction.baseline-artifacts` fails R4
+   * structurally, needing no content at all, while its R6 content test reads a file this run may not
+   * have. Withdrawing the whole rule would erase a violation that was genuinely established; leaving
+   * it evaluated would report one that was not. Recording per check lets aggregation keep the first
+   * and drop the second.
+   */
+  const unknownChecks = new Map();
 
   return {
     root,
@@ -778,6 +809,20 @@ function createRun({ root, strict, json }) {
     json,
     findings,
     sources,
+    unknownChecks,
+
+    /**
+     * Record that a check could not be performed, and emit nothing.
+     *
+     * Deliberately not a finding. A finding is a claim about the project; this is a fact about the
+     * run, and Standard 44 R12's whole point is that the two must not be confused. The evidence
+     * surface already reports what went unread; this records which conclusions therefore cannot be
+     * drawn from it.
+     */
+    unknown(rule, file, reason) {
+      if (!unknownChecks.has(rule)) unknownChecks.set(rule, []);
+      unknownChecks.get(rule).push({ file, reason });
+    },
 
     /** Repo-relative path with forward slashes, so output is stable across platforms. */
     rel: (p) => path.relative(root, p).split(path.sep).join("/"),
@@ -1284,7 +1329,14 @@ function detectMissingDocs(files, contents, run) {
   if (!files.some((f) => rel(f).toLowerCase() === "docs/architecture.md")) missing.push("docs/architecture.md");
   const readme = files.find((f) => /^readme\.md$/i.test(rel(f)));
   if (!readme) missing.push("README.md");
-  else if ((contents.get(readme) ?? "").trim().length < 400) missing.push(`${rel(readme)} (under 400 characters)`);
+  else {
+    // The presence check above is structural and always valid. Only the length test needs content,
+    // so only the length test is withdrawn — the missing `docs/architecture.md` beside it still
+    // fails the rule, because that was established.
+    const c = contentOf(contents, readme);
+    if (!c.available) run.unknown("documentation.architecture", rel(readme), c.reason);
+    else if (c.text.trim().length < 400) missing.push(`${rel(readme)} (under 400 characters)`);
+  }
   if (missing.length === 0) return;
 
   addFinding({
@@ -1389,7 +1441,14 @@ function detectMissingPlanningArtifacts(files, contents, run) {
     return;
   }
 
-  const body = (contents.get(overview) ?? "")
+  const overviewContent = contentOf(contents, overview);
+  if (!overviewContent.available) {
+    // "A plan directory is evidence of a plan only when it has content" is a claim about the file's
+    // body. Over a body nobody read it is a claim about the run.
+    run.unknown("planning.breakdown-directory", rel(overview), overviewContent.reason);
+    return;
+  }
+  const body = overviewContent.text
     .split("\n")
     .filter((line) => line.trim() && !line.trimStart().startsWith("#"));
   if (body.length === 0) {
@@ -1546,7 +1605,14 @@ function detectOpenQuestions(files, contents, run) {
   const { rel, addFinding } = run;
   const qFile = files.find((f) => rel(f) === "artifacts/project-baseline/open-questions.md");
   if (!qFile) return;
-  const text = contents.get(qFile) ?? "";
+  const questions = contentOf(contents, qFile);
+  if (!questions.available) {
+    // The quiet polarity. Both counts below come from matching this text, so an unread file scores
+    // zero on each and the rule passes — silence indistinguishable from a clean document.
+    run.unknown("reconstruction.open-questions", rel(qFile), questions.reason);
+    return;
+  }
+  const text = questions.text;
   // Fixed, greppable marker written by the project-reconstruction skill's questions template.
   const open = (text.match(/^\s*-?\s*\*\*Status:\*\*\s*open\s*$/gim) ?? []).length;
 
@@ -1624,7 +1690,22 @@ async function detectPlanDiscrepancies(files, contents, run) {
   const planFiles = files.filter((f) => /^artifacts\/project-plan-breakdown\/.+\.md$/.test(rel(f)));
   if (planFiles.length === 0) return;
 
-  const items = planFiles.flatMap((f) => parsePlanItems(contents.get(f) ?? "", rel(f)));
+  // One read, two rules, and they must move together. `planning.item-fields` and
+  // `planning.plan-code-consistency` are both derived from these bytes, and today one is withdrawn
+  // by CONTENT_DERIVED_RULES while the other is not — byte-identical evidence classified two ways by
+  // a table that is not addressing the thing that varies. Recording the unknown against both is what
+  // makes the read site, rather than the table, the thing that decides.
+  //
+  // Files that WERE read are still parsed: a violation found in one plan file is established
+  // regardless of another going unread, and aggregation keeps it.
+  for (const f of planFiles.filter((f) => !contentOf(contents, f).available)) {
+    const reason = contentOf(contents, f).reason;
+    run.unknown("planning.item-fields", rel(f), reason);
+    run.unknown("planning.plan-code-consistency", rel(f), reason);
+  }
+  const items = planFiles
+    .filter((f) => contentOf(contents, f).available)
+    .flatMap((f) => parsePlanItems(contentOf(contents, f).text, rel(f)));
   const executable = items.filter((i) => i.fields.has("Status"));
   if (executable.length === 0) return;
 
@@ -1839,8 +1920,13 @@ function detectStandardsViolations(files, contents, run) {
     }
     const promptFile = files.find((f) => rel(f) === "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md");
     if (promptFile) {
-      const t = contents.get(promptFile) ?? "";
-      if (!/reconstructed from the existing codebase/i.test(t)) {
+      // The mixed case in one detector. R4 above is structural and may already have failed; R6 here
+      // needs the prompt's text. Withdrawing both because this one is unknown would erase R4's
+      // established violation, which is precisely why the check rather than the rule is the unit.
+      const prompt = contentOf(contents, promptFile);
+      if (!prompt.available) {
+        run.unknown("reconstruction.baseline-artifacts", rel(promptFile), prompt.reason);
+      } else if (!/reconstructed from the existing codebase/i.test(prompt.text)) {
         violations.push([rel(promptFile), "R6: reconstructed prompt does not declare itself reconstructed", R.prompt]);
       }
     }
@@ -2792,10 +2878,26 @@ export async function main(args) {
   // in when the repository cannot be read: it can report only that it found nothing, which over an
   // unsearched file is a statement about the run rather than about the project.
   const filesWentUnsearched = surfaceLoss.capped || surfaceLoss.budget.exhausted;
+
+  // Aggregation from checks, which is the part the two mechanisms above cannot do.
+  //
+  //   any confirmed violation      -> failed, carrying only the checks that confirmed it
+  //   no violation + any unknown   -> not-evaluated
+  //   all known and no violation   -> passed
+  //
+  // The first line is the one that needs the check-level record. A rule with an unknown check AND a
+  // confirmed violation stays evaluated and stays failed: the violation was established by a check
+  // that ran, and withdrawing the rule would discard a real finding because a DIFFERENT check went
+  // unread. `reconstruction.baseline-artifacts` is exactly that shape — structural R4, content R6 —
+  // and it is why no table over rule ids can express this.
+  const confirmed = new Set(findings.filter((f) => f.rule).map((f) => f.rule));
+  const unknownAndUnestablished = (id) => run.unknownChecks.has(id) && !confirmed.has(id);
+
   const evaluatedThisRun = EVALUATED_RULES.filter(
     (id) =>
       !(id === "scm.no-committed-env-files" && envCheck.evaluated === false) &&
-      !(filesWentUnsearched && CONTENT_DERIVED_RULES.includes(id)),
+      !(filesWentUnsearched && CONTENT_DERIVED_RULES.includes(id)) &&
+      !unknownAndUnestablished(id),
   );
 
   const verdict = evaluate({

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -1587,8 +1587,48 @@ function detectUnfinished(files, run) {
 
 const ENTRYISH = /(^|\/)(index|main|app|Program|Startup|__init__|__main__|setup|conftest)\.[a-z]+$/i;
 
+/**
+ * The one detector whose SEARCH spans every file rather than a filtered subset.
+ *
+ * Its candidates are code files, but the reference lookup below asks whether a stem appears in
+ * ANYTHING. `rules/verification.json` states the proposition as *"Code no longer reachable from any
+ * entry point"* and the finding says *"referenced nowhere else in the repository"* — both
+ * repository-wide absence claims, and nothing in the catalogue defines a narrower searchable-text
+ * universe. So "anywhere" may not be quietly reread as "in the files we happened to open".
+ *
+ * That makes the reference space part of the evidence, and it can be incomplete in a way none of the
+ * recorded loss conditions describes: a file outside `TEXT_EXT` is collected into `files` and skipped
+ * by the read loop with a bare `continue`, so nothing was lost — nothing was ever going to be read —
+ * and `filesWentUnsearched` stays false. The absence of its text was then read as the absence of a
+ * reference, and the rule reached `failed / evaluated` naming a file that is not dead.
+ *
+ * Checked before any candidate is judged, rather than beside the finding, and that ordering is the
+ * fix. An orphan is established by NOT finding something, so it cannot be treated as a confirmed
+ * violation that survives evidence loss the way a match in a file that WAS read does: the missing
+ * evidence is exactly what would refute it. Emitting the finding first and withdrawing after would
+ * hit the `confirmed` exemption in aggregation and keep the verdict.
+ */
 function detectDeadCode(files, contents, run) {
   const { rel, addFinding } = run;
+
+  // Measured over the reference space itself rather than by enumerating the ways a file can go
+  // missing, because the extension skip is not one of them and a sixth would not be either. A
+  // retained prefix counts as incomplete for the same reason it does everywhere else: a stem absent
+  // from the first bytes of a file is not absent from the file.
+  const unsearchable = files.filter((other) => {
+    const c = contentOf(contents, other, run);
+    return !c.available || c.partial;
+  });
+  if (unsearchable.length > 0) {
+    run.unknown(
+      "quality.dead-code",
+      rel(unsearchable[0]),
+      `${unsearchable.length} file(s) went unsearched, so "referenced nowhere" is not established` +
+        (unsearchable.length > 1 ? ` (${rel(unsearchable[0])} and ${unsearchable.length - 1} more)` : ""),
+    );
+    return;
+  }
+
   const candidates = files.filter((f) => {
     const r = rel(f);
     if (!/\.(m?[jt]sx?|py|cs|go|rb)$/.test(r)) return false;

--- a/standards/44-existing-project-reconstruction.md
+++ b/standards/44-existing-project-reconstruction.md
@@ -453,6 +453,25 @@ Operationally:
    citing the evidence newly found, and becomes `CONFIRMED_BY_OWNER` only through R9 with its
    provenance fields. A label never strengthens silently, and never strengthens because the claim was
    repeated often enough to feel established.
+4. **The invariant is symmetric: unavailable evidence produces no result in either direction.**
+   Evidence that was not obtained MUST NOT be interpreted as evidence of anything, including of
+   absence. A check whose required evidence is unavailable is `UNKNOWN`; it may produce neither a
+   satisfaction claim nor a violation finding, and the disposition of whatever it feeds is derived
+   from the checks that ran rather than from a substituted value.
+
+   The three sentences above this one all describe the *negative* direction — not finding a thing —
+   and that asymmetry was itself the defect. Stated only that way, the invariant reads as a rule
+   about clean results, and a tool can honour every word of it while manufacturing a **failure**: a
+   README nobody could open is "under 400 characters", and a declaration nobody read is "missing".
+   Missing evidence has no natural polarity. Which verdict it fabricates is decided by whether the
+   check is satisfied by presence or by absence, so a rule that governs only one of them governs
+   whichever half the next check happens to fall in.
+
+   The operative word is *unavailable*, not *empty*. Wherever a lookup for absent evidence can return
+   the same value as a lookup for genuinely empty evidence, this invariant is unenforceable no matter
+   what the surrounding code says, because the distinction it rests on has already been discarded at
+   the point of reading. Availability therefore has to be answered by the lookup itself rather than
+   asserted afterwards.
 
 The same invariant appears elsewhere in the standards under other names, and they are cross-references
 rather than duplicates: [Standard 24](24-validator-rules.md) — a check may claim only what its own
@@ -492,8 +511,17 @@ because their limits matter:
 | `CONFIRMED_BY_OWNER` carries a `(YYYY-MM-DD)` date (R3, R9) | Every confirmation in `open-questions.md` can be reassessed against a date | The rest of R9's provenance, which is prose; and any labeled claim outside that one file. The scan reads the questions document, so that is all it may claim ([Standard 24](24-validator-rules.md)) |
 | Open questions are surfaced rather than quietly closed (R8) | Questions marked open are counted and reported | Whether a question marked answered really was |
 
-**Not mechanically checked, and honestly so.** R11 and R12 are discipline, not structure, and no rule
-ID is claimed for them:
+**Mechanically enforced against this framework's own evaluator.** R12's fourth point is a constraint
+on any tool that reports results, this one included, and it is the one part of R11/R12 that is not
+purely discipline. `standards audit` answers every content lookup with availability rather than with
+text, records a check whose evidence was unavailable as unknown, and aggregates rule disposition from
+the checks that ran — so a rule with an unread check and no confirmed violation reports
+`not-evaluated`, while one whose violation was established by a check needing no content stays
+`failed` and carries only that finding. No rule ID is claimed for R12 itself; the enforcement is
+structural, in `scripts/standards.mjs`, and is pinned by `test/evidence-availability.test.mjs`.
+
+**Not mechanically checked, and honestly so.** R11 and the rest of R12 are discipline, not structure,
+and no rule ID is claimed for them:
 
 - R11's substantive-content test is a judgement about whether a plan file says anything real. The
   tooling makes the same judgement in its own narrow way — `standards init` treats a directory as

--- a/test/audit-read-budget.test.mjs
+++ b/test/audit-read-budget.test.mjs
@@ -343,6 +343,19 @@ test("a content rule cannot pass over files nothing searched", async () => {
       (partial.findings ?? []).some((f) => f.id === "evidence-read-budget"),
       "the run did not report an exhausted budget, so the assertions below prove nothing",
     );
+    // SPLIT BY WHETHER THE RULE WAS ESTABLISHED, which this originally did not distinguish.
+    //
+    // The blanket assertion was `disposition !== "evaluated"` for all three, and it collided with
+    // issue #38's truth table: `any confirmed violation -> FAILED`. This tree writes a swallowed
+    // exception into EVERY file, so the files read before the budget ran out genuinely establish
+    // `errors.no-swallowed-exceptions`. Withdrawing it would discard a violation the run actually
+    // found, and report `skipped / not-evaluated` over a defect sitting in its own findings list.
+    //
+    // What this test exists for is unchanged and is still asserted for every rule: none may report a
+    // CLEAN result over unsearched files. The split makes that stricter rather than weaker, because
+    // each rule now has to land in the right one of two states instead of any state that is not one
+    // named value.
+    let established = 0;
     for (const id of CONTENT_RULES) {
       const hit = statusOf(partial, id);
       assert.ok(hit, `${id} disappeared from the report entirely`);
@@ -351,8 +364,22 @@ test("a content rule cannot pass over files nothing searched", async () => {
         "passed",
         `${id} passed over a surface with unsearched files: ${JSON.stringify(hit)}`,
       );
-      assert.notEqual(hit.disposition, "evaluated", `${id} claimed evaluation over unsearched files`);
+
+      if ((partial.findings ?? []).some((f) => f.rule === id)) {
+        established += 1;
+        assert.equal(
+          hit.status,
+          "failed",
+          `${id} had a violation confirmed by a file that WAS read and was withdrawn anyway: ${JSON.stringify(hit)}`,
+        );
+      } else {
+        assert.notEqual(hit.disposition, "evaluated", `${id} claimed evaluation over unsearched files`);
+      }
     }
+    assert.ok(
+      established > 0,
+      "no rule was established by a read file, so the confirmed-violation branch above is vacuous",
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -1038,3 +1038,160 @@ test("a reference in a file the budget could not reach cannot establish dead cod
     await rm(root, { recursive: true, force: true });
   }
 });
+
+
+// --- The boundary is the mechanism ----------------------------------------------------------------
+//
+// Criterion 1 of #38 is typed, and it is deliberately not the same requirement as the verdict-level
+// invariant every falsifier above measures: *a content lookup for a file the run did not obtain
+// cannot return a string. No call site can reach `""` or `"{}"` for unread content, and THE
+// MECHANISM ENFORCES THIS RATHER THAN A COMMENT ASSERTING IT.*
+//
+// The behavioural tests above cannot establish that clause. They prove that the sites which exist
+// today behave, one site at a time, which is exactly the property that decays: the seam was opt-in
+// at the call site, so a new detector inherited nothing and the next `contents.get(f) ?? ""` was one
+// line of ordinary-looking code away. This test is the enforcement, and it is a source-level
+// assertion on purpose — the criterion asks for a mechanism, and the mechanism is that the raw map
+// is not reachable from a detector at all.
+//
+// It is written to fail on the parent commit, where every detector took `contents` as a parameter.
+
+const SOURCE = readFileSync(CLI, "utf8");
+
+/**
+ * The source with comment lines dropped, because this file scans for a coercion by shape.
+ *
+ * Written after the first run of the last test below failed on a sentence in a comment describing
+ * the coercion it was looking for. That is the criterion's own distinction arriving as a bug: a
+ * comment naming `?? ""` is not a call site reaching for it, and a test that cannot tell them apart
+ * is asserting about prose. It is also the fifth time this repository has confused a mention for a
+ * use, which is why the split is a named helper rather than an inline filter.
+ */
+const codeOnly = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+    .join("\n");
+
+/** Each detector's parameter list and body, taken from the source rather than by calling it. */
+const detectorBodies = () => {
+  const found = [...SOURCE.matchAll(/^(?:async )?function (detect[A-Za-z]+)\(([^)]*)\)\s*\{([\s\S]*?)^\}/gm)];
+  assert.ok(
+    found.length >= 15,
+    `only ${found.length} detectors were parsed out of the source; the matcher has drifted from the code`,
+  );
+  return found;
+};
+
+test("no detector can be handed the raw content map", () => {
+  // The structural half. A detector receives `run`, and `run` exposes views; there is no parameter
+  // through which the map arrives, so the expression that caused this defect cannot be written.
+  for (const [, name, params] of detectorBodies()) {
+    assert.ok(
+      !/\bcontents\b/.test(params),
+      `${name} still takes the raw contents map as a parameter, so the seam is opt-in again`,
+    );
+  }
+});
+
+test("no detector reads the raw content map, and no lookup is coerced to a string", () => {
+  // The reachability half, for the map arriving by some route other than a parameter — a closure, a
+  // property off `run`, a module-level binding. And the coercion itself: a view returns a record, so
+  // `?? ""` after one is not a fallback, it is a type error waiting to read as an empty file.
+  // `[, name, , rawBody]`: the third capture is the parameter list and the fourth is the body. The
+  // first version of this loop took the third, so every assertion below was scanning a parameter
+  // list and passing vacuously — found by mutating a detector to destructure `contents` off `run`
+  // and watching nothing fail. A test that cannot fail is the same defect as a rule that cannot.
+  for (const [, name, , rawBody] of detectorBodies()) {
+    const body = codeOnly(rawBody);
+    // The identifier at all, not just `.get`/`.has`: a detector that destructures `contents` off
+    // `run`, or closes over it, has reopened the same door by a route a method-name check misses.
+    assert.ok(
+      !/\bcontents\b/.test(body),
+      `${name} reaches the raw contents map`,
+    );
+    assert.ok(
+      !/\w+Of\([^)]*\)\s*\?\?/.test(body),
+      `${name} coerces the result of a content view, which is the defect one indirection away`,
+    );
+    assert.ok(
+      !/\?\?\s*"\{\}"/.test(body),
+      `${name} falls back to "{}" — an unread manifest is not an empty manifest`,
+    );
+  }
+});
+
+test("every content view answers with a record, and the four are the only route", () => {
+  // The type itself, asserted where it is defined. `available` and `partial` are separate fields
+  // because their two directions are not symmetric: a violation found in a retained prefix was
+  // genuinely found, while a clean result over that prefix says nothing about the bytes after it.
+  const views = ["textOf", "sourceOf", "structureOf", "commentsOf"];
+  for (const v of views) {
+    assert.match(
+      SOURCE,
+      new RegExp(`${v}: \\(f\\) => viewOf\\(f, (null|"code"|"structure"|"comments")\\)`),
+      `${v} is not defined as a view over the shared lookup, so it may answer with something else`,
+    );
+  }
+  for (const field of ["available", "partial", "text", "reason"]) {
+    assert.ok(SOURCE.includes(`${field}:`), `the content record no longer carries ${field}`);
+  }
+  // Any coercion of a missing split-source entry, not one spelling of it. The first version of
+  // this assertion pinned the exact `?? ""` the defect had been written as, and a mutant supplying
+  // `?? { code: "", structure: "", comments: "" }` walked straight through it -- the same shape of
+  // hole as the criterion itself, in the test meant to hold the criterion.
+  assert.ok(
+    !/sources\.get\([^)]*\)[^;\n]*\?\?/.test(codeOnly(SOURCE)),
+    "a derived view coerces a missing split-source entry into a value a caller can read as text",
+  );
+});
+
+/**
+ * Rule-bound content detectors, and the rule each must record its own losses against.
+ *
+ * WHY THIS IS A SOURCE-LEVEL ASSERTION AND NOT A BEHAVIOURAL ONE. Mutation testing found that
+ * deleting the `run.unknown(...)` call from these detectors changes no verdict this suite can
+ * observe, and the reason is measured rather than assumed: `CONFIG_EXT` and `CODE_EXT` are both
+ * subsets of `TEXT_EXT`, so every file these detectors read is one the read loop attempts, so any
+ * unavailability is already one of the recorded loss conditions, so the coarse
+ * `filesWentUnsearched` trigger withdraws the rule regardless. The per-detector call is redundant
+ * TODAY, and only today.
+ *
+ * That is exactly the situation where a boundary rots. `quality.dead-code` is the proof: its
+ * reference space reaches files outside `TEXT_EXT`, the coarse trigger does not cover it, and the
+ * rule fabricated a verdict for as long as nobody looked. Leaving these detectors depending on a
+ * condition that happens to subsume them means the next detector to read outside that set fails the
+ * same way — silently, and with a green suite.
+ *
+ * So the requirement is asserted where it is actually made: a detector that binds a rule and reads
+ * content must record its own loss against its own rule, and must treat a retained prefix as one.
+ */
+const RULE_BOUND_CONTENT_DETECTORS = [
+  ["detectDeadCode", "quality.dead-code"],
+  ["detectDocDiscrepancies", "documentation.code-consistency"],
+  ["detectSecretsInArtifacts", "security.no-secrets-in-artifacts"],
+  ["detectSwallowedExceptions", "errors.no-swallowed-exceptions"],
+  ["detectUnfinished", "quality.unfinished-work"],
+  ["detectCertBypass", "security.no-cert-bypass"],
+  ["detectSqlConcat", "security.no-sql-concat"],
+  ["detectOpenQuestions", "reconstruction.open-questions"],
+];
+
+test("a rule-bound detector records its own evidence loss, against its own rule", () => {
+  const bodies = new Map(detectorBodies().map(([, name, , body]) => [name, codeOnly(body)]));
+  for (const [name, rule] of RULE_BOUND_CONTENT_DETECTORS) {
+    const body = bodies.get(name);
+    assert.ok(body, `${name} was not found in the source; the table has drifted from the code`);
+    // Whitespace-tolerant: the call is wrapped across lines wherever the reason is composed.
+    assert.ok(
+      new RegExp(`run\\.unknown\\(\\s*"${rule}"`).test(body),
+      `${name} reads content and binds ${rule}, but records no loss against it — it is relying on ` +
+        "the coarse surface trigger, which is exactly what quality.dead-code fell out of",
+    );
+    assert.ok(
+      /\.partial\b/.test(body),
+      `${name} does not distinguish a retained prefix from the file; a clean result over the first ` +
+        "bytes is a statement about those bytes",
+    );
+  }
+});

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -34,7 +34,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, writeFile, rm, chmod } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -735,6 +735,145 @@ test("GUARD: governed content still reaches its real verdict, and .git never cou
       baitedVerdicts(root),
       ["failed/evaluated", "failed/evaluated", "warning/evaluated"],
       "governed first-party code did not reach its real verdict",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+/** Prove a directory really cannot be listed, for the same reason `reallyUnreadable` exists. */
+function reallyUnlistable(dir) {
+  try {
+    readdirSync(dir);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// --- Evidence loss bounds silence; it does not unfind what was found -----------------------------
+//
+// Three boundaries raised in review of this branch. Each is a way for the withdrawal machinery to
+// give a wrong answer, and the first two point in opposite directions: one withdraws a rule that was
+// established, the other keeps a rule that was not.
+
+/** A committed repository carrying the bait, plus whatever else the caller needs. */
+async function baitedFixture(extra = {}) {
+  const root = await tmp();
+  const git = (...args) => {
+    const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    assert.equal(r.status, 0, `git ${args.join(" ")} failed: ${r.stderr}`);
+  };
+  git("init", "-q");
+  git("config", "user.email", "test@example.invalid");
+  git("config", "user.name", "test");
+  await writeFile(path.join(root, "README.md"), `# Specimen\n\n${"substantive prose ".repeat(60)}\n`);
+  await writeFile(path.join(root, "project-policy.yml"), CONTENT_POLICY);
+  for (const [rel, body] of Object.entries(extra)) {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body);
+  }
+  git("add", "-A");
+  git("-c", "commit.gpgsign=false", "commit", "-qm", "specimen");
+  return root;
+}
+
+const statusOf = (json, id) => {
+  const r = resultFor(json, id);
+  return `${r.status}/${r.disposition}`;
+};
+
+test("a confirmed violation survives an unrelated file going unreadable", async () => {
+  // Evidence loss bounds what a run may conclude from SILENCE. It cannot unfind what the run already
+  // found, and the surface-level branch did not honour that: one unreadable file anywhere withdrew
+  // every rule in CONTENT_DERIVED_RULES, so a violation detected in a file that WAS read came back
+  // `skipped / not-evaluated`. The finding stayed in the report while the rule reported nothing —
+  // the two halves of one run disagreeing about whether a secret had been found.
+  const root = await baitedFixture({ "src/bait.js": CONTENT_BAIT });
+  const spare = path.join(root, "docs", "spare.md");
+  try {
+    await mkdir(path.join(root, "docs"), { recursive: true });
+    await writeFile(spare, "# Spare\n\nUnrelated to the bait.\n");
+    await denyRead(spare);
+    assert.ok(reallyUnreadable(spare), "could not make the spare file unreadable; fix the harness rather than skipping");
+
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.ok(surface.unreadableFiles.length > 0, "the fixture stopped producing a read failure");
+
+    const json = run("validate", root, AMPLE);
+    assert.ok(
+      findingsFor(json, "security.no-sql-concat").length > 0,
+      "the bait stopped producing a finding, so this test would prove nothing",
+    );
+    assert.equal(
+      statusOf(json, "security.no-sql-concat"),
+      "failed/evaluated",
+      "a violation found in a file that was read must survive an unrelated file being unreadable",
+    );
+  } finally {
+    await restoreRead(spare);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a directory that could not be listed withdraws the rules its contents would have fed", async (t) => {
+  // Nothing beneath an unlistable directory is ever collected, so an absence-based rule reports
+  // "found nothing" over files it never had the chance to see. The surface recorded the loss as an
+  // `evidence-unreadable-dir` finding and the trigger ignored it, so the verdict stayed clean beside
+  // a finding saying the run could not look.
+  const root = await baitedFixture();
+  const hidden = path.join(root, "src");
+  try {
+    await mkdir(hidden, { recursive: true });
+    await writeFile(path.join(hidden, "inner.js"), "const x = 1;\n");
+    await denyRead(hidden);
+    if (!reallyUnlistable(hidden)) {
+      t.skip("this host refuses to make a directory unlistable; the boundary runs on the Linux image");
+      return;
+    }
+
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.ok(surface.unreadableDirectories.length > 0, "the fixture stopped producing an unlistable directory");
+    assert.equal(surface.readBudget.exhausted, false, "the budget was spent, so this is not the loss mode under test");
+
+    const json = run("validate", root, AMPLE);
+    assert.equal(
+      statusOf(json, "security.no-sql-concat"),
+      "skipped/not-evaluated",
+      "an absence-based rule must not pass over a directory the run could not list",
+    );
+  } finally {
+    await restoreRead(hidden);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a retained prefix is not the file, and cannot establish a clean result", async () => {
+  // The third loss mode the item names and the first implementation ignored. `readText` caps each
+  // read at MAX_READ_BYTES, so a large file is retained IN PART while `contents.has(f)` answers yes.
+  // The bait here sits after the cap: every byte of the violation is outside what the run holds, so
+  // the rule reported `passed` over a file it had read four hundred kilobytes of.
+  const CAP = 400_000;
+  const padded = `${"// padding\n".repeat(Math.ceil(CAP / 10) + 1000)}\n${CONTENT_BAIT}`;
+  const root = await baitedFixture({ "src/big.js": padded });
+  try {
+    assert.ok(Buffer.byteLength(padded, "utf8") > CAP, "the specimen must exceed the per-file cap");
+
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.ok(surface.truncatedFiles.length > 0, "the fixture stopped producing a truncated read");
+    assert.equal(surface.readBudget.exhausted, false, "the budget was spent, so this is not the loss mode under test");
+
+    const json = run("validate", root, AMPLE);
+    assert.deepEqual(
+      findingsFor(json, "security.no-sql-concat"),
+      [],
+      "the bait was supposed to be past the cap; if it is visible this test proves nothing",
+    );
+    assert.equal(
+      statusOf(json, "security.no-sql-concat"),
+      "skipped/not-evaluated",
+      "a clean result over a prefix is a statement about the prefix, not about the file",
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -33,7 +33,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, chmod } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -417,6 +418,160 @@ test("the mechanism is inert when nothing is lost", async () => {
       .filter((r) => r.disposition === "not-evaluated" && POLICY.includes(r.ruleId))
       .map((r) => r.ruleId);
     assert.deepEqual(withdrawn, [], "a declared rule was withdrawn on a run that read everything");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- The other way content goes unobtained -------------------------------------------------------
+//
+// Everything above makes evidence unavailable through the read BUDGET, which is the injectable and
+// deterministic mechanism. It is not the only one, and the seam covered only that one: on a failed
+// read, `readText` returns `{ ok: false, text: "" }` and the loop stored that empty string, so
+// `contents.has(f)` answered yes and `contentOf` called it available. A file the process could not
+// open produced the identical fabrication — a ~200 KB README reported as "under 400 characters" —
+// by a different route, and no falsifier above could see it, because they all vary the budget.
+//
+// The permission manipulation is real and is VERIFIED to have bitten before anything is asserted,
+// following test/audit.test.mjs; a test that quietly skipped when it could not restrict a path
+// would be exactly the false green this item is about.
+
+const IS_WINDOWS = process.platform === "win32";
+
+async function denyRead(file) {
+  if (IS_WINDOWS) spawnSync("icacls", [file, "/deny", `${process.env.USERNAME}:R`], { encoding: "utf8" });
+  else await chmod(file, 0o000);
+}
+
+async function restoreRead(file) {
+  if (IS_WINDOWS) spawnSync("icacls", [file, "/remove:d", process.env.USERNAME], { encoding: "utf8" });
+  else await chmod(file, 0o644);
+}
+
+/** Prove the denial actually took effect. Returns true only if the read really fails. */
+function reallyUnreadable(file) {
+  try {
+    readFileSync(file);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+test("an unreadable file is not content either", async () => {
+  const root = await tmp();
+  const readme = path.join(root, "README.md");
+  try {
+    await fixture(root, {
+      "README.md": README_PROSE,
+      "docs/architecture.md": "# Architecture\n\nReal content.\n",
+    });
+    await denyRead(readme);
+    assert.ok(
+      reallyUnreadable(readme),
+      "could not make the README unreadable, so this test would prove nothing — fix the harness rather than skipping",
+    );
+
+    // Full budget on purpose: the loss here is the read failing, not the budget being spent, and
+    // pinning that separately is what keeps this from being a second copy of the falsifiers above.
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.deepEqual(surface.unreadableFiles, ["README.md"], "the fixture stopped producing a read failure");
+    assert.equal(surface.readBudget.exhausted, false, "the budget was spent, so this is not the loss mode under test");
+
+    const json = run("validate", root, AMPLE);
+    assert.deepEqual(
+      findingsFor(json, "documentation.architecture"),
+      [],
+      "a finding was emitted about the length of a file the process could not open",
+    );
+    assertNotEvaluated(json, "documentation.architecture");
+  } finally {
+    await restoreRead(readme);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a rule reading a derived view is withdrawn when a file could not be read", async () => {
+  // The nine rules already covered by the coarse surface-level withdrawal reach content through
+  // `sourceOf`/`structureOf`, which resolve `sources.get(f)?.code ?? ""` — the same coercion one
+  // indirection away. That withdrawal fired on the file cap and on budget exhaustion and not on a
+  // read failure, so those nine kept scanning a blank derived view of a file nobody could open and
+  // reporting the clean result as evidence.
+  const root = await tmp();
+  const locked = path.join(root, "src", "app.js");
+  try {
+    await fixture(root, {
+      "README.md": "# Small\n\nDeliberately short, and irrelevant to this test.\n",
+      "src/app.js": "export function go() {\n  return 1;\n}\n",
+    });
+    await denyRead(locked);
+    assert.ok(reallyUnreadable(locked), "could not make the source file unreadable");
+
+    const json = run("validate", root, AMPLE);
+    for (const id of ["quality.dead-code", "security.no-secrets-in-artifacts", "errors.no-swallowed-exceptions"]) {
+      const r = (json.results ?? []).find((x) => x.ruleId === id);
+      if (!r) continue; // not declared by this fixture's policy; the assertion below is what matters
+      assert.notEqual(
+        r.status,
+        "passed",
+        `${id} reported a clean result over a file the process could not open`,
+      );
+    }
+  } finally {
+    await restoreRead(locked);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a starved run reaches no verdict that needed content, in either polarity", async () => {
+  // Acceptance criterion 3 stated over the whole result set rather than per rule. The falsifiers
+  // above can only catch a fabrication somebody wrote them to name; this catches any rule that
+  // still reaches a verdict when the run read nothing, including one added by work not yet written.
+  //
+  // THE CRITERION IS NARROWED HERE, AND THE NARROWING IS THE POINT. #38 asks for an assertion that
+  // the starved run "reports no rule at disposition: evaluated in either polarity". Taken literally
+  // that is wrong, and this test failed against it before the wording was corrected: this fixture
+  // omits reconstructed-baseline.md, so reconstruction.baseline-artifacts fails R4 — a structural
+  // check over a directory listing, needing no file content at all. It is established, and a
+  // criterion that withdrew it would be demanding the mirror-image fabrication: discarding a real
+  // violation because a DIFFERENT check went unread. What the invariant actually forbids is a
+  // verdict that needed content, so that is what is asserted — no rule reaches passed at all, and
+  // the one rule that stays evaluated carries only its content-free finding.
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "README.md": README_PROSE,
+      "docs/architecture.md": `# Architecture\n\n${bulk("Real architecture prose.")}`,
+      "artifacts/project-plan-breakdown/00-overview.md": `# Overview\n\n${OVERVIEW}`,
+      "artifacts/project-plan-breakdown/01-plan.md": PLAN_BAD,
+      "artifacts/project-baseline/open-questions.md": QUESTIONS_BAD,
+      "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md": PROMPT_OK,
+    });
+
+    // A budget of 1 byte: nothing is retained at all, so no content evidence exists for anything.
+    const surface = run("audit", root, 1).evidenceSurface;
+    assert.equal(surface.readBudget.exhausted, true, "a one-byte budget did not exhaust");
+    assert.equal(surface.readBudget.retainedBytes, 0, "something was retained under a one-byte budget");
+
+    const json = run("validate", root, 1);
+    const declared = (json.results ?? []).filter((r) => POLICY.includes(r.ruleId));
+
+    // The fabricated-pass direction, wholesale. Nothing was read, so nothing is clean.
+    assert.deepEqual(
+      declared.filter((r) => r.status === "passed").map((r) => r.ruleId),
+      [],
+      "a rule reported a clean result on a run that read nothing",
+    );
+
+    // The fabricated-failure direction, allowing exactly what a content-free check established.
+    assert.deepEqual(
+      declared.filter((r) => r.disposition === "evaluated").map((r) => r.ruleId),
+      ["reconstruction.baseline-artifacts"],
+      "a rule reached a verdict that required content the run never obtained",
+    );
+    const survived = findingsFor(json, "reconstruction.baseline-artifacts");
+    assert.equal(survived.length, 1, `expected only the structural R4 finding, got ${JSON.stringify(survived.map((f) => f.message))}`);
+    assert.match(survived[0].message, /R4/, "the surviving finding must be the one that needed no content");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -448,6 +448,19 @@ async function restoreRead(file) {
   else await chmod(file, 0o644);
 }
 
+/**
+ * Restore a DIRECTORY, which is not the same call.
+ *
+ * `0o644` on a directory leaves it without the execute bit, so nothing can traverse it and the
+ * recursive cleanup fails with EACCES -- the test then fails in its own `finally`, having already
+ * proved what it set out to prove. Found in the gate's Linux image, where the permission bits are
+ * real; on Windows the icacls path made it invisible.
+ */
+async function restoreListing(dir) {
+  if (IS_WINDOWS) spawnSync("icacls", [dir, "/remove:d", process.env.USERNAME], { encoding: "utf8" });
+  else await chmod(dir, 0o755);
+}
+
 /** Prove the denial actually took effect. Returns true only if the read really fails. */
 function reallyUnreadable(file) {
   try {
@@ -844,7 +857,7 @@ test("a directory that could not be listed withdraws the rules its contents woul
       "an absence-based rule must not pass over a directory the run could not list",
     );
   } finally {
-    await restoreRead(hidden);
+    await restoreListing(hidden);
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -1021,6 +1021,35 @@ test("a reference living outside the searched extensions cannot establish dead c
   }
 });
 
+test("a reference past the per-file read cap cannot establish dead code either", async () => {
+  // The THIRD door, and the one the other two do not cover. The file is TEXT_EXT, it is opened, and
+  // the budget is ample -- it is simply larger than MAX_READ_BYTES, so only its first 400 KB are
+  // retained and the reference sits past that boundary. `available` is true and `partial` is what
+  // says the search did not cover the file.
+  //
+  // Written because mutation testing found `partial` folded into `available` survived the suite.
+  // The route it reopens is precise: the completeness guard stops flagging the file, the detector
+  // judges a candidate over a reference space it did not finish reading, emits an orphan, and the
+  // `confirmed` exemption in aggregation then KEEPS that verdict -- the coarse `truncatedFiles`
+  // trigger cannot withdraw a rule that already has a confirmed violation. A retained prefix is not
+  // the file, and a clean result over the first bytes is a statement about those bytes.
+  const padding = `// ${"padding ".repeat(9)}
+`;
+  const overCap = padding.repeat(Math.ceil(420_000 / padding.length)) + `// ${REFERENCE}
+`;
+  const root = await deadCodeFixture({ "src/uses.js": overCap });
+  try {
+    const json = run("validate", root, AMPLE);
+    assert.ok(
+      !orphanNames(json).includes("src/widgetrenderer.js"),
+      "a file whose only reference sits past the read cap was named as dead code",
+    );
+    assertNotEvaluated(json, "quality.dead-code");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a reference in a file the budget could not reach cannot establish dead code either", async () => {
   // The same proposition losing its reference space through a DIFFERENT door, and the reason this
   // is a separate test: a fix that special-cased the extension check would pass the falsifier above

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -705,9 +705,17 @@ test("GUARD: repository-ignored content is a narrowing, not a loss", async () =>
     assert.equal(surface.complete, true, "a repository-authorized exclusion made the surface incomplete");
     assert.deepEqual(surface.frameworkExcludedDirectories, []);
 
+    // The two security rules are the load-bearing entries: they are the ones the ignore declaration
+    // would withdraw if a narrowing were being counted as a loss, and they stay evaluated.
+    //
+    // `quality.dead-code` moved to withdrawn for an unrelated and correct reason, and this fixture
+    // is where that first shows. Its proposition is repository-wide absence, so its reference space
+    // is every collected file — and `.gitignore` is extensionless, so `TEXT_EXT` skips it and it is
+    // never searched. The ignore declaration is not the cause: the specimen below with no
+    // `.gitignore` at all reaches `warning/evaluated` on the same rule.
     assert.deepEqual(
       baitedVerdicts(root),
-      ["passed/evaluated", "passed/evaluated", "passed/evaluated"],
+      ["passed/evaluated", "passed/evaluated", "skipped/not-evaluated"],
       "a repository's own ignore declaration withdrew rules it should not have",
     );
   } finally {
@@ -888,6 +896,144 @@ test("a retained prefix is not the file, and cannot establish a clean result", a
       "skipped/not-evaluated",
       "a clean result over a prefix is a statement about the prefix, not about the file",
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- The reference space of an absence claim ------------------------------------------------------
+//
+// `quality.dead-code` is the one detector whose SEARCH spans every file rather than a filtered
+// subset: its candidates are code files, but `files.some((other) => ...)` looks for a reference in
+// anything. That makes it the only site where a file the run never opened can decide a verdict, and
+// it reaches a mode none of the six recorded loss conditions cover.
+//
+// A file outside `TEXT_EXT` is collected into `files` and skipped by the read loop with a bare
+// `continue`. It is absent from `contents` exactly as an unread file is, but nothing was lost —
+// nothing was ever going to be read — so `filesWentUnsearched` is false and no withdrawal fires.
+//
+// WHAT THE RULE CLAIMS, MEASURED RATHER THAN ASSUMED. `rules/verification.json` says *"Code no
+// longer reachable from any entry point"*, and the finding says *"referenced nowhere else in the
+// repository"*. Both are repository-wide absence claims. Nothing in the catalogue defines a narrower
+// searchable-text universe, so "anywhere" may not be quietly read as "in the files we happened to
+// open": when the reference space is incomplete the proposition is not evaluable, and the rule is
+// withdrawn rather than restated.
+
+/** The orphan candidate, plus a reference to it placed where the caller chooses. */
+async function deadCodeFixture(extra) {
+  const root = await tmp();
+  const git = (...args) => {
+    const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    assert.equal(r.status, 0, `git ${args.join(" ")} failed: ${r.stderr}`);
+  };
+  git("init", "-q");
+  git("config", "user.email", "test@example.invalid");
+  git("config", "user.name", "test");
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await writeFile(path.join(root, "README.md"), `# Specimen\n\n${"substantive prose ".repeat(60)}\n`);
+  await writeFile(path.join(root, "project-policy.yml"), DEAD_CODE_POLICY);
+  // Named so no other file mentions the stem by accident, and not ENTRYISH.
+  await writeFile(path.join(root, "src", "widgetrenderer.js"), "export function render() { return 1; }\n");
+  for (const [rel, body] of Object.entries(extra)) {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body);
+  }
+  git("add", "-A");
+  git("-c", "commit.gpgsign=false", "commit", "-qm", "specimen");
+  return root;
+}
+
+const DEAD_CODE_POLICY = [
+  'standardVersion: "2.0.0"',
+  'project: "Dead code reference space specimen"',
+  "rules:",
+  "  quality.dead-code:",
+  "    level: required",
+  "",
+].join("\n");
+
+/** The reference itself, in whatever syntax the host file takes. */
+const REFERENCE = "widgetrenderer is used here";
+
+const orphanNames = (json) =>
+  findingsFor(json, "quality.dead-code").flatMap((f) => f.evidence ?? []);
+
+test("GUARD: a genuine orphan is still established when the reference space is complete", async () => {
+  // The anti-vacuity control, and the one that stops "withdraw whenever anything is missing" from
+  // being a passing answer to the falsifiers below. Every file here is TEXT_EXT, every one is read,
+  // and nothing references the candidate: the absence claim has its whole reference space, so the
+  // rule must reach a scored verdict and name the file.
+  const root = await deadCodeFixture({ "src/other.js": "export const other = 2;\n" });
+  try {
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.equal(surface.complete, true, "the fixture stopped presenting a complete surface");
+
+    const json = run("validate", root, AMPLE);
+    assert.equal(
+      statusOf(json, "quality.dead-code"),
+      "failed/evaluated",
+      "a complete search that found no reference must still be able to say so",
+    );
+    assert.ok(
+      orphanNames(json).includes("src/widgetrenderer.js"),
+      `the orphan was not named; findings were ${JSON.stringify(orphanNames(json))}`,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("CONTROL: a reference the run can read produces no orphan", async () => {
+  // The same specimen, differing in one respect: the reference lives in a file the run opens. This
+  // is the polarity the falsifier is measured against — a mechanism that suppressed everything
+  // would pass the falsifier and the GUARD above would catch it, and a mechanism that did nothing
+  // would pass this and fail the falsifier.
+  const root = await deadCodeFixture({ "src/uses.js": `// ${REFERENCE}\n` });
+  try {
+    // Only the candidate under test is asserted about: `src/uses.js` is itself a candidate whose
+    // own stem nothing references, so it is a legitimate orphan and its presence here is correct.
+    assert.ok(
+      !orphanNames(run("validate", root, AMPLE)).includes("src/widgetrenderer.js"),
+      "a reference in a readable file must not leave the candidate looking orphaned",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a reference living outside the searched extensions cannot establish dead code", async () => {
+  // THE DEFECT. `docs.svg` is committed, first-party, matched by no ignore rule and excluded by no
+  // framework directory name. It is simply not in `TEXT_EXT`, so the read loop skips it without
+  // recording anything, and the absence of its text is read as the absence of a reference. The rule
+  // reached `failed / evaluated` naming a file that is not dead — over content the run never
+  // obtained, with no budget spent, no read failed, no directory unlisted, nothing truncated.
+  const root = await deadCodeFixture({ "docs.svg": `<svg><title>${REFERENCE}</title></svg>\n` });
+  try {
+    const json = run("validate", root, AMPLE);
+    assert.ok(
+      !orphanNames(json).includes("src/widgetrenderer.js"),
+      "a file whose only reference sits in an unsearched file was named as dead code",
+    );
+    assertNotEvaluated(json, "quality.dead-code");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a reference in a file the budget could not reach cannot establish dead code either", async () => {
+  // The same proposition losing its reference space through a DIFFERENT door, and the reason this
+  // is a separate test: a fix that special-cased the extension check would pass the falsifier above
+  // and fail here. What matters is not which mechanism dropped the file but that the search did not
+  // cover it, so the predicate has to be measured over the reference space itself.
+  const root = await deadCodeFixture({ "src/uses.js": `// ${REFERENCE}\n${bulk("padding")}` });
+  try {
+    const json = unreadRun("validate", root, "src/uses.js");
+    assert.ok(
+      !orphanNames(json).includes("src/widgetrenderer.js"),
+      "a file whose only reference sits in an unread file was named as dead code",
+    );
+    assertNotEvaluated(json, "quality.dead-code");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -576,3 +576,167 @@ test("a starved run reaches no verdict that needed content, in either polarity",
     await rm(root, { recursive: true, force: true });
   }
 });
+
+// --- The class the read seam structurally cannot reach --------------------------------------------
+//
+// Everything above loses content that WAS collected: the budget spent it, or the read failed. A
+// framework-excluded file is never collected at all, so it never enters `contents`, no accessor is
+// ever called for it, and no check ever asks — `unknownChecks` cannot record what nobody looked up.
+// Measured before these were written: with tracked committed bait behind a SKIP_DIRS name and a full
+// budget, security.no-sql-concat and security.no-cert-bypass both reported passed/evaluated. Two
+// FORBIDDEN rules reporting clean over tracked first-party code the tool refused to read.
+//
+// THE CONTROL IS THE AUTHORITY OF THE EXCLUSION, NOT ITS EXISTENCE. A repository that declares its
+// own ignore set has narrowed what its project is, which is a legitimate answer and leaves the run
+// complete. A framework that drops tracked code by matching a directory name has lost evidence. And
+// `.git` is neither — `not-project-evidence` — so if mere exclusion counted, every run in every
+// repository would withdraw these rules forever. Specimens 2 and 4 are the guards that make that
+// distinction load-bearing rather than decorative: the blanket fix passes specimen 1 and fails both.
+
+/**
+ * One file tripping three content-derived rules at once, so one specimen covers all three.
+ *
+ * Read from `test/fixtures/` rather than written inline, and the reason is this suite's own
+ * subject: that directory is excluded by name, so nothing inside it is ever scanned. Inline, the
+ * SQL interpolation in it is a real finding against THIS repository — `security.no-sql-concat`
+ * reads `sourceOf`, where string contents stay intact, so bait sitting in a test file is
+ * indistinguishable from the construct it imitates. That is not a use/mention question and
+ * blanking it would be evading the detector rather than satisfying it.
+ *
+ * It cost a red self-audit to learn, which is the right way to learn it: the detector was correct
+ * and the test was wrong.
+ */
+const CONTENT_BAIT = readFileSync(
+  path.join(HERE, "fixtures", "evidence-availability-bait", "bait.js"),
+  "utf8",
+);
+
+const CONTENT_POLICY = [
+  'standardVersion: "2.0.0"',
+  'project: "Framework exclusion specimen"',
+  "rules:",
+  "  security.no-sql-concat:",
+  "    level: forbidden",
+  "  security.no-cert-bypass:",
+  "    level: forbidden",
+  "  quality.dead-code:",
+  "    level: recommended",
+  "",
+].join("\n");
+
+const BAITED_RULES = ["security.no-sql-concat", "security.no-cert-bypass", "quality.dead-code"];
+
+/**
+ * A committed repository with the bait in `dir`, optionally ignored, optionally left untracked.
+ *
+ * `untracked` writes the bait AFTER the commit, so it is present on disk, absent from the index and
+ * matched by no ignore rule — the state a build directory is in, and the one that separates "the
+ * repository disclaimed this" from "this tool dropped it".
+ */
+async function excludedFixture({ dir, ignore = null, untracked = false }) {
+  const root = await tmp();
+  const git = (...args) => {
+    const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    assert.equal(r.status, 0, `git ${args.join(" ")} failed: ${r.stderr}`);
+  };
+  git("init", "-q");
+  git("config", "user.email", "test@example.invalid");
+  git("config", "user.name", "test");
+
+  await mkdir(path.join(root, dir), { recursive: true });
+  await writeFile(path.join(root, "README.md"), `# Specimen\n\n${"substantive prose ".repeat(60)}\n`);
+  await writeFile(path.join(root, "project-policy.yml"), CONTENT_POLICY);
+  if (ignore) await writeFile(path.join(root, ".gitignore"), `${ignore}\n`);
+  if (!untracked) await writeFile(path.join(root, dir, "bait.js"), CONTENT_BAIT);
+
+  git("add", "-A");
+  git("-c", "commit.gpgsign=false", "commit", "-qm", "specimen");
+  if (untracked) await writeFile(path.join(root, dir, "bait.js"), CONTENT_BAIT);
+  return root;
+}
+
+/** Each baited rule as "status/disposition", at full budget so nothing is lost to capacity. */
+function baitedVerdicts(root) {
+  const json = run("validate", root, AMPLE);
+  return BAITED_RULES.map((id) => {
+    const r = (json.results ?? []).find((x) => x.ruleId === id);
+    assert.ok(r, `no result for ${id}`);
+    return `${r.status}/${r.disposition}`;
+  });
+}
+
+test("framework-excluded tracked content withdraws the rules it would have fed", async () => {
+  const root = await excludedFixture({ dir: "fixtures" });
+  try {
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.deepEqual(surface.frameworkExcludedDirectories, ["fixtures"], "the fixture stopped being framework-excluded");
+    assert.equal(surface.complete, false);
+    assert.equal(surface.readBudget.exhausted, false, "budget loss would make this a duplicate of the falsifiers above");
+
+    assert.deepEqual(
+      baitedVerdicts(root),
+      ["skipped/not-evaluated", "skipped/not-evaluated", "skipped/not-evaluated"],
+      "a rule reported a verdict over tracked committed code this tool refused to read",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("GUARD: repository-ignored content is a narrowing, not a loss", async () => {
+  // The repository was asked and answered. Withdrawing here would make every project with a
+  // .gitignore permanently unable to establish a content rule, which is the blanket fix.
+  const root = await excludedFixture({ dir: "thirdparty", ignore: "thirdparty/" });
+  try {
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.equal(surface.complete, true, "a repository-authorized exclusion made the surface incomplete");
+    assert.deepEqual(surface.frameworkExcludedDirectories, []);
+
+    assert.deepEqual(
+      baitedVerdicts(root),
+      ["passed/evaluated", "passed/evaluated", "passed/evaluated"],
+      "a repository's own ignore declaration withdrew rules it should not have",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("untracked content the repository does not disclaim is still a framework loss", async () => {
+  // No ignore rule covers it, so the repository never said this was not its code; the tool dropped
+  // it on a name match. That is the same loss as specimen one, reached without the index.
+  const root = await excludedFixture({ dir: "coverage", untracked: true });
+  try {
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.deepEqual(surface.frameworkExcludedDirectories, ["coverage"]);
+    assert.equal(surface.complete, false);
+
+    assert.deepEqual(
+      baitedVerdicts(root),
+      ["skipped/not-evaluated", "skipped/not-evaluated", "skipped/not-evaluated"],
+      "unignored content dropped by this tool was treated as evidence of a clean result",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("GUARD: governed content still reaches its real verdict, and .git never counts", async () => {
+  // Nothing is excluded here but `.git`, which is `not-project-evidence` and present in every
+  // repository. If it counted as loss, no run anywhere could ever establish these rules again — so
+  // this specimen failing means the authority filter has collapsed into "was anything excluded".
+  const root = await excludedFixture({ dir: "src" });
+  try {
+    const surface = run("audit", root, AMPLE).evidenceSurface;
+    assert.equal(surface.complete, true, ".git or another benign exclusion is being counted as evidence loss");
+    assert.deepEqual(surface.frameworkExcludedDirectories, []);
+
+    assert.deepEqual(
+      baitedVerdicts(root),
+      ["failed/evaluated", "failed/evaluated", "warning/evaluated"],
+      "governed first-party code did not reach its real verdict",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/evidence-availability.test.mjs
+++ b/test/evidence-availability.test.mjs
@@ -1,0 +1,423 @@
+/**
+ * Issue #38: unavailable content evidence must never be read as content.
+ *
+ * THE INVARIANT UNDER TEST. A check whose required content evidence was not obtained may produce
+ * neither a satisfaction claim nor a violation finding about that content. It is `UNKNOWN`, and the
+ * rule it feeds reports `not-evaluated` rather than `passed` or `failed`.
+ *
+ * WHY THIS IS NOT A SENSITIVITY BUG. `contents.get(f) ?? ""` coerces *unread* into *empty*, and empty
+ * is meaningful evidence in both polarities: a README under 400 characters is a finding, and a plan
+ * file with no items is silence. So the coercion does not lose coverage, it manufactures a verdict —
+ * the run reports a result it does not have. That is why the fixtures below are built so the
+ * fabrication is visible as a lie rather than as a gap: the README this suite writes is ~200 KB of
+ * genuine prose, and the baseline run calls it "under 400 characters".
+ *
+ * HOW EVIDENCE IS MADE UNAVAILABLE, AND WHY THIS WAY. The aggregate read budget (`--max-total-read-
+ * bytes`, ADR 0014's per-invocation configuration) is the only loss mechanism that is injectable,
+ * deterministic and already shipped. The target file is written LARGER THAN THE WHOLE BUDGET, so the
+ * outcome does not depend on directory walk order: whenever its turn comes it cannot be retained,
+ * and `budget.exhausted` is sticky, so a target reached after some other file tripped the bound is
+ * equally unread. Every test asserts that precondition from the run's own accounting rather than
+ * assuming it — a falsifier that stopped making the evidence unavailable would otherwise start
+ * passing vacuously, which is the failure mode this whole item is about.
+ *
+ * BOTH POLARITIES, AND A CONTROL EACH. Three of the five fabricate a FAILURE and two fabricate a
+ * PASS. Each falsifier is paired with a full-coverage control on the SAME fixture asserting the rule
+ * still reaches its correct verdict when the evidence is read, and each control points the opposite
+ * way from its falsifier. A suppression mechanism that suppressed everything would pass all five
+ * falsifiers and fail all five controls; a mechanism that did nothing would do the reverse.
+ *
+ * RED-FIRST. Every falsifier here fails on `99952bd`, which is the point of writing them first.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(HERE, "..", "scripts", "standards.mjs");
+
+/** Smaller than any target file below, so the target can never be retained. */
+const BUDGET = 32 * 1024;
+
+/** Comfortably above the whole fixture, so the control run reads everything. */
+const AMPLE = 64 * 1024 * 1024;
+
+/** ~200 KB, over the budget and under the 400 KB per-file cap, so it is unread rather than truncated. */
+const bulk = (line) => `${line}\n`.repeat(Math.ceil((200 * 1024) / (line.length + 1)));
+
+const tmp = () => mkdtemp(path.join(os.tmpdir(), "evidence-availability-"));
+
+/**
+ * A committed, first-party repository nothing can exclude.
+ *
+ * Tracked and committed so `ignoredEntries()` cannot claim it, no vendor marker, no `SKIP_DIRS`
+ * name: if the exclusion boundary regressed to excluding too much, these tests would fail rather
+ * than quietly pass for the wrong reason.
+ */
+async function fixture(root, files) {
+  const git = (...args) => {
+    const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    assert.equal(r.status, 0, `git ${args.join(" ")} failed: ${r.stderr}`);
+  };
+  git("init", "-q");
+  git("config", "user.email", "test@example.invalid");
+  git("config", "user.name", "test");
+
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body);
+  }
+  await writeFile(path.join(root, "project-policy.yml"), POLICY);
+  git("add", "-A");
+  git("-c", "commit.gpgsign=false", "commit", "-qm", "fixture");
+}
+
+/** Declares exactly the rules under test. A rule a policy omits takes the framework default. */
+const POLICY = [
+  'standardVersion: "2.0.0"',
+  'project: "Evidence availability fixture"',
+  "rules:",
+  "  documentation.architecture:",
+  "    level: required",
+  "  planning.breakdown-directory:",
+  "    level: required",
+  "  planning.item-fields:",
+  "    level: required",
+  "  planning.plan-code-consistency:",
+  "    level: required",
+  "  reconstruction.baseline-artifacts:",
+  "    level: required",
+  "  reconstruction.open-questions:",
+  "    level: required",
+  "",
+].join("\n");
+
+function run(command, dir, budget) {
+  const r = spawnSync(
+    process.execPath,
+    [CLI, command, `--dir=${dir}`, "--json", `--max-total-read-bytes=${budget}`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  let json;
+  try {
+    json = JSON.parse(r.stdout);
+  } catch {
+    assert.fail(`${command} stdout was not JSON.\nstatus: ${r.status}\nstderr: ${r.stderr.slice(0, 2000)}`);
+  }
+  return json;
+}
+
+/**
+ * Assert the run genuinely failed to read `target`, then return the verdict over the same evidence.
+ *
+ * The precondition is asserted rather than assumed, because every falsifier below is only meaningful
+ * over evidence that is actually absent — a fixture that stopped aiming the budget at the file under
+ * test would otherwise start passing vacuously.
+ *
+ * It is taken from an `audit` run because `validate --json` does not report an evidence surface at
+ * all: its envelope carries the verdict and nothing about what the run could not read. The two
+ * commands walk the same tree under the same budget by the same code, so the surface `audit`
+ * measures is the surface `validate` had. That `validate` cannot say so itself is an observation
+ * about the envelope, recorded here and deliberately not repaired by these tests.
+ */
+function unreadRun(command, dir, target) {
+  const s = run("audit", dir, BUDGET).evidenceSurface;
+  assert.equal(s.readBudget.exhausted, true, "the budget was not exhausted, so nothing went unread");
+  assert.ok(s.readBudget.unreadFiles > 0, "the budget was exhausted but no file was reported unread");
+  assert.equal(s.complete, false, "the surface claimed completeness while eligible files went unread");
+  assert.ok(
+    s.readBudget.sample.includes(target),
+    `${target} is not among the unread sample ${JSON.stringify(s.readBudget.sample)}; ` +
+      "the fixture stopped aiming the budget at the file under test",
+  );
+  return run(command, dir, BUDGET);
+}
+
+const resultFor = (json, ruleId) => {
+  const r = (json.results ?? []).find((x) => x.ruleId === ruleId);
+  assert.ok(r, `no result for ${ruleId}; the policy fixture did not declare it`);
+  return r;
+};
+
+const findingsFor = (json, ruleId) => (json.findings ?? []).filter((f) => f.rule === ruleId);
+
+/** The disposition the invariant requires when a check's own evidence was not obtained. */
+function assertNotEvaluated(json, ruleId) {
+  const r = resultFor(json, ruleId);
+  assert.equal(
+    r.disposition,
+    "not-evaluated",
+    `${ruleId} reported disposition "${r.disposition}" (status ${r.status}) over content the run never read`,
+  );
+  assert.equal(r.status, "skipped", `${ruleId} must not carry a scored status when its evidence is unavailable`);
+}
+
+// --- Fabricated failures ------------------------------------------------------------------------
+
+const README_PROSE = bulk("This README is real, substantive, committed prose about the fixture project.");
+
+test("documentation.architecture cannot report a short README it never opened", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "README.md": README_PROSE,
+      "docs/architecture.md": "# Architecture\n\nReal content.\n",
+    });
+    const json = unreadRun("validate", root, "README.md");
+
+    // The lie, stated as an assertion: the file is ~200 KB and the baseline calls it under 400 bytes.
+    assert.deepEqual(
+      findingsFor(json, "documentation.architecture"),
+      [],
+      "a finding was emitted about the content of a file the run never read",
+    );
+    assertNotEvaluated(json, "documentation.architecture");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("documentation.architecture still passes on the same fixture when the README is read", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "README.md": README_PROSE,
+      "docs/architecture.md": "# Architecture\n\nReal content.\n",
+    });
+    assert.equal(run("audit", root, AMPLE).evidenceSurface.complete, true, "the control run did not achieve full coverage");
+    const json = run("validate", root, AMPLE);
+    const r = resultFor(json, "documentation.architecture");
+    assert.equal(r.disposition, "evaluated", "full coverage must reach a real disposition, not a withdrawal");
+    assert.equal(r.status, "passed", "a 200 KB README with an architecture document must satisfy the rule");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+const OVERVIEW = bulk("Real overview body text, outside any heading, describing the plan.");
+
+test("planning.breakdown-directory cannot report an empty overview it never opened", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-plan-breakdown/00-overview.md": `# Overview\n\n${OVERVIEW}` });
+    const json = unreadRun("validate", root, "artifacts/project-plan-breakdown/00-overview.md");
+
+    assert.deepEqual(
+      findingsFor(json, "planning.breakdown-directory"),
+      [],
+      "a finding was emitted about the body of a file the run never read",
+    );
+    assertNotEvaluated(json, "planning.breakdown-directory");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("planning.breakdown-directory still passes on the same fixture when the overview is read", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-plan-breakdown/00-overview.md": `# Overview\n\n${OVERVIEW}` });
+    const json = run("validate", root, AMPLE);
+    const r = resultFor(json, "planning.breakdown-directory");
+    assert.equal(r.disposition, "evaluated");
+    assert.equal(r.status, "passed", "an overview with real body content must satisfy the rule");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+const PROMPT_OK = `# Reconstructed prompt\n\nThis was reconstructed from the existing codebase.\n\n${bulk("Supporting detail.")}`;
+
+test("reconstruction.baseline-artifacts cannot report a missing declaration it never opened", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "artifacts/project-baseline/reconstructed-baseline.md": "# Baseline\n\nReal content.\n",
+      "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md": PROMPT_OK,
+    });
+    const json = unreadRun("validate", root, "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md");
+
+    assert.deepEqual(
+      findingsFor(json, "reconstruction.baseline-artifacts"),
+      [],
+      "an error-severity violation was asserted about text the run never read",
+    );
+    assertNotEvaluated(json, "reconstruction.baseline-artifacts");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("reconstruction.baseline-artifacts still passes on the same fixture when the prompt is read", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "artifacts/project-baseline/reconstructed-baseline.md": "# Baseline\n\nReal content.\n",
+      "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md": PROMPT_OK,
+    });
+    const json = run("validate", root, AMPLE);
+    const r = resultFor(json, "reconstruction.baseline-artifacts");
+    assert.equal(r.disposition, "evaluated");
+    assert.equal(r.status, "passed", "a prompt declaring itself reconstructed must satisfy R6");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- Fabricated passes --------------------------------------------------------------------------
+//
+// The quieter half, and the more dangerous one. Silence over unread evidence is indistinguishable
+// from a clean result, so these two fixtures are built to CONTAIN a real violation: the control must
+// report `failed`, which is what proves the falsifier suppressed a fabrication rather than a finding.
+
+const QUESTIONS_BAD = `# Open questions\n\n- **Q:** Something. CONFIRMED_BY_OWNER\n\n${bulk("Padding prose.")}`;
+
+test("reconstruction.open-questions cannot report a clean document it never opened", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-baseline/open-questions.md": QUESTIONS_BAD });
+    const json = unreadRun("validate", root, "artifacts/project-baseline/open-questions.md");
+    assertNotEvaluated(json, "reconstruction.open-questions");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("reconstruction.open-questions still fails on the same fixture when the document is read", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-baseline/open-questions.md": QUESTIONS_BAD });
+    const json = run("validate", root, AMPLE);
+    const r = resultFor(json, "reconstruction.open-questions");
+    assert.equal(r.disposition, "evaluated");
+    assert.equal(
+      r.status,
+      "failed",
+      "the control fixture carries an undated CONFIRMED_BY_OWNER; if it passes, the falsifier above proves nothing",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+/** An executable plan item missing `Deliverables`, which planning.item-fields requires. */
+const PLAN_BAD = [
+  "# Plan",
+  "",
+  "### An item that is missing a required field",
+  "",
+  "- **Status:** READY",
+  "- **Purpose:** To be incomplete on purpose.",
+  "",
+  bulk("Padding prose that keeps this file over the budget."),
+].join("\n");
+
+test("planning.item-fields cannot report complete items in a file it never opened", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-plan-breakdown/01-plan.md": PLAN_BAD });
+    const json = unreadRun("validate", root, "artifacts/project-plan-breakdown/01-plan.md");
+    assertNotEvaluated(json, "planning.item-fields");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("planning.item-fields still fails on the same fixture when the plan is read", async () => {
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-plan-breakdown/01-plan.md": PLAN_BAD });
+    const json = run("validate", root, AMPLE);
+    const r = resultFor(json, "planning.item-fields");
+    assert.equal(r.disposition, "evaluated");
+    assert.equal(
+      r.status,
+      "failed",
+      "the control fixture carries an item missing Deliverables; if it passes, the falsifier above proves nothing",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- The two structural cases the rule-level table cannot express -------------------------------
+
+test("two rules read from one site behave identically under identical evidence loss", async () => {
+  // `planning.item-fields` and `planning.plan-code-consistency` are emitted by detectPlanDiscrepancies
+  // from the SAME read. One is in CONTENT_DERIVED_RULES and one is not, so byte-identical evidence
+  // produces withdrawal for one and fabrication for the other. No entry added to a recognition table
+  // fixes that, because the table is not addressing the thing that varies — which is why the check,
+  // not the rule, has to be the unit.
+  const root = await tmp();
+  try {
+    await fixture(root, { "artifacts/project-plan-breakdown/01-plan.md": PLAN_BAD });
+    const json = unreadRun("validate", root, "artifacts/project-plan-breakdown/01-plan.md");
+
+    const fields = resultFor(json, "planning.item-fields");
+    const consistency = resultFor(json, "planning.plan-code-consistency");
+    assert.equal(
+      fields.disposition,
+      consistency.disposition,
+      `one read produced disposition "${fields.disposition}" for planning.item-fields and ` +
+        `"${consistency.disposition}" for planning.plan-code-consistency`,
+    );
+    assert.equal(fields.status, consistency.status);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an established violation survives beside an unknown check on the same rule", async () => {
+  // The mixed case, and the reason the CHECK rather than the RULE is the unit. Under
+  // reconstruction.baseline-artifacts, R4 is structural — the baseline directory exists without
+  // reconstructed-baseline.md — and needs no content at all. R6 is a content test on a prompt this
+  // run cannot afford to read. Withdrawing the whole rule would erase a failure that was genuinely
+  // established; reporting both would fabricate the second. Exactly one finding is correct.
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      // R4 fails structurally: the directory exists, reconstructed-baseline.md does not.
+      "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md": bulk("A prompt that never declares itself."),
+    });
+    const json = unreadRun("validate", root, "artifacts/project-baseline/RECONSTRUCTED-PROMPT.md");
+
+    const found = findingsFor(json, "reconstruction.baseline-artifacts");
+    assert.equal(found.length, 1, `expected only the structural R4 finding, got ${JSON.stringify(found.map((f) => f.message))}`);
+    assert.match(found[0].message, /R4/, "the surviving finding must be the structural one");
+
+    const r = resultFor(json, "reconstruction.baseline-artifacts");
+    assert.equal(r.status, "failed", "a confirmed violation must still fail the rule");
+    assert.equal(r.disposition, "evaluated", "a rule with a confirmed violation is not withdrawn");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the mechanism is inert when nothing is lost", async () => {
+  // The other direction, and the acceptance criterion that keeps this from being a suppression
+  // switch: with full coverage, no rule may be withdrawn for lack of evidence at all.
+  const root = await tmp();
+  try {
+    await fixture(root, {
+      "README.md": README_PROSE,
+      "docs/architecture.md": "# Architecture\n\nReal content.\n",
+      "artifacts/project-plan-breakdown/00-overview.md": `# Overview\n\n${OVERVIEW}`,
+    });
+    assert.equal(run("audit", root, AMPLE).evidenceSurface.complete, true, "the fixture did not achieve full coverage");
+    const json = run("validate", root, AMPLE);
+
+    const withdrawn = (json.results ?? [])
+      .filter((r) => r.disposition === "not-evaluated" && POLICY.includes(r.ruleId))
+      .map((r) => r.ruleId);
+    assert.deepEqual(withdrawn, [], "a declared rule was withdrawn on a run that read everything");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/fixtures/evidence-availability-bait/bait.js
+++ b/test/fixtures/evidence-availability-bait/bait.js
@@ -1,0 +1,18 @@
+// Bait for test/evidence-availability.test.mjs, kept HERE rather than inline in that test because
+// this directory is exactly what those specimens are about: `test/fixtures` is excluded by name, so
+// content inside it is never scanned. Inline, the SQL interpolation below is a real finding against
+// this repository -- `security.no-sql-concat` reads `sourceOf`, where string contents stay intact,
+// so a bait string in a test file is indistinguishable from the construct it imitates. It is not a
+// use/mention question and blanking it would be evading a detector rather than satisfying it.
+//
+// Three rules in one file, so one specimen covers all three: certificate bypass, SQL interpolation,
+// and an unreferenced export.
+const https = require("https");
+const agent = new https.Agent({ rejectUnauthorized: false });
+function q(id) {
+  return db.query(`SELECT * FROM users WHERE id = ${id}`);
+}
+function neverCalled() {
+  return 42;
+}
+module.exports = { agent, q };


### PR DESCRIPTION
**Five rules could reach a verdict from content the run never read. Three fabricated a failure and two fabricated a pass.**

`contents.get(f) ?? ""` coerces *unread* into *empty* at twelve sites. Empty is meaningful evidence in **both** polarities, so the coercion did not lose coverage — it manufactured verdicts.

Stated as an executable assertion: the fixture README in this PR is **~200 KB of real prose**, and the baseline reports it as `README.md (under 400 characters)`.

| Rule | Unread content fabricates |
|---|---|
| `documentation.architecture` | a **failure** — `""` is under 400 chars |
| `planning.breakdown-directory` | a **failure** — `""` has no body lines |
| `reconstruction.baseline-artifacts` | a **failure**, at error severity |
| `reconstruction.open-questions` | a **pass** — no matches, so silence |
| `planning.item-fields` | a **pass** — no items parsed |

## The check is the unit, not the rule

`contentOf` answers with **availability rather than text** — there is no `?? ""` to reach for because there is no string to reach. A check whose content is unavailable records an unknown against the rule it would have fed and emits nothing; disposition is aggregated from the checks that ran.

```
any confirmed violation      → failed, carrying only the checks that confirmed it
no violation + any unknown   → not-evaluated
all known and no violation   → passed
```

The first line is why no table over rule ids can express this. `reconstruction.baseline-artifacts` fails **R4 structurally** beside an unread **R6**: withdrawing the rule erases an established violation, leaving it reports one that was never made. This is **explicitly not** an extension of `CONTENT_DERIVED_RULES` — and `planning.item-fields` and `planning.plan-code-consistency`, derived from one read and classified two ways by that table, now move together.

## Two loss modes, and the second was found in this PR's own first implementation

The item frames evidence loss through the read budget. A **failed read** was the other route to the identical fabrication, and the first version of this mechanism did not close it: on failure `readText` returns `text: ""` and the loop stored it, so a file the process could not open answered `available` with an empty string. It read as safe because the halves are eighteen hundred lines apart — the lookup asks `contents.has(f)`, and only the reader of the read loop knows an unreadable file still answers yes. The surface-level withdrawal had the same hole, firing on the file cap and budget exhaustion but not on a read failure, so its **trigger was corrected rather than its table extended**.

## Evidence

**16 falsifiers, written red-first.** Against `99952bd` they stand at **7 failing / 6 passing**; the two covering the read-failure route are red against the first implementation of the mechanism itself. Each falsifier is paired with a full-coverage control on the same fixture pointing the **opposite** way — a mechanism that suppressed everything would fail every control.

**Five mutants, all killed, and discriminated rather than counted.** Coercing `contentOf` back to `?? ""` is killed by nine tests; bypassing the aggregation withdrawal by eight; a no-op `run.unknown()` by eight. The mixed-case falsifier kills the lookup mutant and **not** the aggregation one. Storing a failed read again, and dropping read failure from the surface trigger, are each killed by **exactly one test, and a different one**.

**Full six-stage gate PASSED** on committed content at `2ba4f77`, and separately at `6b64908` and `d91fb4a` — so the mechanism and the human review are evidenced at distinct revisions rather than as one combined claim.

**Inert here, established by comparison rather than inspection.** The `99952bd` evaluator and this one were run against the *same* tree and produce byte-identical verdicts. `validate` is 24 passed, 4 failed, 0 warnings, 22 skipped — the four failures being the four standing recorded human rejections, unchanged and untouched.

Standard 44 R12 gains a fourth point. Its first three describe only the negative direction, and a tool can honour every word of them while manufacturing a **failure**: missing evidence has no natural polarity.

## Status is IN_REVIEW, not COMPLETE — one criterion is unmet in its letter

The first acceptance criterion says *no call site can reach `""` or `"{}"` for unread content*. **Seven raw read sites remain** and `contents` is still passed to every detector, so the seam is opt-in at the call site rather than enforced by construction.

What **is** established is the weaker claim that no remaining site can fabricate a **verdict**: two bind no rule at all and produce descriptive findings only (`detectCapabilities`, `detectJobs`), and the other five feed rules already withdrawn wholesale by `CONTENT_DERIVED_RULES`. Enforcing the criterion literally means withholding `contents` from detectors entirely, which changes audit output well beyond this defect.

**Recorded as unmet rather than reinterpreted into met.** Whether that scoping is acceptable or is work still owed is the owner's ruling, not this item's.

## Four attestations refreshed, and two gaps they cannot close

All four were stale on `99952bd` **before this branch existed**. Each was re-reviewed fresh at `d91fb4a`, no digest inherited, nothing declared not-applicable. The review reduced to two files: exactly one reviewed path changed per rule, with every other path byte-identical by blob comparison.

The one change shaped like a weakening was read rather than counted: a test asserting `complete === true` for this repository was removed — and it had been **false-passing**, because this repository loses `test/fixtures` to `SKIP_DIRS` and the flag never accounted for exclusion. One assertion became seven.

Two scope limitations are recorded in the attestations rather than resolved inside them, both flagged as separate owner decisions:

- **`meta.standards-not-weakened` has no `standards/` file among its reviewed paths.** A digest over its declared set is structurally incapable of seeing a standard being weakened — that rule's own subject — and this branch amends Standard 44. The amendment was examined explicitly and that approval rests on the evidence sentence, not on the digest.
- **`architecture.no-duplicate-implementations` does not review `scripts/standards.mjs`**, the file most likely to carry a duplicate. What the examination found there is an *unconverted site* rather than a duplicate: `sourceOf`, `structureOf` and `commentsOf` still coerce through the sources map.

Neither path set was widened here — doing so inside the event would make the approval assert more than its digest covers.

## Also in this PR

A **candidate finding**, recorded deliberately without item grammar: `validate --json` reports a verdict and nothing about what the run could not read, while `audit --json` carries a full evidence surface. It is the same question one level up, about the envelope rather than a disposition, and #38's mechanism is complete without it. Left unscoped because the obvious fix changes a published contract.

`validate` will be red on the four standing human rejections, as on `develop`'s own tip. That is expected repository state, not a PR defect.

Refs #38 — **not** `Closes`, because the disposition is reserved.
