### PR TITLE
A malformed field heading is rejected loudly, never converted to absence (#19)

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -1941,7 +1941,77 @@ falsifies, and renaming it would erase the record of a framing this item had to 
 
 ### Decide how the plan-item field parser handles qualified headings
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-29. The decision is an explicit grammar plus a diagnostic, and the
+  measurement that shaped it found a third failure class this item did not record.
+
+  **Three failure classes, measured end to end against a five-item fixture plan.**
+
+  | | Written | Before | After |
+  | --- | --- | --- | --- |
+  | 1 | `- **Status — as of today:** READY` | **the item disappears** — excluded from `executable` before any check runs, and *no finding of any kind* is emitted | parses as `Status`; the item is evaluated |
+  | 2 | `- **Acceptance Criteria — amended today:** a` | `(no Acceptance Criteria)` against an item that visibly has one | parses as `Acceptance Criteria` |
+  | 3 | `- **Tracked by — see the note:** issue #99` | delegation disclosure **deleted**, so a `COMPLETE` that nobody verified reads as established | parses; the cached-copy warning is emitted |
+
+  **Class 1 is not in this item's original text, and it is the worst of the three.** The other two
+  produce something wrong; this one produces nothing at all. A fixture item carrying all six fields,
+  one of them qualified, was reported clean.
+
+  **Class 3 is understated above what this item recorded.** Framed here as a field disappearing, it
+  measures as worse: losing `Tracked by` does not merely drop a field, it *manufactures* an
+  unearned claim, because the item's own `Status` stops being labelled a cached copy of an authority
+  nobody consulted.
+
+- **The grammar, adopted.** Exactly two forms, and a label occupies one line.
+
+  ```text
+  - **<key>:** value
+  - **<key> — <qualifier>:** value
+  ```
+
+  The key is matched **exactly** after trimming; the separator is a space, an em dash and a space,
+  and nothing else; the colon is required. No prefix matching, no case folding, no fuzziness. The
+  qualifier is free prose that nothing reads.
+
+- **PR #54 stays rejected under this grammar, and that is the point.** Its heading dropped the colon
+  *and* wrapped across two lines. The defect was never that a human-readable qualification failed to
+  parse — it is that the rejection was silent in class 1 and misdiagnosed in class 2. What changed is
+  the report, not the tolerance.
+
+- **The diagnostic's boundary is what had to be measured, and the obvious version of it is wrong.**
+  Reporting any unrecognised bold bullet inside an item fires **136 times on this repository's own
+  plan**, every one of them correct content: 64 keyed bullets whose key nothing reads — `Evidence`
+  alone appears in eight of the nine plan files — and 72 bold prose lead-ins such as
+  `**CI deliberately does not run --strict.**`. A positional rule fails too: **26 items** carry bold
+  bullets after their last known field, so there is no contiguous field block to anchor to.
+
+  So the diagnostic fires only where a label's canonical key is **exactly** a field the plan reads,
+  or is one followed by a dash where the separator belongs. Measured across all 13 plan files in
+  `artifacts/` and `test/fixtures/` — 492 classified bullets — it produces **zero** findings.
+
+- **A fourth class the strict separator creates, and which had to be caught rather than shipped.**
+  Adopting ` — ` as the only separator makes `Status - as of today`, `Status – as of today` and
+  `Status—as of today` unknown keys, which is *silent loss again* — the defect this item exists to
+  remove, reintroduced by its own fix. They are reported as a malformed separator instead. The rule
+  distinguishing them from `Acceptance Criteria-ish`, which must stay an ordinary unknown key, is
+  that an em or en dash is never intra-word while a plain hyphen usually is, so a hyphen counts only
+  when whitespace surrounds it. The first version of this rule fired on `Acceptance Criteria-ish`
+  and was rejected by the suite before it left the worktree.
+
+- **The ordering is load-bearing and was wrong first.** The diagnostic must run *before* the
+  executable filter and its early return, because a malformed `Status` is precisely what stops an
+  item being executable. The first implementation collected syntax problems after that point; a
+  single-item fixture returned before collecting anything, and class 1 stayed invisible. The test
+  named for it is what failed, and the ordering is now pinned by that test.
+
+- **Eight mutants, all killed, and one of them earned the suite an extra test.** Relaxing the key
+  match from a prefix to a substring survived every other test here. The case that kills it is
+  ordinary rather than exotic: a prose lead-in the same length as a field name mentioned after the
+  dash, such as a bolded `Caveat` followed by an em dash and a sentence mentioning `Status` — six
+  characters before the separator, and the field name after it — which a substring rule reports as a
+  malformed `Status` field. That is precisely the false-positive class this item was told not to
+  create, and it survived until a mutant asked for it.
+
+  **Previously: READY.**
 - **Tracked by:** GitHub issue
   [#19](https://github.com/mikeycdavis/EngineeringStandards/issues/19)
 - **Evidence:** open as of 2026-08-11. The parser in
@@ -1960,19 +2030,38 @@ falsifies, and renaming it would erase the record of a framing this item had to 
   findings, and it was found only by a one-off script written during the 2026-08-11 plan audit. So
   the impact is not confined to required fields generating a misleading *"missing required field"*
   message; for optional fields, a qualified heading disappears silently and permanently.
-- **Deliverables:** a decision on the owning layer and the fix, plus a regression. Deliberately not
+- **Deliverables:** ~~a decision on the owning layer and the fix, plus a regression. Deliberately not
   chosen here — the parser could recognise a known field name as a prefix, or the plan format and
-  templates could make the exact token mechanically unavoidable. A third option is compatible with
-  either: report an unrecognised field key as its own finding, so a near-miss explains itself.
+  templates could make the exact token mechanically unavoidable.~~ **Chosen 2026-08-29: an explicit
+  grammar in the parser, plus the third option, which the original text noted was compatible with
+  either — a malformed field heading reports itself.** Prefix recognition was rejected outright: it
+  is the fuzzy matching that would misread `Verification of the digest`, and the grammar gets the
+  same result with an exact key and a declared separator. The template route was not taken because it
+  cannot reach a plan already written, and every specimen so far was authored by hand.
 - **Acceptance Criteria:**
-  - A qualified heading is either accepted or produces a finding that names the heading as the
-    cause. `(no Acceptance Criteria)` against an item that visibly has one is the outcome to remove.
-  - The fix covers fields outside `PLAN_FIELDS`, or the plan explicitly records that it does not and
-    why. Fixing only the required fields would leave the silent case exactly as it is.
-  - A prefix-matching fix must not misread `- **Verification of the digest:**` as the `Verification`
-    field. Whichever direction is taken needs a known-negative fixture, not only a known-positive.
-- **Verification:** `npm test` with the new fixtures; plant a qualified heading of each shape in a
-  fixture plan item and confirm the chosen behaviour, including for a non-required field.
+  - A malformed or qualified `Status` MUST NOT make an item disappear. It either parses, or produces
+    a finding — silence is the failure this criterion exists to forbid, and it is the class the
+    original wording did not cover.
+  - A malformed `Tracked by` MUST NOT suppress the delegation disclosure. Restoring the field is not
+    sufficient on its own: the cached-copy warning is what stops an unverified `COMPLETE` reading as
+    established, so the test asserts the warning rather than the field.
+  - A wrapped or otherwise malformed label MUST be rejected loudly rather than converted to absence.
+    Where the field really is missing, the missing-field finding still fires **and** the syntax
+    finding names the line and the label beside it — the pair is the fix, because suppressing the
+    first would under-report a real R7 violation.
+  - A qualified heading is accepted when it follows the grammar, and `(no Acceptance Criteria)`
+    standing alone against an item that visibly has one is gone.
+  - The fix covers fields outside `PLAN_FIELDS` — `Tracked by` is included by name, and a key nothing
+    reads stays exactly as before rather than becoming an error.
+  - The grammar must not misread `- **Verification of the digest:**` as `Verification`. All four
+    near-misses — that one, `Statuses`, `Acceptance Criteria-ish`, `Dependencies and risks` — are
+    held as known-negatives, and ordinary bold prose inside an item must not become a parser error.
+  - One qualified field must not be mistaken for another, and a duplicate canonical key must not let
+    a qualified label silently overwrite the field a reader can see.
+- **Verification:** `npm test`. Twelve tests in
+  [`test/plan-field-grammar.test.mjs`](../../test/plan-field-grammar.test.mjs), each building a real
+  plan and running the real CLI. Eight are positives; four are the anti-vacuity half, which a
+  diagnostic that fired on everything would fail.
 - **Dependencies:** none.
 - **Repairing the four instances is not fixing this.** The malformed `Evidence` heading in this file
   was corrected in the same change that created this item. That removed one specimen; the parser

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -1923,25 +1923,129 @@ function detectOpenQuestions(files, run) {
   });
 }
 
-/** Parse `### Title` items and their `- **Field:** value` lines out of a plan-breakdown file. */
+/**
+ * The plan-item field grammar. Exactly two forms, and a label occupies one line:
+ *
+ * ```text
+ * - **<key>:** value
+ * - **<key> — <qualifier>:** value
+ * ```
+ *
+ * The key is canonical and matched EXACTLY after trimming; the qualifier is free prose for a human
+ * and is read by nothing. There is no prefix matching, no case folding, and no fuzziness anywhere —
+ * `Verification of the digest` is a different key from `Verification`, and stays one.
+ *
+ * The separator is a space, an em dash, and a space, and nothing else. That is narrow on purpose:
+ * a comma, a parenthesis, and a bare hyphen all occur inside labels people legitimately write, so
+ * admitting them would make the key depend on punctuation the author did not intend as structure.
+ */
+const FIELD_SEPARATOR = " — ";
+const PLAN_FIELDS = ["Status", "Purpose", "Deliverables", "Acceptance Criteria", "Verification", "Dependencies"];
+
+/**
+ * Every key any consumer reads. `Tracked by` is here and not in PLAN_FIELDS because it is optional,
+ * but losing it is worse than losing an optional field: it is the disclosure that an item's status
+ * is a cached copy of an authority nobody consulted, and without it that status reads as established.
+ */
+const READABLE_FIELDS = new Set([...PLAN_FIELDS, "Tracked by", "TrackedBy"]);
+
+/** A well-formed field line, unchanged from the form every existing plan already uses. */
+const FIELD_LINE = /^\s*-\s+\*\*([^:*]+):\*\*\s*(.*)$/;
+
+/**
+ * A bullet that OPENS a bold run. Deliberately looser than FIELD_LINE in three ways, because its
+ * job is to notice a field that was written wrongly rather than to read one: `*` bullets count,
+ * no closing `**` is required, so a label wrapped across two source lines is still seen.
+ */
+const BOLD_OPEN = /^\s*[-*]\s+\*\*(.*)$/;
+
+/**
+ * A separator that was attempted and missed. An em or en dash is never intra-word, so it is always
+ * an attempt at structure; a plain hyphen usually is intra-word, so it counts only when whitespace
+ * surrounds it. That distinction is the whole reason `Acceptance Criteria-ish` stays an ordinary
+ * unknown key while `Acceptance Criteria - amended` is reported as a malformed separator.
+ */
+const NEAR_SEPARATOR = /^(?:\s*[–—]\s*|\s+-\s+)/;
+
+/** The text before the first separator. The qualifier after it is for people, and is discarded. */
+function canonicalFieldKey(label) {
+  const at = label.indexOf(FIELD_SEPARATOR);
+  return (at === -1 ? label : label.slice(0, at)).trim();
+}
+
+/**
+ * Did this label mean to name `key` and miss the separator? Returns the intended key or null.
+ * Exact prefix, then a dash where the separator belongs — never a fuzzy resemblance.
+ */
+function intendedKey(label) {
+  const trimmed = label.trim();
+  for (const field of READABLE_FIELDS) {
+    if (!trimmed.startsWith(field)) continue;
+    const rest = trimmed.slice(field.length);
+    if (rest.trim() !== "" && NEAR_SEPARATOR.test(rest)) return field;
+  }
+  return null;
+}
+
+/**
+ * Parse `### Title` items and their field lines out of a plan-breakdown file.
+ *
+ * Each item also carries `syntax`: labels that were trying to be a field and failed. That list is
+ * the point of the reader rather than a by-product. Before it existed, a malformed label was
+ * indistinguishable from an absent field, and the three ways that went wrong all reported something
+ * untrue — a qualified `Status` removed the item from evaluation entirely and said nothing, a
+ * qualified required field produced "(no Acceptance Criteria)" against an item that visibly had one,
+ * and a qualified `Tracked by` deleted the cached-status disclosure so a delegated status read as
+ * established. Rejecting malformed syntax is right; converting it into absence is not.
+ */
 function parsePlanItems(text, file) {
   const items = [];
   let current = null;
-  for (const line of text.split(/\r?\n/)) {
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
     const heading = line.match(/^###\s+(.*)$/);
     if (heading) {
       if (current) items.push(current);
-      current = { title: heading[1].trim(), file, fields: new Map() };
+      current = { title: heading[1].trim(), file, fields: new Map(), syntax: [] };
       continue;
     }
-    const field = line.match(/^\s*-\s+\*\*([^:*]+):\*\*\s*(.*)$/);
-    if (field && current) current.fields.set(field[1].trim(), field[2].trim());
+    if (!current) continue;
+    const lineNumber = index + 1;
+
+    const field = line.match(FIELD_LINE);
+    if (field) {
+      const label = field[1].trim();
+      const key = canonicalFieldKey(label);
+      if (READABLE_FIELDS.has(key)) {
+        // First occurrence wins. Canonicalisation makes two labels able to collide where the raw
+        // strings could not, and silently overwriting one with the other would let a qualified
+        // duplicate replace the field a reader can see.
+        if (current.fields.has(key)) {
+          current.syntax.push({ line: lineNumber, key, kind: "duplicate", label });
+        } else {
+          current.fields.set(key, field[2].trim());
+        }
+        continue;
+      }
+      const intended = intendedKey(label);
+      if (intended) current.syntax.push({ line: lineNumber, key: intended, kind: "separator", label });
+      // An unknown key is not an error. `Evidence` is a house convention on most items here, and a
+      // label nothing reads is a label nothing reads — it is stored exactly as before.
+      else current.fields.set(label, field[2].trim());
+      continue;
+    }
+
+    const bold = line.match(BOLD_OPEN);
+    if (!bold) continue;
+    // Strip a closing `**` and a trailing colon, so `- **Status**:` and `* **Status:**` are seen as
+    // broken field syntax rather than read as ordinary prose.
+    const label = bold[1].split("**")[0].replace(/:\s*$/, "");
+    const key = canonicalFieldKey(label);
+    const intended = READABLE_FIELDS.has(key) ? key : intendedKey(label);
+    if (intended) current.syntax.push({ line: lineNumber, key: intended, kind: "syntax", label: label.trim() });
   }
   if (current) items.push(current);
   return items;
 }
-
-const PLAN_FIELDS = ["Status", "Purpose", "Deliverables", "Acceptance Criteria", "Verification", "Dependencies"];
 
 /**
  * The canonical lifecycle vocabulary — Standard 8, decided in ADR 0001. Legacy tokens are accepted
@@ -1981,6 +2085,43 @@ async function detectPlanDiscrepancies(files, run) {
   const items = planFiles
     .filter((f) => run.textOf(f).available)
     .flatMap((f) => parsePlanItems(run.textOf(f).text, rel(f)));
+  // BEFORE the executable filter, and before its early return, because a malformed `Status` is
+  // exactly what stops an item being executable. A diagnostic that ran after this point could not
+  // see the case that most needs reporting: a plan whose every item has a broken Status would be
+  // reported as having no executable items, which is silence rather than a finding. This is the
+  // ordering the suite pins, and it was wrong first — a single-item fixture returned before
+  // collecting anything, and the test for it failed until the block moved up here.
+  const malformed = [];
+  for (const item of items) {
+    for (const problem of item.syntax) {
+      const what =
+        problem.kind === "duplicate"
+          ? `a second ${problem.key} field`
+          : problem.kind === "separator"
+            ? `${problem.key} followed by something that is not the separator`
+            : `${problem.key} written in a form the plan grammar does not accept`;
+      malformed.push(`${item.file}:${problem.line} :: ${item.title} :: ${what} -- ${problem.label}`);
+    }
+  }
+  if (malformed.length > 0) {
+    addFinding({
+      id: "plan-item-field-syntax",
+      rule: "planning.item-fields",
+      category: "Plan/code discrepancies",
+      severity: "error",
+      label: "OBSERVED",
+      evidence: uniq(malformed),
+      message:
+        `${malformed.length} plan item field heading(s) name a field the plan reads but are not ` +
+        "written in a form it accepts, so the field was not read.",
+      remediation:
+        "Write the heading as `- **Field:** value`, or `- **Field \u2014 qualifier:** value` where a " +
+        "qualifier helps a reader. The key must match exactly, the separator is a space, an em dash " +
+        "and a space, the colon is required, and the whole label must fit on one line.",
+      standardRef: R.plan,
+    });
+  }
+
   const executable = items.filter((i) => i.fields.has("Status"));
   if (executable.length === 0) return;
 

--- a/test/plan-field-grammar.test.mjs
+++ b/test/plan-field-grammar.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * A malformed field heading is rejected loudly, never converted into an absent field.
+ *
+ * Issue #19 recorded two failure shapes. Measurement found three, and the one it missed is the
+ * worst: a malformed `Status` does not produce "missing Status", it removes the item from the
+ * executable set entirely, so every check on that item stops running and nothing is reported. The
+ * other two are a misleading "(no Acceptance Criteria)" against an item that visibly has one, and a
+ * malformed `Tracked by`, which deletes the disclosure that a status is a cached copy of an
+ * authority nobody consulted — turning an unverified status into an apparently established one.
+ *
+ * PR #54 is the live specimen and is deliberately still rejected here. Its heading dropped the
+ * colon and wrapped across two lines, and no grammar admitting that would be worth having. The
+ * defect was never that a human-readable qualification failed to parse; it was that the rejection
+ * was silent in one case and misdiagnosed in another.
+ *
+ * The diagnostic's boundary is the part that had to be measured rather than reasoned about, because
+ * the obvious version of it — report any bold bullet that is not a known field — fires 136 times on
+ * this repository's own plan, which is correct. Plan items legitimately carry keyed bullets nothing
+ * reads (`Evidence` appears in eight of the nine files) and bold prose lead-ins (72 of them). So the
+ * diagnostic fires only where a label's canonical key is EXACTLY a field the plan reads, or is one
+ * followed by a dash where the separator belongs. Measured against every plan file in the
+ * repository and every fixture: zero findings.
+ *
+ * The last four tests are the anti-vacuity half. A diagnostic that fires on everything would pass
+ * every positive test in this file.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(HERE, "..", "scripts", "standards.mjs");
+
+const RULE = "planning.item-fields";
+const AMPLE = 8_000_000;
+
+const POLICY = [
+  'standardVersion: "2.0.0"',
+  'project: "plan field grammar fixture"',
+  "rules:",
+  "  planning.item-fields:",
+  "    level: required",
+  "",
+].join("\n");
+
+function cli(command, dir) {
+  const r = spawnSync(
+    process.execPath,
+    [CLI, command, `--dir=${dir}`, "--json", `--max-total-read-bytes=${AMPLE}`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return assert.fail(`${command} stdout was not JSON.\nstderr: ${r.stderr.slice(0, 2000)}`);
+  }
+}
+
+const findingsById = (json, id) => (json.findings ?? []).filter((f) => f.id === id);
+const syntaxEvidence = (json) => findingsById(json, "plan-item-field-syntax").flatMap((f) => f.evidence ?? []);
+const missingEvidence = (json) => findingsById(json, "standards-violations").flatMap((f) => f.evidence ?? []);
+const delegationEvidence = (json) =>
+  findingsById(json, "delegated-liveness-unverifiable").flatMap((f) => f.evidence ?? []);
+
+/** The six fields, well formed, so a fixture differs from the next only in the line under test. */
+const SIX = [
+  "- **Status:** READY",
+  "- **Purpose:** p",
+  "- **Deliverables:** d",
+  "- **Acceptance Criteria:** a",
+  "- **Verification:** v",
+  "- **Dependencies:** none",
+];
+
+/** Build a plan whose single item is `SIX` with one line replaced, or with extra lines appended. */
+function item(title, { replace = {}, extra = [] } = {}) {
+  const lines = SIX.map((l) => {
+    for (const [prefix, replacement] of Object.entries(replace)) {
+      if (l.startsWith(prefix)) return replacement;
+    }
+    return l;
+  });
+  return [`### ${title}`, ...lines, ...extra, ""].join("\n");
+}
+
+async function withPlan(planBody, fn) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "plan-grammar-"));
+  try {
+    await mkdir(path.join(root, "artifacts", "project-plan-breakdown"), { recursive: true });
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await writeFile(path.join(root, "src", "index.ts"), "export const x = 1;\n");
+    await writeFile(path.join(root, "README.md"), "# Fixture\n");
+    await writeFile(path.join(root, "project-policy.yml"), POLICY);
+    await writeFile(
+      path.join(root, "artifacts", "project-plan-breakdown", "01-p.md"),
+      ["# 01 — P", "", planBody].join("\n"),
+    );
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------- the grammar accepts a qualifier
+
+test("a qualified key parses as the canonical field", async () => {
+  await withPlan(
+    item("Qualified acceptance criteria", {
+      replace: { "- **Acceptance Criteria:**": "- **Acceptance Criteria — amended today:** a" },
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(missingEvidence(json), [], "a qualified heading was read as an absent field");
+      assert.deepEqual(syntaxEvidence(json), [], "a well-formed qualified heading was reported as malformed");
+    },
+  );
+});
+
+test("a qualified Status keeps the item evaluable rather than making it disappear", async () => {
+  await withPlan(
+    item("Qualified status", {
+      replace: { "- **Status:**": "- **Status — as of today:** READY" },
+      // Deliberately drop nothing: if the item is evaluated, this is silent. The falsifier is the
+      // NEXT test, which proves the fixture can produce a missing-field finding at all.
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(syntaxEvidence(json), []);
+      assert.deepEqual(missingEvidence(json), [], "the item reported a missing field");
+    },
+  );
+});
+
+test("the qualified-Status fixture is not vacuous — dropping a field still fails", async () => {
+  const body = item("Qualified status, missing a field", {
+    replace: { "- **Status:**": "- **Status — as of today:** READY", "- **Verification:**": "" },
+  });
+  await withPlan(body, (root) => {
+    const json = cli("audit", root);
+    const missing = missingEvidence(json);
+    assert.equal(missing.length, 1, `expected exactly one missing field, got ${JSON.stringify(missing)}`);
+    assert.match(missing[0], /no Verification/);
+  });
+});
+
+test("a qualified Tracked by preserves the delegated-status disclosure", async () => {
+  await withPlan(
+    item("Delegated with a qualified label", {
+      replace: { "- **Status:**": "- **Status:** COMPLETE" },
+      extra: ["- **Tracked by — see the migration note:** GitHub issue #99"],
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      const delegated = delegationEvidence(json);
+      assert.equal(delegated.length, 1, "the delegation disclosure was lost, so COMPLETE reads as established");
+      assert.match(delegated[0], /cached copy/);
+    },
+  );
+});
+
+// ------------------------------------------------------------- malformed syntax is reported loudly
+
+test("a colon-less qualified label is reported, and names the heading", async () => {
+  await withPlan(
+    item("Colon-less label", {
+      replace: { "- **Acceptance Criteria:**": "- **Acceptance Criteria — amended today.** a" },
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      const syntax = syntaxEvidence(json);
+      assert.equal(syntax.length, 1, `expected one syntax finding, got ${JSON.stringify(syntax)}`);
+      assert.match(syntax[0], /Acceptance Criteria/);
+      assert.match(syntax[0], /01-p\.md:\d+/, "the finding does not name the line");
+    },
+  );
+});
+
+test("a malformed Status is reported even though it stops the item being executable", async () => {
+  await withPlan(
+    item("Wrong separator on status", {
+      replace: { "- **Status:**": "- **Status - as of today:** READY" },
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      const syntax = syntaxEvidence(json);
+      assert.equal(syntax.length, 1, "the item vanished silently, which is the defect this closes");
+      assert.match(syntax[0], /Status/);
+      // And the item really is non-executable, so this finding is the ONLY thing that reports it.
+      assert.deepEqual(missingEvidence(json), []);
+    },
+  );
+});
+
+test("a wrapped label is reported rather than treated as an absent field", async () => {
+  await withPlan(
+    [
+      "### Wrapped label",
+      ...SIX.filter((l) => !l.startsWith("- **Acceptance Criteria:**")),
+      "- **Acceptance Criteria — amended by the owner on 2026-08-29. This is a",
+      "  correction to the contract:** a",
+      "",
+    ].join("\n"),
+    (root) => {
+      const json = cli("audit", root);
+      assert.equal(syntaxEvidence(json).length, 1, "a wrapped label was silently absent");
+      // The field genuinely is missing, and now the reason is stated beside it rather than alone.
+      assert.equal(missingEvidence(json).length, 1);
+      assert.match(missingEvidence(json)[0], /no Acceptance Criteria/);
+    },
+  );
+});
+
+test("a duplicate canonical key does not let a qualified label overwrite the field", async () => {
+  await withPlan(
+    item("Duplicate status", { extra: ["- **Status — a second one:** CANCELLED"] }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.equal(syntaxEvidence(json).length, 1, "a second Status was absorbed silently");
+      assert.match(syntaxEvidence(json)[0], /a second Status field/);
+    },
+  );
+});
+
+// ------------------------------------------------------------------------------- anti-vacuity half
+
+test("the four near-misses stay unknown keys and raise nothing", async () => {
+  await withPlan(
+    item("Near misses", {
+      extra: [
+        "- **Verification of the digest:** unrelated",
+        "- **Statuses:** unrelated",
+        "- **Acceptance Criteria-ish:** unrelated",
+        "- **Dependencies and risks:** unrelated",
+      ],
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(syntaxEvidence(json), [], "a near-miss was read as a malformed field");
+      assert.deepEqual(missingEvidence(json), [], "a near-miss displaced a real field");
+    },
+  );
+});
+
+test("ordinary bold prose inside an item is not a field-syntax finding", async () => {
+  await withPlan(
+    item("Prose bullets", {
+      extra: [
+        "- **Evidence:** open as of today.",
+        "- **The bug worth remembering: it detected itself.** prose",
+        "- **Status is not a claim about the world.** prose",
+        "- **Amendment — why the criterion is superseded.** prose",
+      ],
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(syntaxEvidence(json), [], "explanatory prose became a parser error");
+    },
+  );
+});
+
+test("a qualified label maps only to its own field, never to another", async () => {
+  await withPlan(
+    item("One qualified field", {
+      replace: { "- **Verification:**": "- **Verification — how it was run:** v" },
+      extra: ["- **Acceptance Criteria — a second one:** a"],
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      // `Verification — how it was run` must not satisfy `Acceptance Criteria`, and the duplicate
+      // Acceptance Criteria must be reported as a duplicate rather than filling some other field.
+      assert.equal(syntaxEvidence(json).length, 1);
+      assert.match(syntaxEvidence(json)[0], /a second Acceptance Criteria field/);
+      assert.deepEqual(missingEvidence(json), [], "a qualified Verification stopped satisfying Verification");
+    },
+  );
+});
+
+test("field-shaped bullets that miss the bold-and-colon form are still reported", async () => {
+  // Two shapes no test covered until a mutant survived by deleting the handling for them: a `*`
+  // bullet, which markdown allows and the field regex does not, and a colon outside the bold run.
+  await withPlan(
+    [
+      "### Broken bullet shapes",
+      ...SIX.filter((l) => !l.startsWith("- **Verification:**")),
+      "* **Verification:** v",
+      "",
+    ].join("\n"),
+    (root) => {
+      const json = cli("audit", root);
+      assert.equal(syntaxEvidence(json).length, 1, "a `*` bullet field was read as prose");
+      assert.match(syntaxEvidence(json)[0], /Verification/);
+    },
+  );
+  await withPlan(
+    [
+      "### Colon outside the bold run",
+      ...SIX.filter((l) => !l.startsWith("- **Verification:**")),
+      "- **Verification**: v",
+      "",
+    ].join("\n"),
+    (root) => {
+      const json = cli("audit", root);
+      assert.equal(syntaxEvidence(json).length, 1, "a colon outside the bold run was read as prose");
+    },
+  );
+});
+
+test("a field name mentioned inside prose is not a field heading", async () => {
+  // The key must be a PREFIX of the label, not merely present in it. A mutant relaxing that to a
+  // substring test survived the rest of this suite, and the case that kills it is ordinary: the
+  // lead-in before the dash happens to be the same length as the field name mentioned after it.
+  await withPlan(
+    item("Prose mentioning a field name", {
+      extra: [
+        "- **Caveat — Status is cached here.** prose",
+        "- **Note — the Verification below is partial.** prose",
+      ],
+    }),
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(syntaxEvidence(json), [], "prose mentioning a field name became a parser error");
+    },
+  );
+});
+
+test("a well-formed plan raises nothing at all", async () => {
+  await withPlan(item("Entirely well formed"), (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(syntaxEvidence(json), []);
+    assert.deepEqual(missingEvidence(json), []);
+  });
+});


### PR DESCRIPTION
Closes #19.

## The item recorded two failure classes; measurement found three

| | Written | Before | After |
| --- | --- | --- | --- |
| 1 | `- **Status — as of today:** READY` | **the item disappears** — dropped from `executable` before any check runs, *no finding of any kind* | parses; the item is evaluated |
| 2 | `- **Acceptance Criteria — amended today:** a` | `(no Acceptance Criteria)` against an item that visibly has one | parses |
| 3 | `- **Tracked by — see the note:** issue #99` | delegation disclosure **deleted**, so an unverified `COMPLETE` reads as established | parses; cached-copy warning emitted |

**Class 1 was not in the item.** It is the worst of the three: the other two produce something wrong, this one produces nothing. **Class 3 is understated there** — it does not merely drop a field, it *manufactures* an unearned claim.

## The grammar

```
- **<key>:** value
- **<key> — <qualifier>:** value
```

One line, colon required, key matched **exactly** after trimming, separator is a space + em dash + space. No prefix matching, no case folding. `Verification of the digest` stays a different key from `Verification`.

**PR #54 is still rejected**, and deliberately. It dropped the colon *and* wrapped across two lines. The defect was never that a human-readable qualification failed to parse — it was that the rejection was silent in class 1 and misdiagnosed in class 2.

## The boundary, measured rather than reasoned about

The obvious diagnostic — report any unrecognised bold bullet — **fires 136 times on this repository's own plan**, every one correct content: 64 keyed bullets nothing reads (`Evidence` in eight of nine files) and 72 bold prose lead-ins. A positional rule fails too: **26 items** carry bold bullets after their last known field, so there is no contiguous field block.

So it fires only where a canonical key is **exactly** a readable field, or is one followed by a dash where the separator belongs. Across all 13 plan files in `artifacts/` and `test/fixtures/` — 492 classified bullets — **zero findings**.

## A fourth class the fix itself created

Adopting ` — ` as the only separator would make `Status - as of today`, `Status – as of today` and `Status—as of today` unknown keys — silent loss again, reintroduced by its own fix. They are reported as a malformed separator. An em/en dash is never intra-word so it always counts; a plain hyphen counts only when whitespace surrounds it, which keeps `Acceptance Criteria-ish` an ordinary unknown key.

## Two things that were wrong first

**Ordering.** The diagnostic must run *before* the executable filter, because a malformed `Status` is what stops an item being executable. The first implementation collected after that point; a single-item fixture returned before collecting anything, and its test failed until the block moved.

**Eight mutants, all killed — one survived first.** Relaxing the key match from a prefix to a substring passes every other test here. The case that kills it is ordinary: a prose lead-in the same length as a field name mentioned after the dash, which a substring rule reports as a malformed field. That is exactly the false-positive class this work was told not to create, and it survived until a mutant asked for it.

## Verification

Local CI **PASSED** at `f6ac301`. **439 tests, 435 passing, 0 failures, 4 skipped.** 14 new tests in `test/plan-field-grammar.test.mjs`, five of them the anti-vacuity half a fire-on-everything diagnostic would fail. Zero findings against this repository's own plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)