### PR TITLE
Say what a consumer may compare, and name what nobody can establish yet (#1)

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1850,8 +1850,62 @@ falsifies, and renaming it would erase the record of a framing this item had to 
 
 ### Resolve Standard 31 R4's comparability gap
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-29. R4 now carries a comparability contract; the producer-side
+  prerequisite it names is owned by issue
+  [#55](https://github.com/mikeycdavis/EngineeringStandards/issues/55) and is deliberately not
+  answered here.
+
+  **The mechanism the issue reported is obsolete, and the defect it points at is not.** #1's evidence
+  is that a consumer cannot tell "the project re-declared against a newer version" from "the validator
+  moved underneath an unchanged declaration". A version-identity guard at `scripts/standards.mjs:3193`
+  already refuses to emit an envelope when those two disagree — exit 2, typed `VERSION_MISMATCH`. It
+  landed at `11d8632` on 2026-08-09 20:37; #1 was filed 2026-08-10 01:37, five hours later, against
+  the tree its author had. The report was true when its evidence was gathered.
+
+  So a non-null `standardVersion` is *both* what the project declares and what evaluated it, and #1's
+  requested `validatorVersion` is not merely unbuilt — the separation it asks for is **unrepresentable**,
+  because the guard refuses to emit the envelope in which the two could differ.
+
+  **The gap survives at a granularity the guard cannot reach.** Under a constant `VERSION 2.0.0`,
+  `scripts/standards.mjs` changed across 21 commits and `rules/` across 6; `scm.no-committed-env-files`
+  moved its `assurance`, and three rules moved a `$assuranceNote` that the envelope does not carry.
+
+  **The falsifier, measured rather than argued.** Two validators, both `VERSION 2.0.0`, run against a
+  byte-identical unchanged tree naming `overlays/prod` with `deploy/k8s/overlays/prod` present:
+  `status`, `level`, `severity`, `validationType`, `assurance`, `disposition`, `evidence`, `score`,
+  `summary`, `standardVersion` and `schemaVersion` are **all identical**, and the observation moved
+  from *this path does not exist* to *could not be resolved, and whether the document is wrong was not
+  established*. Different measurements; nothing joinable says so. Any contract asserting those two are
+  machine-detectably comparable is wrong, which is why R4 declares the dimension `unknown` rather than
+  supplying a basis it does not have.
+
+  **A first draft of R4 was withdrawn before it was written, and the falsifier came from this
+  repository.** It would have said that a change in `level`, `severity`, `validationType`, `assurance`
+  or `disposition` breaks the series as a rule-semantic change. Ownership was then measured:
+  `severity` is catalog-only (0/50 results differ from it), `level` is policy-owned with a catalog
+  fallback (a fixture declaring `required` over a catalog `recommended` reports `required`), and
+  `validationType` and `assurance` follow the result path rather than the catalog — **23 of 50 results
+  in this repository's own envelope disagree with the catalog on one of the two**. PR #54 then proved
+  it outright: it touched neither `rules/` nor `scripts/` by a single line, and moved two rules from
+  `not-evaluated`/`none` to `attested`/`full`. The withdrawn wording would have called that a broken
+  series. It is the project's evidence state legitimately advancing, which is what a longitudinal view
+  exists to show.
+
+  R4 as written therefore names those fields **observable evaluation context**, rules that a change in
+  them must not be misattributed to rule semantics, and — separately — that their *equality* proves
+  nothing about the context that produced them, since two runs may agree on all of them while
+  consuming different policy content, evidence, or files.
+
+  **Previously: READY.**
 - **Tracked by:** GitHub issue [#1](https://github.com/mikeycdavis/EngineeringStandards/issues/1)
+- **Prerequisite, owned elsewhere and deliberately not closed here:**
+  [#55](https://github.com/mikeycdavis/EngineeringStandards/issues/55) — Standard 25 R2 owns the
+  envelope, so the missing producer-issued rule-set identity is defined there or nowhere. This item
+  does not wait on it: a consumer that knows it cannot compare will refuse rather than compare
+  wrongly, which is #1's own stated first remedy. No fingerprint shape is proposed, because the two
+  obvious ones are each blocked by something measured — a git-blob identity is unavailable to a
+  package installed without a repository, and a raw working-tree digest differs between a CRLF
+  checkout and a `git archive` export, which is the defect ADR 0011 exists to prevent.
 - **Evidence:** open as of 2026-08-11.
   [`standards/31-whatsnext-compatibility.md`](../../standards/31-whatsnext-compatibility.md) R4
   defines the *join key* — two results are the same finding if they share `project` and `ruleId` —
@@ -1872,6 +1926,13 @@ falsifies, and renaming it would erase the record of a framing this item had to 
   - Whatever is required of the JSON envelope is already present in it, or the change discloses that
     it is not.
 - **Verification:** `npm run fidelity && npm run inventory && npm test`.
+- **How the acceptance criteria were met.** The first: the contract is in R4, not in the tool, and no
+  code changed. The second: `fidelity` passes, R4 carries no verbatim source block, and the addition
+  is disclosed in the standard's own additions-beyond-the-source list. The third is the one that
+  permits closure at all — *"or the change discloses that it is not"* — and this is that case. What
+  the envelope needs is a rule-set identity it does not have; R4 says so, and #55 owns supplying it.
+  Closing on a disclosed absence is what that clause was written for, and it is not the same as
+  closing on a satisfied requirement.
 - **Dependencies:** [ADR 0002](../adr/0002-canonical-rule-identity.md), already settled.
 - **Note on this item's history:** an earlier reconciliation of Standard 31 merged into `develop` at
   `5b4b917`. That commit is an ancestor of `origin/develop` — the reconciliation landed. The issue

--- a/standards/31-whatsnext-compatibility.md
+++ b/standards/31-whatsnext-compatibility.md
@@ -74,7 +74,8 @@ A consumer MAY depend on these, and only these:
 | Exceptions applied | [Standard 20](20-exceptions.md); reported per [Standard 23](23-standards-validator-cli.md) R5 |
 | Evidence | [Standard 25](25-validator-output.md) R3; `evidence`, `files` |
 | Remediation | [Standard 25](25-validator-output.md) R3; `remediation` |
-| Validator and schema version | [Standard 25](25-validator-output.md) R2; `schemaVersion` |
+| Envelope format version | [Standard 25](25-validator-output.md) R2; `schemaVersion` |
+| Framework release that evaluated the project | [Standard 21](21-versioning.md) R5 and the version-identity guard; `standardVersion` |
 
 Two things this list does *not* include, deliberately:
 
@@ -115,6 +116,51 @@ Consequences for the validator:
 - **Aliases MUST NOT appear in output** ([ADR 0002](../artifacts/adr/0002-canonical-rule-identity.md)).
   A consumer joining on a name that varies by input file has no join key at all.
 
+**Identity is not comparability, and comparability has two parts.** The join key answers *are these
+the same rule?* A consumer computing a regression is claiming more than that: that both readings
+measured the same thing. Two distinct questions decide it, and they have different answers.
+
+**Observable evaluation context — what the run reports about how it evaluated.** `level` is the
+project's declaration, overriding the catalog wherever the policy names a rule. `disposition` is how
+the result was reached, and `validationType` and `assurance` follow it rather than the catalog: an
+attested result reports `manual-review` and `full` whatever the catalog says, and a skipped result
+reports `none`. A consumer MUST read these as evaluation context and MUST NOT read a change in them
+as a change in what the rule means. A rule moving from `not-evaluated` to `attested`, or from
+`evaluated` to `not-applicable`, is a real and reportable transition in the project's own state;
+presenting it as a regression or as a remediation misattributes it to code that did not move.
+
+**Equality of those fields does not establish that the context was the same.** They are what the run
+reports, not the whole of what it consumed. Two runs may agree on every one of them while evaluating
+different policy content, different evidence, or a different set of files, and nothing in the
+envelope distinguishes those cases. A consumer MAY use a change in them as positive evidence that
+the context moved; it MUST NOT use their equality as evidence that the context held.
+
+**Rule-semantic comparability — did the rule mean the same thing?** This is **not** establishable
+from the envelope. `severity` is the only rule-semantic value carried, and it is the smallest part of
+what a rule means. A rule's description, remediation, assurance note and detector may all change
+while the framework release, the join key, and every field above are identical — and when they do,
+two readings can differ in what they measured while nothing a consumer can join on differs at all.
+
+`standardVersion` is **necessary and insufficient**. A validator MUST refuse to emit a verdict
+labelled with a version that did not produce it ([Standard 21](21-versioning.md) R5), so equal
+`standardVersion` establishes that one framework release produced both readings and nothing further:
+detectors and catalog content change within a release. Where `standardVersion` differs, the readings
+were produced by different releases and MUST NOT be presented as one series; this is the same
+prohibition R6 applies to averaging scores, applied to the comparison rather than to the aggregate.
+
+**A consumer MUST therefore treat rule-semantic comparability as `unknown`, and MUST disclose it** —
+on successful comparisons as well as refused ones. It MUST NOT infer it from a rule count, a coverage
+figure, a message, a remediation string, or a checkout on disk. A wrong inference restores confidence
+in exactly the comparison that should not be trusted, and a consumer that declines to assert a
+regression it cannot ground is behaving correctly, not incompletely.
+
+**The prerequisite is producer-side and is deliberately not defined here.** Establishing rule-semantic
+comparability requires an identity for the evaluating rule set at finer granularity than the release,
+issued by the validator. [Standard 25](25-validator-output.md) R2 owns the envelope and is where such
+a field belongs; this standard introduces no field, and will cite that one when it exists. Until then
+`unknown` is the honest contract, and saying so is what stops a consumer inventing a basis the
+producer never supplied.
+
 ### R5 — Work items derive from findings; findings never derive from work items
 
 Where a consumer creates work items from violations, the finding is the source and the work item is
@@ -150,7 +196,11 @@ different denominators, MUST NOT be presented as a portfolio compliance figure
   than a note about sequencing.
 - R3's separation of `schemaVersion` from `standardVersion`, and why "detect outdated standard
   versions" requires it.
-- R4's join key and its three consequences.
+- R4's join key and its three consequences, and R4's separation of identity from comparability — the
+  observable evaluation context, the ruling that equality of those fields proves nothing about the
+  context that produced them, and rule-semantic comparability as an explicitly `unknown` disposition
+  pending a producer-issued rule-set identity. The source asks for correlation and does not reach the
+  question of whether two correlated results may be compared.
 - R5 in full — the one-direction rule between findings and work items.
 - R6 in full — carrying assurance into portfolio aggregates, and the ranking failure it prevents.
 


### PR DESCRIPTION
Closes #1. Prerequisite owned by #55.

## What #1 reported is obsolete; what it points at is not

The version-identity guard (`scripts/standards.mjs:3193`) refuses to emit an envelope when the policy's declared version differs from the framework's own — exit 2, typed `VERSION_MISMATCH`. It landed at `11d8632` **2026-08-09 20:37**; #1 was filed **2026-08-10 01:37**, five hours later, against the tree its author had. So `standardVersion` is already truthful validator provenance, and the `validatorVersion` #1 requested is **unrepresentable** rather than unbuilt — the guard refuses to emit the envelope in which the two could differ.

The gap survives at a granularity the guard cannot reach. Under a constant `VERSION 2.0.0`: **21 commits** to `scripts/standards.mjs`, **6** to `rules/`, with `scm.no-committed-env-files` moving its `assurance`.

## The falsifier

Two validators, both `2.0.0`, run against a byte-identical unchanged tree. `status`, `level`, `severity`, `validationType`, `assurance`, `disposition`, `evidence`, `score`, `summary`, `standardVersion`, `schemaVersion` — **all identical**. The observation moved from *this path does not exist* to *could not be resolved, and whether the document is wrong was not established*. Different measurements; nothing joinable says so.

## A first draft was withdrawn, and the falsifier came from this repository

It would have said a change in `level`, `severity`, `validationType`, `assurance` or `disposition` breaks the series as a rule-semantic change. Ownership was measured instead:

| Field | Owner | Evidence |
| --- | --- | --- |
| `severity` | catalog only | 0/50 results differ from catalog |
| `level` | project policy, catalog fallback | fixture: policy `required` over catalog `recommended` → `required` |
| `validationType`, `assurance` | the result path | **23/50** results disagree with the catalog on one of them |
| `disposition` | runtime only | no catalog counterpart |

**PR #54 settled it**: it touched neither `rules/` nor `scripts/` by a single line and moved two rules from `not-evaluated`/`none` to `attested`/`full`. The withdrawn wording would have called that a broken series. It is the project's evidence state legitimately advancing.

## What R4 now says

- Those fields are **observable evaluation context**; a change in them must not be misattributed to rule semantics.
- **Their equality proves nothing about the context that produced them** — two runs may agree on all of them while consuming different policy content, evidence, or files. A consumer MAY use a change as evidence the context moved; it MUST NOT use equality as evidence it held.
- **Rule-semantic comparability is `unknown`** and MUST be disclosed rather than inferred.
- `standardVersion` is necessary and insufficient; where it differs, the readings MUST NOT be presented as one series.
- The prerequisite is producer-side, belongs to Standard 25 R2, and is **not defined here**.

R2's guarantee table also promised "Validator and schema version" and cited `schemaVersion`, which Standard 25 R2 defines as the output format's version. The row is split.

## Verification

Local CI **PASSED** at `2293a60`. 425 tests, 421 passing, 0 failures, 4 skipped. No code changed — this is normative text plus the §08 record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)