### PR TITLE
A leading ./ is a working directory the document may never have established (#4)

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1658,17 +1658,43 @@ that is a decision rather than a formality.
 - **Status:** READY
 - **Tracked by:** GitHub issue [#4](https://github.com/mikeycdavis/EngineeringStandards/issues/4)
 - **Evidence:** open as of 2026-08-11.
-- **Purpose:** The README path validator resolves paths from the repository root regardless of the
+- **Purpose:** ~~The README path validator resolves paths from the repository root regardless of the
   context the command was invoked in, so correct relative links can be reported as broken and
-  incorrect ones can pass. A path checker that resolves against the wrong base is worse than no path
-  checker, because its findings look authoritative.
-- **Deliverables:** resolution against the correct base, with the choice of base stated rather than
-  implicit.
+  incorrect ones can pass.~~ **Corrected 2026-08-28 by measurement against the adopter.** The
+  document-relative versus root-relative framing was wrong, and so was the heading's "local command
+  context" — both survive above only so the correction is legible. The detector's sole extraction
+  surface is inline code spans; markdown links, fenced blocks and bare prose are never candidates.
+  Neither reported path came from a command context, and deleting both fenced blocks from the
+  adopter's README changes the output not at all.
+- **The measured triggers**, correlated one-to-one at ReleasePilot `f94dbe0` by de-backticking each
+  span alone and observing which finding disappeared:
+
+  | Finding | Trigger | Base claimed |
+  | --- | --- | --- |
+  | `README.md -> ./mvnw` | `README.md:33`, under `## Prerequisites`: prose naming the Maven Wrapper | none — no working directory is established, and the `from ./backend` comment is forty lines away under a different heading |
+  | `README.md -> overlays/prod` | `README.md:126`, a docs bullet | none — the only signal is a sibling link one clause away |
+
+  The two other `./mvnw` spans are not candidates: lines 74 and 140 sit inside fenced blocks, and
+  line 133's span contains a space, which `looksLikeRepositoryPath` already rejects.
+- **Deliverables:** a leading `./` denotes a reference relative to a working directory. Where the
+  document does not establish one, the base is *unavailable* rather than root, so the token is
+  withdrawn through `run.unknown` and the rule reports `not-evaluated` — never `missing`. Joining
+  such a token to the repository root answers a question the document never asked.
+- **`overlays/prod` is recorded as unresolved, and is deliberately still reported.** Nothing states
+  that a link one clause away establishes a base, and resolving it by proximity would be inference
+  presented as measurement — the failure mode this detector layer has already shipped twice. It
+  stays a finding until an owner decides whether proximity is a contract this framework wants.
 - **Acceptance Criteria:**
-  - A fixture with links that are correct relative to the document and a fixture with links that are
-    correct only relative to the root produce opposite results, and the right one each way.
+  - ~~A fixture with links that are correct relative to the document and a fixture with links that are
+    correct only relative to the root produce opposite results.~~ Inoperative: the README selector is
+    anchored to the root README, where those two bases are identical.
+  - A cwd-relative token in prose establishing no working directory reports `not-evaluated`, and a
+    genuinely broken one behaves identically — the coverage cost, asserted rather than discovered.
+  - Ordinary root-scoped paths still pass and still fail, dot-prefixed ones included.
   - The existing finding that an HTTP route in a README is not a missing file (`78f3afb`) is
     unaffected.
+  - A nearby link does not establish a base, and an ambiguous token withdrawing does not take a
+    confirmed violation beside it with it.
 - **Verification:** `npm test`; the audit reports no README path findings against this repository.
 - **Dependencies:** the absence and discrepancy categories in [`03`](03-standards-audit-cli.md).
 

--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1655,9 +1655,50 @@ that is a decision rather than a formality.
 
 ### Fix README path resolution under local command context
 
-- **Status:** READY
+*(The heading is left as filed. "Local command context" is part of what the measurement below
+falsifies, and renaming it would erase the record of a framing this item had to correct.)*
+
+- **Status:** COMPLETE as to the measured `./` defect — 2026-08-28 at `de6ad01`, established by the
+  full repository gate at that commit: `inventory`, `fidelity`, `policy`, `diagrams`, `test` and
+  `audit` all passed, 420 tests, 416 passing, 0 failures, 4 skipped. `validate` reports 14 passed, 4
+  failed, 0 warnings, 32 skipped — unchanged, and the four are the four standing human rejections.
+  `documentation.code-consistency` was already `not-evaluated` for this repository at `a91676d` and
+  still is; this repository's own README carries no `./` span, so the change moves nothing here.
+
+  **The item does not close, and issue #4 should not close on it.** The owner's stated acceptance
+  condition is that the adopting repository becomes compliant *for this finding* with its working
+  tree unmodified. Measured at ReleasePilot `f94dbe0` against this commit, one finding remains:
+
+  | Before | After |
+  | --- | --- |
+  | `README.md -> ./mvnw` | withdrawn — `not-evaluated`, no finding |
+  | `README.md -> overlays/prod` | **unchanged, still reported** |
+
+  Closing on "one of two fixed" would restate a partial repair as the acceptance condition being
+  met. What remains is a decision rather than an implementation: whether a link one clause away
+  establishes a base for a sibling token. Adopting that as a contract is the only thing that would
+  clear `overlays/prod`, and it is the owner's to adjudicate — the alternative measured on the way
+  here, withdrawing any token whose parent directory is absent from the root, was rejected because
+  it stops reporting an entire deleted directory tree, which is the stale-documentation case the
+  rule exists to catch.
+
+  **Five mutants, all killed, and one earned its keep by surviving.** Keying the guard on a bare `.`
+  rather than `./` withdraws `.github/workflows/ci.yml` — an ordinary root-relative claim that
+  happens to start with a dot — and nothing in the suite objected until that mutant said so. A sixth
+  reported survival was a harness defect, not a live mutant: its anchor matched an unrelated
+  `continue;` five hundred lines earlier. Applied by hand at the real site it fails three tests. The
+  harness measurement was discarded rather than recorded, on the standing rule that an impossible
+  survival is a fact about the harness.
+
+  **Previously: READY.**
 - **Tracked by:** GitHub issue [#4](https://github.com/mikeycdavis/EngineeringStandards/issues/4)
 - **Evidence:** open as of 2026-08-11.
+- **The two SHAs in issue #4 are different trees, and must not be presented as one acceptance run.**
+  `f94dbe0` is the audited specimen and carries no `project-policy.yml` at all. The `VERSION_MISMATCH`
+  recorded in the issue's second comment therefore cannot have come from it; that file first appears
+  at `7e143a6` (2026-08-21), a descendant. `audit` needs no policy and reproduces the specimen at
+  `f94dbe0` directly, which is why the measurement above did not need the blocked `validate` path —
+  but whoever runs the owner's acceptance procedure has to know which of the two trees they are on.
 - **Purpose:** ~~The README path validator resolves paths from the repository root regardless of the
   context the command was invoked in, so correct relative links can be reported as broken and
   incorrect ones can pass.~~ **Corrected 2026-08-28 by measurement against the adopter.** The

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -2159,6 +2159,34 @@ function detectDocDiscrepancies(files, run) {
     const p = token.slice(1, -1).trim();
     if (!looksLikeRepositoryPath(p)) continue;
     const clean = p.replace(/\/$/, "");
+
+    // A LEADING `./` NAMES A WORKING DIRECTORY, AND THIS DOCUMENT MAY NOT ESTABLISH ONE.
+    //
+    // `./x` asserts a location relative to wherever the reader is standing, which for a command is
+    // whatever they last changed to. Joining it to the repository root answers a question the
+    // document never asked, and the answer looks authoritative: issue #4's `./mvnw` was reported
+    // missing against an adopter whose README named it correctly, as the Maven Wrapper, in prose
+    // that never claimed it sat at the root.
+    //
+    // So the base is UNAVAILABLE rather than root, and an unavailable base is a fact about the run
+    // (Standard 44 R12) — recorded through `unknown`, never as a finding. The aggregation's
+    // precedence rule is what makes this safe per token: a rule with a confirmed violation stays
+    // `failed` and keeps that finding, so withdrawing one ambiguous token cannot launder a real one
+    // beside it. Only a README whose every candidate is ambiguous reports `not-evaluated`.
+    //
+    // The cost is stated rather than discovered: a genuinely broken `./does-not-exist` in bare prose
+    // is now unreported too. That is the honest outcome and not a gap to close by trying prefixes
+    // until one matches — a base guessed from the filesystem is not a base the document stated, and
+    // a check that resolves eagerly enough to always succeed has stopped being a check.
+    if (clean.startsWith("./")) {
+      run.unknown(
+        "documentation.code-consistency",
+        rel(readme),
+        `\`${p}\` is stated relative to a working directory, and this document does not establish one`,
+      );
+      continue;
+    }
+
     if (!existsSync(path.join(root, clean))) broken.push(`${rel(readme)} -> ${p}`);
   }
 

--- a/test/readme-path-context.test.mjs
+++ b/test/readme-path-context.test.mjs
@@ -1,0 +1,248 @@
+/**
+ * A leading `./` names a working directory, and a README need not establish one.
+ *
+ * Issue #4 was filed as a base-resolution defect — document-relative versus root-relative — and the
+ * measurement against the adopter falsifies that framing. Both reported paths came from inline code
+ * spans; neither came from the fenced command block the issue names as the cause, and deleting both
+ * fences changes the output not at all. The triggers at ReleasePilot `f94dbe0` are exactly:
+ *
+ *   README.md:33   "For backend development: JDK 21 (the Maven Wrapper ./mvnw bootstraps Maven itself)."
+ *   README.md:126  "Kubernetes manifests: deploy/k8s (kustomize base + overlays/prod)." — where the
+ *                  first of those is a markdown link and the second a bare code span.
+ *
+ * (Both are written here without backticks or link syntax on purpose: this file is itself checked
+ * for broken links, and quoting the specimen faithfully would make the test suite report it.)
+ *
+ * Line 33 sits under `## Prerequisites`, forty lines from the `from ./backend` comment and under a
+ * different heading, so no working directory is established for it. `./mvnw` therefore has no base
+ * this run can resolve, and joining it to the repository root fabricates one.
+ *
+ * Only that correction is implemented. `overlays/prod` stays reported, because the only thing
+ * suggesting `deploy/k8s` as its base is an adjacent link, and no contract states that proximity
+ * establishes a base. Resolving it would be inference dressed as measurement, so the finding stands
+ * and the remaining ambiguity is the owner's to adjudicate.
+ *
+ * Both directions are asserted throughout. The withdrawal tests are paired with the cases that must
+ * still fail, because a check that resolves eagerly enough to always succeed has stopped being a
+ * check — and the last test is the one that keeps this honest: withdrawing an ambiguous token must
+ * not launder a real broken path standing beside it.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(HERE, "..", "scripts", "standards.mjs");
+
+const RULE = "documentation.code-consistency";
+
+/** Ample enough that nothing in these small fixtures goes unread, so no coarse withdrawal fires. */
+const AMPLE = 8_000_000;
+
+const POLICY = [
+  'standardVersion: "2.0.0"',
+  'project: "README path context fixture"',
+  "rules:",
+  "  documentation.code-consistency:",
+  "    level: required",
+  "",
+].join("\n");
+
+function cli(command, dir) {
+  const r = spawnSync(
+    process.execPath,
+    [CLI, command, `--dir=${dir}`, "--json", `--max-total-read-bytes=${AMPLE}`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return assert.fail(
+      `${command} stdout was not JSON.\nstatus: ${r.status}\nstderr: ${r.stderr.slice(0, 2000)}`,
+    );
+  }
+}
+
+const evidenceOf = (json) =>
+  (json.findings ?? []).filter((f) => f.rule === RULE).flatMap((f) => f.evidence ?? []);
+
+const resultFor = (json) => {
+  const r = (json.results ?? []).find((x) => x.ruleId === RULE);
+  assert.ok(r, `no result for ${RULE}; the policy fixture did not declare it`);
+  return r;
+};
+
+/**
+ * A real tree, because the check is `existsSync` and a stub over it would test the stub. `src/` and
+ * `deploy/k8s/overlays/prod` exist in every fixture so that each README below differs only in what
+ * it says, never in what is there.
+ */
+async function withReadme(readme, fn) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "readme-path-"));
+  try {
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await mkdir(path.join(root, "deploy", "k8s", "overlays", "prod"), { recursive: true });
+    await mkdir(path.join(root, "backend"), { recursive: true });
+    await writeFile(path.join(root, "src", "index.ts"), "export const x = 1;\n");
+    await writeFile(path.join(root, "backend", "mvnw"), "#!/bin/sh\n");
+    await mkdir(path.join(root, ".github", "workflows"), { recursive: true });
+    await writeFile(path.join(root, ".github", "workflows", "ci.yml"), "on: push\n");
+    await writeFile(path.join(root, "README.md"), readme);
+    await writeFile(path.join(root, "project-policy.yml"), POLICY);
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+/** The disposition an unresolvable base requires: withdrawn, not passed and not failed. */
+function assertNotEvaluated(json) {
+  const r = resultFor(json);
+  assert.equal(
+    r.disposition,
+    "not-evaluated",
+    `${RULE} reported disposition "${r.disposition}" (status ${r.status}) over a base it could not resolve`,
+  );
+  assert.equal(r.status, "skipped", `${RULE} must not carry a scored status when the base is unavailable`);
+}
+
+// --- The measured specimen ----------------------------------------------------------------------
+
+test("a cwd-relative token in prose that establishes no working directory is not a missing file", async () => {
+  const readme = [
+    "# Fixture",
+    "",
+    "## Prerequisites",
+    "",
+    "- For backend development: JDK 21 (the Maven Wrapper `./mvnw` bootstraps Maven itself).",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(
+      evidenceOf(cli("audit", root)),
+      [],
+      "`./mvnw` was reported missing against a document that never claimed it sits at the root",
+    );
+    assertNotEvaluated(cli("validate", root));
+  });
+});
+
+test("the coverage cost is recorded: a broken cwd-relative token withdraws identically", async () => {
+  // Deliberately the same shape with a path that genuinely does not exist anywhere. It must behave
+  // exactly as the case above, because the run cannot tell them apart without a base — and that is
+  // the price of refusing to guess one, stated here rather than discovered by an adopter later.
+  const readme = ["# Fixture", "", "Run `./does-not-exist` to begin.", ""].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(
+      evidenceOf(cli("audit", root)),
+      [],
+      "a cwd-relative token was resolved against the root after all",
+    );
+    assertNotEvaluated(cli("validate", root));
+  });
+});
+
+// --- The directions that must still work ---------------------------------------------------------
+
+test("ordinary root-scoped paths still pass and still fail", async () => {
+  const readme = [
+    "# Fixture",
+    "",
+    "Present: `src/index.ts`.",
+    "Absent: `src/nope.ts`.",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(
+      evidenceOf(json),
+      ["README.md -> src/nope.ts"],
+      "a root-relative path stopped being checked against the root",
+    );
+    assert.equal(resultFor(cli("validate", root)).disposition, "evaluated");
+  });
+});
+
+test("a dot-prefixed root path is a root claim and is still checked", async () => {
+  // The guard keys on `./`, not on a leading dot, and this is the test that holds the difference.
+  // `.github/workflows/ci.yml` is an ordinary root-relative claim that happens to start with a dot;
+  // withdrawing it would silently stop checking every dotfile path a README names. Found by a
+  // surviving mutant (`startsWith(".")`), not by review.
+  const readme = [
+    "# Fixture",
+    "",
+    "CI lives in `.github/workflows/ci.yml`.",
+    "Gone: `.github/workflows/nope.yml`.",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(
+      evidenceOf(cli("audit", root)),
+      ["README.md -> .github/workflows/nope.yml"],
+      "a dot-prefixed root-relative path stopped being checked against the root",
+    );
+  });
+});
+
+test("an HTTP route is still not a missing file (78f3afb)", async () => {
+  const readme = [
+    "# Fixture",
+    "",
+    "The API is served at `/api/v1/users` and health at `/actuator`.",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(evidenceOf(cli("audit", root)), [], "a route was read as a repository path");
+  });
+});
+
+test("a nearby link does not establish a base for an ambiguous sibling token", async () => {
+  // `deploy/k8s/overlays/prod` exists in the fixture, so resolving `overlays/prod` against the
+  // linked directory would make this pass. It must not: nothing states that a link one clause away
+  // is a base, and a detector that inferred it would be guessing in the direction of silence.
+  const readme = [
+    "# Fixture",
+    "",
+    "- Kubernetes manifests: [`deploy/k8s`](deploy/k8s) (kustomize base + `overlays/prod`).",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(
+      evidenceOf(cli("audit", root)),
+      ["README.md -> overlays/prod"],
+      "the detector resolved a token by proximity to a link, which no contract states",
+    );
+  });
+});
+
+// --- Anti-vacuity: the withdrawal must not launder a real finding ---------------------------------
+
+test("an ambiguous token withdraws without taking a confirmed violation with it", async () => {
+  // ReleasePilot's exact shape, and the case that decides whether this change is safe. The token
+  // scan reports one unknown check and one real breakage from the same file; the rule must stay
+  // failed and keep the finding it established, or a single `./x` anywhere in a README would become
+  // a way to silence every broken path beside it.
+  const readme = [
+    "# Fixture",
+    "",
+    "- For backend development: the Maven Wrapper `./mvnw` bootstraps Maven itself.",
+    "- Manifests: [`deploy/k8s`](deploy/k8s) (kustomize base + `overlays/prod`).",
+    "",
+  ].join("\n");
+  await withReadme(readme, (root) => {
+    assert.deepEqual(
+      evidenceOf(cli("audit", root)),
+      ["README.md -> overlays/prod"],
+      "the confirmed violation was withdrawn along with the ambiguous token",
+    );
+    const r = resultFor(cli("validate", root));
+    assert.equal(r.disposition, "evaluated", "a rule with a confirmed violation withdrew wholesale");
+    assert.equal(r.status, "failed", "the confirmed violation stopped being scored");
+  });
+});


### PR DESCRIPTION
Issue #4 was filed as a base-resolution defect — document-relative versus root-relative. The framing was wrong, and measurement against the adopter is what showed it.

## What was measured

The detector's only extraction surface is inline code spans. Markdown links, fenced blocks and bare prose are never candidates:

| Form | Scanned |
| --- | --- |
| Inline code span | **yes — the only source** |
| Markdown link, fenced block, prose | no |

So **neither reported path came from the fenced command block the issue names as the cause.** Deleting both fences from ReleasePilot's README changes the output not at all, and the issue's own minimal reproduction produces only one of its two findings.

De-backticking each span alone correlates them one-to-one at `f94dbe0`:

| Finding | Trigger | Base claimed |
| --- | --- | --- |
| `README.md -> ./mvnw` | `README.md:33`, prose under `## Prerequisites` naming the Maven Wrapper | none — the `from ./backend` comment is forty lines away under a different heading |
| `README.md -> overlays/prod` | `README.md:126`, a docs bullet | none — only a sibling link one clause away |

## What changed

A leading `./` asserts a location relative to wherever the reader is standing. Where the document establishes no working directory the base is *unavailable* rather than root, so the token is withdrawn via `run.unknown` and the rule reports `not-evaluated` — never `missing`.

The aggregation's existing precedence rule makes this safe per token: *confirmed violation + unknown check → failed, evaluated, carrying only the confirmed finding*. One ambiguous token cannot launder a real breakage beside it, and a test holds that.

**The coverage cost is asserted, not discovered:** a genuinely broken `./does-not-exist` in bare prose is now unreported too.

## What deliberately did not change

`overlays/prod` is still reported. Its only base signal is an adjacent link, and no contract says proximity establishes a base. The alternative measured on the way here — withdrawing any token whose parent directory is absent from the root — was rejected: it stops reporting an entire deleted directory tree, which is the stale-documentation case the rule exists for.

**Issue #4 does not close on this.** The owner's acceptance condition is that the adopter goes green for this finding with its tree unmodified; one of two findings remains. Whether proximity is a contract this framework wants is an owner decision, not an implementation.

## Verification

- Gate PASSED at `de6ad01` and again at `a259f56`; 420 tests, 416 passing, 0 failures, 4 skipped.
- `validate` 14 passed / 4 failed / 32 skipped — unchanged, the four being the standing human rejections.
- `documentation.code-consistency` was already `not-evaluated` for this repository at `a91676d` and still is; our README carries no `./` span.
- Five mutants, all killed. One earned its keep by surviving: keying the guard on a bare `.` withdraws `.github/workflows/ci.yml`, an ordinary root claim, and nothing objected until that mutant said so.

Also recorded: `f94dbe0` carries no `project-policy.yml`, so the `VERSION_MISMATCH` in issue #4's second comment belongs to a descendant (`7e143a6`). The two are different trees and are not one acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)