### PR TITLE
The rule that says "fill it in" now checks whether anyone did

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1598,8 +1598,16 @@ that is a decision rather than a formality.
   enforces R11. `standards init` writes a template; the rule then passes because the file exists;
   the project is reported as having a manifest it has never filled in. Tool-generated scaffolding is
   being read as evidence of intent by the framework that forbids exactly that.
-- **Deliverables:** a content check of the same family as `hasContent()` in
-  [`scripts/init.mjs`](../../scripts/init.mjs), which already fixed this bug class on the `init` side.
+- **Deliverables:** ~~a content check of the same family as `hasContent()` in
+  [`scripts/init.mjs`](../../scripts/init.mjs), which already fixed this bug class on the `init`
+  side.~~ **Corrected 2026-08-28, before closing:** the shared thing is the bug class, not the
+  mechanism, and the line as written named a lineage the implementation does not have.
+  `hasContent()` asks whether a *directory* holds any `.md` file — the question "is this plan folder
+  empty" — and there is no reading of it that answers "has this file been filled in". What shipped
+  measures the manifest's own substance: template prompts still standing, and headings with nothing
+  beneath them. Recorded rather than quietly satisfied, because a closed item whose deliverable line
+  names a function it never called is the same defect this item is about — a record read as evidence
+  of something nobody checked.
 - **Acceptance Criteria:**
   - A file that is byte-identical to its template, or that retains its placeholder headings with
     nothing under them, does not satisfy the rule.

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -8,9 +8,11 @@ Before the plan repair, eleven GitHub issues, four recorded rule rejections, and
 deferred design questions existed as a parallel obligation system that no plan item claimed. A plan
 that omits its own open work will always report itself complete.
 
-**Every open GitHub issue is claimed by exactly one plan item.** Thirteen are open. Seven are
-claimed here — #1, #4, #6, #8, #19, #21, #32 — and the other six are claimed where their subject
-lives: [#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
+**Every open GitHub issue is claimed by exactly one plan item — except two, named below.**
+Thirteen are open. Five are claimed here — #1, #4, #19, #21, #32 — six are claimed where their
+subject lives, and #45 and #46 are claimed by nothing, which the amendment at the end of this
+section derives and does not round away. The six live where their subject does:
+[#10 and #11](04-compliance-and-policy-system.md) by the exception machinery,
 [#3](06-must-never-standards.md) by the detectors, and
 [#2, #9 and #16](07-distributed-validation-and-ci.md) by the adoption path. None is rejected as
 out of release scope.
@@ -42,6 +44,29 @@ ownership rule two paragraphs above. Seven and six partition thirteen with nothi
 arithmetic agreeing with an increment is a check on the increment, not a substitute for the
 derivation: three of the four amendments below were arrived at by incrementing, and two of them were
 wrong.
+
+**Amended 2026-08-28 (second), and the invariant above no longer holds.** Two arrivals and two
+departures move the total by nothing and the composition by four, which is exactly the shape an
+increment gets wrong. **#6** and **#8** close at `e7a6d22` and leave both sets together, being one
+item. [#45](https://github.com/mikeycdavis/EngineeringStandards/issues/45) (`validate-self`'s
+framework pin, and what the pin is for) and
+[#46](https://github.com/mikeycdavis/EngineeringStandards/issues/46) (the catalog's unconditional
+"never a failure") were opened while closing #38 and this item, and **no plan item claims either**.
+
+Re-derived rather than adjusted: the open set read from `gh issue list` is #1, #2, #3, #4, #9, #10,
+#11, #16, #19, #21, #32, #45, #46 — thirteen. *Claimed here*, from the `Tracked by` fields, is #1,
+#4, #19, #21, #32 — five. Claimed elsewhere is #2, #3, #9, #10, #11, #16 — six. **Unclaimed: #45 and
+#46 — two.** Five, six and two partition thirteen with nothing counted twice.
+
+The unclaimed pair is recorded rather than absorbed. Renumbering the sentence above until the
+arithmetic closed would have restated the invariant as satisfied while it was not, which is the
+failure this whole paragraph exists to prevent, one level up: a count that is made to agree is not a
+count. Both are findings whose scope nobody has settled — #45 turns on what the pin is *for*, and
+#46 on whether the mechanism or the sentence should move — and scoping them is the work of opening
+items, which is a decision rather than a formality. Until that happens the honest statement is that
+the invariant holds for eleven of thirteen and is named as broken for the other two. The total
+returning to thirteen is a coincidence of two closures meeting two openings, not evidence that
+nothing moved.
 
 **Amended again 2026-08-25:** **#7** closed on owner review of its seven-criterion contract, so it
 leaves both the open set and *claimed here*, taking fifteen/nine to fourteen/eight. Six elsewhere is
@@ -1145,7 +1170,11 @@ that approval deliberately does not cover.
   project policy may nonetheless raise the rule to `level: required`, and it then reports `failed`.
   So "never a failure" is a property of the default rather than of the rule, and the catalog states
   it unconditionally. Out of scope for #38, which is about evidence availability, and left visible
-  rather than folded into a defect it is not part of.
+  rather than folded into a defect it is not part of. **Filed 2026-08-28 as
+  [#46](https://github.com/mikeycdavis/EngineeringStandards/issues/46)**, with the escalation
+  measured at `b20423a` rather than restated, so the observation is tracked somewhere an owner will
+  see it instead of resting in a closed item's evidence. It is not claimed by this file: no section
+  here carries it as `Tracked by`, and writing one would scope work nobody has scoped.
 
   **Owner ruling on the surviving mutants, 2026-08-27: conditional, and the condition caught one.**
   A survivor is acceptable only where it is redundant with an independently established boundary and
@@ -1509,7 +1538,54 @@ that is a decision rather than a formality.
 
 ### Make `architecture.project-manifest` check content, not presence
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-28 at `e7a6d22`, established by the full repository gate at that
+  commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and `audit` all passed, 413 tests,
+  409 passing, 0 failures, 4 skipped. `validate` at that content reports 14 passed, 4 failed, 0
+  warnings, 32 skipped — unchanged from before this item, and the four failures are the four
+  standing human rejections. Self-audit at zero error findings, also unchanged. This row is the
+  commit after `e7a6d22` and changes only this section and the two paragraphs named below, which is
+  why the gate it names is the one before it.
+
+  | Criterion | Established by |
+  | --- | --- |
+  | Byte-identical to its template does not satisfy the rule | *the untouched template does not satisfy the rule that tells you to copy it* |
+  | Placeholder headings with nothing under them do not satisfy it | *headings with nothing beneath them are not a manifest*, and *a table skeleton with no rows in it is not content* |
+  | Exactly what `init` writes fails; a filled-in manifest passes | *what `standards init` writes is that same specimen, measured rather than assumed*; *a genuinely filled-in manifest satisfies the rule* |
+  | This repository's own `PROJECT.md` still passes, for the right reason | *this repository's own manifest satisfies the rule*, with the reason isolated by *an angle-bracketed path inside a code span is documentation* — two fixtures differing only in the backticks |
+  | `npm test`; self-audit unchanged at zero error findings | 413/409/0/4 and 0 error findings at `e7a6d22` |
+
+  **The two issues were one specimen, and that is now measured rather than asserted.** `PROJECT.md`
+  carries no `standardVersion:` line for `stampVersion` to stamp and no agent-instruction markers for
+  `injectAgentInstructions` to replace, so init's generator is the identity on it. The test runs that
+  generator instead of restating the equality, so a template that later gains a generated line turns
+  #8 back into a second specimen rather than into a silent gap.
+
+  **Seven mutants, each killed by a discriminating set.** Dropping the prompt scan is caught by the
+  template and by the prose half of the code-span pair; dropping the empty-heading scan by the bare
+  headings and the table skeleton; counting a table header as a data row by the skeleton alone;
+  reading unavailable content as content by the withdrawal test alone; and raising the finding
+  unconditionally by all four passing cases and no failing one, which is the anti-vacuity direction.
+
+  **One defect was found by mutation rather than by review, and it was mine.** Removing code once,
+  before both scans, passed every test then written and was still wrong: a fenced line ending in `>`
+  is not an unanswered field, and a section whose whole body is a code block is not a section with
+  nothing beneath it. A single strip satisfies one direction by breaking the other. The two scans now
+  read different text, and the two mutants — strip nothing for prompts, strip code for emptiness —
+  are killed by the same test because that test holds both directions, each with its own message.
+
+  **What this item does not claim.** Currency. The catalog note now says existence and
+  filled-in-ness are checked and that whether the current-state fields are *current* is not, adding
+  that no automated check can establish it: a manifest answered once and never revisited is
+  indistinguishable, in its bytes, from one answered today. `assurance` stays `partial` for that
+  reason. The prompt scan also has a stated reachable false positive — raw HTML with an attribute at
+  end of line, `<img src="x">` — recorded in the code rather than left for a reader to discover.
+
+  **The disposition is reserved.** Under [ADR 0005](../adr/0005-attestations-are-recorded-human-evidence.md)
+  this item does not close itself. What remains for a second party is the ordinary question: that the
+  two scans, the reachable false positive, and the accepted limit on currency are what this
+  repository wants.
+
+  **Previously: READY.**
 - **Tracked by:** GitHub issues [#6](https://github.com/mikeycdavis/EngineeringStandards/issues/6)
   and [#8](https://github.com/mikeycdavis/EngineeringStandards/issues/8) — **merged into this one
   item**, because they are two manifestations of one defect: #6 against an untouched `PROJECT.md`

--- a/rules/architecture.json
+++ b/rules/architecture.json
@@ -21,7 +21,7 @@
       "deprecatedIn": null,
       "supersededBy": null,
       "removedIn": null,
-      "$assuranceNote": "Existence is checked; whether its current-state fields are current is not."
+      "$assuranceNote": "Existence is checked, and whether the file still reads as the template rather than as this project. Whether its current-state fields are CURRENT is not checked, and no automated check can establish that."
     },
     {
       "id": "architecture.adr",

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -1459,14 +1459,92 @@ function detectMissingDocs(files, run) {
 }
 
 /**
+ * Template prompts still standing in a manifest, and headings with nothing beneath them.
+ *
+ * The rule's `remediation` says "copy the template and fill it in", and until now only the copying
+ * was checked. `standards init` writes `templates/PROJECT.md` with no substitution — PROJECT.md
+ * carries neither a `standardVersion:` line for `stampVersion` to stamp nor the agent-instruction
+ * markers — so the untouched template and the file `init` just wrote are byte-identical here. Issues
+ * #6 and #8 are therefore one specimen for this artifact, but the check does not rely on that: it
+ * measures the manifest's own substance rather than comparing against the template, so a template
+ * that later gains a generated line does not silently start passing.
+ *
+ * **A prompt is angle-bracketed and ends its line.** Code spans and fences are removed first, which
+ * is what keeps this repository's own `standards/NN-<kebab-title>.md` from reading as an unfilled
+ * field — a path inside backticks is documentation, not a prompt. Closing HTML tags and spaceless
+ * ones like `<br>` are excluded too. What remains reachable as a false positive is raw HTML with an
+ * attribute at end of line, e.g. `<img src="x">`; that is stated rather than hidden, and the finding
+ * is phrased as a question for the same reason the catalog calls this assurance `partial`.
+ */
+function unfilledManifestPrompts(text) {
+  // A template comment is not an answer, so neither scan below counts it.
+  const prose = text.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Code is removed for the prompt scan and kept for the emptiness scan, because it means opposite
+  // things to the two questions. A fenced line like `<html lang="en">` ends in `>` and would read as
+  // an unanswered field; the same block under a heading is unmistakably an answer. Stripping code
+  // once, for both, was wrong in the second direction and is what the two falsifiers below hold.
+  const prompts = (
+    prose
+      .replace(/```[\s\S]*?```/g, "")
+      .replace(/`[^`\n]*`/g, "")
+      .match(/<(?!\/)[^<>]*\s[^<>]*>[ \t]*$/gm) || []
+  ).map((p) => p.trim());
+
+  // A section whose body is empty once the table skeleton is removed. This exists because a prompt
+  // check alone is defeated by deleting the angle brackets and writing nothing, which would leave a
+  // manifest that is emptier than the template and passes where the template fails.
+  const empty = [];
+  const sections = prose.split(/^##\s+(.+)$/m);
+  for (let i = 1; i < sections.length; i += 2) {
+    if (withoutTableSkeletons(sections[i + 1]).trim() === "") empty.push(sections[i].trim());
+  }
+  return { prompts, empty };
+}
+
+/**
+ * Drop table blocks that carry no data, keeping ones that do.
+ *
+ * A header row is part of the skeleton, not an answer: `| Layer | Technology |` over a separator and
+ * nothing else is the template's Stack section verbatim, and counting the header as content made the
+ * whole section read as filled in. Rows are indexed rather than pattern-matched — row 0 is the
+ * header and row 1 the separator, by markdown's own definition — so a block survives only when some
+ * row from the third onwards has a cell in it.
+ */
+function withoutTableSkeletons(body) {
+  const out = [];
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; ) {
+    if (!/^\s*\|/.test(lines[i])) {
+      out.push(lines[i]);
+      i += 1;
+      continue;
+    }
+    const block = [];
+    while (i < lines.length && /^\s*\|/.test(lines[i])) block.push(lines[i++]);
+    const hasData = block
+      .slice(2)
+      .some((row) => row.split("|").slice(1, -1).some((cell) => cell.trim() !== ""));
+    if (hasData) out.push(...block);
+  }
+  return out.join("\n");
+}
+
+/**
  * Structural checks for the two architecture rules. Both are `assurance: partial` in the catalog:
  * the file existing is not the same as the file being correct or current, and the catalog says so
  * rather than leaving a reader to infer it (Standard 24 R2).
+ *
+ * The manifest rule now also asks whether the file was filled in, which moves one case out of
+ * `partial` and leaves the rest there. Currency is what remains unestablished, and nothing here can
+ * establish it: a manifest answered once and never revisited is indistinguishable, in its bytes,
+ * from one answered today.
  */
-function detectArchitectureArtifacts(run) {
-  const { has, addFinding } = run;
+function detectArchitectureArtifacts(files, run) {
+  const { has, rel, addFinding } = run;
   const manifest = ["PROJECT.md", "artifacts/project-manifest.md"];
-  if (!manifest.some((f) => has(f))) {
+  const present = manifest.filter((f) => has(f));
+  if (present.length === 0) {
     addFinding({
       id: "missing-project-manifest",
       rule: "architecture.project-manifest",
@@ -1477,6 +1555,46 @@ function detectArchitectureArtifacts(run) {
       message: "No project manifest exists; a fresh agent has nowhere to learn what this is or what state it is in.",
       standardRef: R.artifacts,
     });
+  } else {
+    // Presence was established above and stands on its own. Only the content test needs the file's
+    // text, so only the content test withdraws when that text is unavailable (#38): a manifest the
+    // run never read is not a manifest observed to be unfilled.
+    for (const name of present) {
+      const f = files.find((p) => rel(p) === name);
+      if (!f) continue;
+      const c = run.textOf(f);
+      if (!c.available) {
+        run.unknown("architecture.project-manifest", name, c.reason);
+        continue;
+      }
+      const { prompts, empty } = unfilledManifestPrompts(c.text);
+      if (prompts.length === 0 && empty.length === 0) continue;
+      const evidence = [
+        ...prompts.map((p) => `${name}: unfilled field ${p}`),
+        ...empty.map((h) => `${name}: heading "${h}" has nothing beneath it`),
+      ];
+      addFinding({
+        id: "unfilled-project-manifest",
+        rule: "architecture.project-manifest",
+        category: "Missing planning artifacts",
+        severity: "warning",
+        label: "OBSERVED",
+        evidence,
+        // Named from what was actually found. A finding that reports prompts where it measured
+        // empty headings is the same category error one layer out: evidence describing something
+        // other than what established it.
+        message:
+          `${name} ${[
+            prompts.length > 0 ? "still carries the template's own prompts" : "",
+            empty.length > 0 ? "has headings with nothing beneath them" : "",
+          ]
+            .filter(Boolean)
+            .join(" and ")}, so it records what a manifest should say rather than what this ` +
+          "project is. Scaffolding a tool wrote is not evidence that anyone answered it " +
+          "(Standard 44 R11).",
+        standardRef: R.artifacts,
+      });
+    }
   }
   // Standard 11 R1 is a SHOULD, and it names one location out of several the industry settled on.
   // `docs/adr/` and `doc/adr/` are what Nygard's original article and adr-tools established, and a
@@ -2886,7 +3004,7 @@ export async function main(args) {
   detectAiInterfaces(files, run);
 
   detectMissingDocs(files, run);
-  detectArchitectureArtifacts(run);
+  detectArchitectureArtifacts(files, run);
   detectMissingPlanningArtifacts(files, run);
   detectMissingAuditInfrastructure(files, run);
   detectUnverifiedFunctionality(files, run);

--- a/test/manifest-content.test.mjs
+++ b/test/manifest-content.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * `architecture.project-manifest` checks that the manifest was filled in, not that it exists.
+ *
+ * The rule's own remediation says "copy the template and fill it in", and only the copying was
+ * checked: `standards init` wrote the scaffolding and the rule then passed because the file existed.
+ * That is the exact defect Standard 44 R11 was written about, occurring in the tool that enforces
+ * R11 — tool-generated scaffolding read as evidence of intent.
+ *
+ * Issues #6 and #8 are one item because they are one specimen. #6 is the untouched template and #8
+ * is init's own output; for this artifact those are the same bytes, and the test below establishes
+ * that by running init's generator rather than by asserting it.
+ *
+ * Every case is asserted in both directions, per this suite's standing rule: a check that only ever
+ * fires is as uninformative as one that never does. The direction that constrains the design is the
+ * passing one — this repository's own PROJECT.md contains an angle-bracketed path, and a naive
+ * prompt scan would report the framework's own manifest as unfilled.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { stampVersion } from "../scripts/init.mjs";
+import { injectAgentInstructions } from "../scripts/agent-instructions.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(HERE, "..", "scripts", "standards.mjs");
+const REPO = path.join(HERE, "..");
+const TEMPLATE = path.join(REPO, "templates", "PROJECT.md");
+
+const RULE = "architecture.project-manifest";
+const FINDING = "unfilled-project-manifest";
+
+/** Ample enough that nothing in these one-file fixtures goes unread. */
+const AMPLE = 8_000_000;
+
+function cli(command, dir, budget = AMPLE) {
+  const r = spawnSync(
+    process.execPath,
+    [CLI, command, `--dir=${dir}`, "--json", `--max-total-read-bytes=${budget}`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return assert.fail(
+      `${command} stdout was not JSON.\nstatus: ${r.status}\nstderr: ${r.stderr.slice(0, 2000)}`,
+    );
+  }
+}
+
+const unfilled = (json) => (json.findings ?? []).filter((f) => f.id === FINDING);
+const evidenceOf = (json) => unfilled(json).flatMap((f) => f.evidence ?? []);
+
+async function withFixture(manifest, fn) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "manifest-content-"));
+  await writeFile(path.join(root, "PROJECT.md"), manifest);
+  try {
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const FILLED = [
+  "# PROJECT — Widget Press",
+  "",
+  "## Purpose",
+  "",
+  "Widget Press renders widgets for the print desk. It replaces the manual paste-up step.",
+  "",
+  "## Stack",
+  "",
+  "| Layer | Technology |",
+  "| --- | --- |",
+  "| Runtime | Node 20 |",
+  "",
+  "## Current state",
+  "",
+  "- **Current status:** IN_PROGRESS",
+  "- **Known blockers:** none recorded",
+  "",
+].join("\n");
+
+// --- The specimen, from both directions it was reported ------------------------------------------
+
+test("the untouched template does not satisfy the rule that tells you to copy it", async () => {
+  const template = await readFile(TEMPLATE, "utf8");
+  await withFixture(template, (root) => {
+    const json = cli("audit", root);
+    const found = unfilled(json);
+    assert.equal(found.length, 1, "the untouched template was accepted as a project manifest");
+    assert.equal(found[0].rule, RULE);
+    assert.ok(
+      evidenceOf(json).some((e) => e.includes("<Project name>")),
+      "the finding does not name a field that was left unanswered",
+    );
+  });
+});
+
+test("what `standards init` writes is that same specimen, measured rather than assumed", async () => {
+  // #8 was filed against init's output and #6 against the template. They are the same bytes here:
+  // PROJECT.md carries no `standardVersion:` line for stampVersion to stamp and no agent-instruction
+  // markers for injectAgentInstructions to replace, so init's generator is the identity on it. This
+  // runs that generator instead of restating the claim, so a template that later gains a generated
+  // line turns this into a second specimen rather than into a silent gap.
+  const template = await readFile(TEMPLATE, "utf8");
+  const written = injectAgentInstructions(stampVersion(template), "9.9.9");
+  await withFixture(written, (root) => {
+    assert.equal(
+      unfilled(cli("audit", root)).length,
+      1,
+      "init's own output is accepted as a filled-in manifest",
+    );
+  });
+});
+
+// --- Deleting the prompts is not filling them in -------------------------------------------------
+
+test("headings with nothing beneath them are not a manifest", async () => {
+  const bare = "# PROJECT — Widget Press\n\n## Purpose\n\n## Stack\n\n## Current state\n";
+  await withFixture(bare, (root) => {
+    const json = cli("audit", root);
+    assert.equal(
+      unfilled(json).length,
+      1,
+      "a manifest emptier than the template passed where the template fails",
+    );
+    assert.deepEqual(
+      evidenceOf(json).sort(),
+      [
+        'PROJECT.md: heading "Current state" has nothing beneath it',
+        'PROJECT.md: heading "Purpose" has nothing beneath it',
+        'PROJECT.md: heading "Stack" has nothing beneath it',
+      ],
+      "the finding does not name the headings it measured",
+    );
+    assert.match(
+      unfilled(json)[0].message,
+      /has headings with nothing beneath them/,
+      "the message reports prompts it did not find",
+    );
+  });
+});
+
+test("a table skeleton with no rows in it is not content", async () => {
+  const skeleton =
+    "# PROJECT — Widget Press\n\n## Stack\n\n| Layer | Technology |\n| --- | --- |\n| | |\n";
+  await withFixture(skeleton, (root) => {
+    assert.equal(
+      unfilled(cli("audit", root)).length,
+      1,
+      "an empty table counted as a filled-in section",
+    );
+  });
+});
+
+// --- The direction that constrains the design ----------------------------------------------------
+
+test("a genuinely filled-in manifest satisfies the rule", async () => {
+  await withFixture(FILLED, (root) => {
+    assert.deepEqual(unfilled(cli("audit", root)), [], "a filled-in manifest was reported unfilled");
+  });
+});
+
+test("an angle-bracketed path inside a code span is documentation, not an unanswered field", async () => {
+  // This repository's own PROJECT.md contains `standards/NN-<kebab-title>.md`. A prompt scan that
+  // did not strip code spans would report the framework's manifest as unfilled — the false-positive
+  // failure mode this suite exists for, in the file the rule is dogfooded against.
+  // The two differ by the backticks and nothing else, so a pass on the first is attributable to the
+  // code-span rule rather than to the check being blind to this shape of text anywhere.
+  const SPAN = "<the standards directory>";
+  const inCode = `${FILLED}\n## Artifact locations\n\nStandards live in \`${SPAN}\`\n`;
+  const inProse = `${FILLED}\n## Artifact locations\n\nStandards live in ${SPAN}\n`;
+  await withFixture(inCode, (root) => {
+    assert.deepEqual(
+      unfilled(cli("audit", root)),
+      [],
+      "a path inside backticks was read as an unfilled field",
+    );
+  });
+  await withFixture(inProse, (root) => {
+    assert.equal(
+      unfilled(cli("audit", root)).length,
+      1,
+      "stripping code spans also blinded the check outside them, so the exemption is not the reason the case above passes",
+    );
+  });
+});
+
+test("code means opposite things to the two scans, and is read that way", async () => {
+  // Removing code once, for both questions, passed every other test here and was still wrong. A
+  // fenced line ending in `>` is not an unanswered field, and a section whose whole body is a code
+  // block is not a section with nothing beneath it. Each direction is held separately because a
+  // single strip satisfies one of them by breaking the other.
+  const fencedTag = `${FILLED}\n## Architectural rules\n\n\`\`\`html\n<html lang="en">\n\`\`\`\n`;
+  await withFixture(fencedTag, (root) => {
+    assert.deepEqual(
+      unfilled(cli("audit", root)),
+      [],
+      "a tag inside a fenced block was read as an unanswered field",
+    );
+  });
+
+  const onlyCode = `${FILLED}\n## Commands\n\n\`\`\`bash\nnpm run build\n\`\`\`\n`;
+  await withFixture(onlyCode, (root) => {
+    assert.deepEqual(
+      unfilled(cli("audit", root)),
+      [],
+      "a section whose whole answer is a code block was reported as having nothing beneath it",
+    );
+  });
+});
+
+test("this repository's own manifest satisfies the rule", async () => {
+  assert.deepEqual(
+    unfilled(cli("audit", REPO)).map((f) => f.evidence),
+    [],
+    "the framework's own PROJECT.md is reported unfilled",
+  );
+});
+
+// --- A manifest the run never read is not a manifest observed to be unfilled ---------------------
+
+test("the content check withdraws when the manifest went unread", async () => {
+  // The same fixture that fails above, under a budget that retains nothing. Presence is structural
+  // and still established; only the content test needs the bytes, so only it withdraws (#38).
+  const template = await readFile(TEMPLATE, "utf8");
+  await withFixture(template, (root) => {
+    const surface = cli("audit", root, 1).evidenceSurface;
+    assert.equal(surface.complete, false, "the starved run read everything, so this proves nothing");
+    const starved = cli("validate", root, 1);
+    assert.deepEqual(
+      unfilled(starved),
+      [],
+      "an unfilled manifest was reported from content the run never read",
+    );
+    const r = (starved.results ?? []).find((x) => x.ruleId === RULE);
+    assert.equal(
+      r.disposition,
+      "not-evaluated",
+      `${RULE} reported "${r.disposition}" over content it never read`,
+    );
+    assert.equal(
+      r.status,
+      "skipped",
+      `${RULE} carried a scored status while its evidence was unavailable`,
+    );
+  });
+});


### PR DESCRIPTION
`architecture.project-manifest` tested only that `PROJECT.md` exists, so `standards init` wrote the
template and the rule passed on the file it had just scaffolded. That is the exact defect Standard 44
R11 was written about, occurring in the tool that enforces R11.

Closes #6. Closes #8.

## They were one specimen, and that is now measured

`PROJECT.md` carries no `standardVersion:` line for `stampVersion` to stamp and no agent-instruction
markers for `injectAgentInstructions` to replace, so init's generator is the identity on it. The test
runs that generator rather than asserting the equality — a template that later gains a generated line
turns #8 back into a second specimen instead of into a silent gap.

## Code means opposite things to the two questions

A fenced line like `<html lang="en">` ends in `>` and would read as an unanswered field, so code is
removed before the prompt scan. A section whose whole body is a code block is unmistakably answered,
so code is kept for the emptiness scan. **Stripping once for both passed every test then written and
was still wrong in the second direction**; mutation found it, not review. The two directions are now
held separately.

A table header is skeleton, not an answer: `| Layer | Technology |` over a separator and nothing else
is the template's Stack section verbatim.

Only the content test needs the file's bytes, so only it withdraws when those bytes are unavailable
(#38). Presence is structural and still stands.

## Mutation

Seven mutants, each killed by a discriminating set — drop the prompt scan, drop the empty-heading
scan, count a table header as a data row, read unavailable content as content, raise the finding
unconditionally, and the two code-handling directions. The unconditional mutant is killed by all four
passing cases and no failing one, which is the anti-vacuity direction.

## Gate

`e7a6d22` and `26a284b` both PASSED the full repository gate. 413 tests, 409 passing, 0 failures, 4
skipped. `validate` reports 14 passed, 4 failed, 32 skipped — **unchanged**, and the four failures are
the four standing human rejections (`ai.no-fabricated-capabilities`, `ai.no-safety-bypass`,
`errors.no-false-success`, `scm.no-shared-history-rewrite`), all `attested-rejected`. Self-audit at
zero error findings, also unchanged.

## What this does not claim

Currency. The catalog note now says existence and filled-in-ness are checked and that whether the
current-state fields are *current* is not, adding that no automated check can establish it. `assurance`
stays `partial`. The prompt scan has a stated reachable false positive — raw HTML with an attribute at
end of line — recorded in the code rather than left to be discovered.

§08's claim invariant is **named as broken** rather than renumbered: #45 and #46 were opened while
closing #38 and this item, and no plan item claims either. Five here, six elsewhere, two unclaimed,
partitioning thirteen.
