### PR TITLE
One signal was two, and neither could see the other's case (#21)

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -2069,34 +2069,139 @@ falsifies, and renaming it would erase the record of a framing this item had to 
 
 ### Decide which layer detects unresolved merge-conflict metadata
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-29. The layer question is answered, and the measurement answered it
+  by splitting it: there is no single layer, because there is no single signal.
+
+  **Two propositions, different owners, and neither detects the other's case.**
+
+  | | Proposition | Owner | Reaches `develop`? |
+  | --- | --- | --- | --- |
+  | **P1** | this tracked file's committed content contains a conflict-marker group | an `audit` finding, `INFERRED`, **no catalog rule** | **yes — it did** |
+  | **P2** | this working tree is mid-conflict | a local preflight in `scripts/ci-context.sh` / `.ps1`, outside the catalog | no |
+
+  **They are disjoint, measured rather than reasoned.** A delete/modify conflict leaves stages in
+  the index, `MERGE_HEAD` on disk and `status` reporting `UD`, over a file whose content holds **no
+  markers at all**. A committed marker leaves a clean index, a clean status and no metadata. Content
+  scanning misses the first; every repository-state probe misses the second.
+
+  **P2 can never reach CI, and that is what decided its layer rather than a preference.** `git
+  commit` refuses an unmerged index; `git add` clears the stages and deletes `CHERRY_PICK_HEAD`, so
+  the state is *erased* by the act that would carry it forward. `ci-context.sh` clones committed
+  HEAD and `actions/checkout` does the same, so no index stage can exist in either. A CI-time check
+  for P2 could not fire even once. It was already refused locally, but under the wrong name — as
+  *"the working tree has uncommitted changes"* — and now says which state it found.
+
+  **The incident was a cherry-pick**, so `CHERRY_PICK_HEAD` existed and `MERGE_HEAD` did not. A
+  probe written as `git rev-parse --verify MERGE_HEAD` would have missed the specimen this item is
+  about. The preflight reads `git ls-files -u` and the full operation set — merge, cherry-pick,
+  revert, rebase, sequencer, `AUTO_MERGE` — and reports `unknown` where the repository cannot
+  answer, rather than inferring clean.
+
+  **P2's two signals are both load-bearing, and the test drives them separately.** The index misses
+  a resolution that has been staged while the operation is still open; the metadata misses nothing
+  there, and the reverse case — a delete/modify conflict — is invisible to any content check
+  because the file holds no markers. The refusal moved ahead of every other repository read, so a
+  directory that cannot answer the question is refused as `unknown` instead of failing later with
+  git's own unexplained error.
+
+  **Previously: READY.**
+- **Superseded status line:** READY
 - **Tracked by:** GitHub issue
   [#21](https://github.com/mikeycdavis/EngineeringStandards/issues/21)
 - **Evidence:** open as of 2026-08-11, and **reproduced on `develop` rather than hypothesised**.
   Three cherry-pick conflict markers reached `develop` in this file, introduced by `8870a43` and
   removed by `18857e9`. While they were present the repository passed `inventory`, `fidelity`,
   `policy`, `diagrams`, 229 tests, and a self-audit reporting **0 errors and 0 warnings**.
-  `git diff --check` detects them in one command and names the lines.
+  ~~`git diff --check` detects them in one command and names the lines.~~ **Corrected 2026-08-29:
+  useful only in the pre-commit diff window; silent after commit.** It reads *added lines in a
+  diff*, not repository content, so it was true while the markers were unstaged and false from the
+  moment `8870a43` landed — which is the state this item exists for. Measured on a repository
+  holding committed markers and a clean tree, `git diff --check` exits **0** and prints nothing.
+  Adopting it would have shipped a gate that cannot see its own specimen.
 - **Purpose:** Unresolved merge metadata can sit in a tracked file — in the canonical release-gate
   artifact, inside a plan item's `Verification` field — while every gate reports clean. The plan
   parser reads `- **Field:**` lines and ignores all others, Markdown renders markers as ordinary
   text, and the tests assert behaviour rather than file-content shape. The defect was found by
   external review, not by this repository's own tooling.
-- **Deliverables:** a decision on the owning enforcement layer, and a check with fixtures. **The
-  layer is deliberately not chosen here**, because the incident does not settle it. The question
-  underneath: is unresolved merge metadata a *finding about the repository*, or a *hygiene
-  precondition* that should fail before the evaluator is asked anything? Candidates are a repository
-  hygiene command run by CI alongside the existing invariant checks, an `audit` finding category, or
-  an extension of an existing validation layer.
+- **Deliverables:** ~~a decision on the owning enforcement layer, and a check with fixtures. **The
+  layer is deliberately not chosen here**, because the incident does not settle it.~~ **Chosen
+  2026-08-29, and the question's own framing is what the measurement corrected.** It asked whether
+  unresolved merge metadata is *a finding about the repository* or *a hygiene precondition*. It is
+  both, because it is two signals: the committed content is a finding (P1, an `audit` finding
+  category — one of the three candidates named here), and the live conflicted tree is a
+  precondition (P2, the hygiene-command candidate, narrowed to a preflight because CI cannot
+  observe it at all). The third candidate, extending a validation layer, was rejected with
+  Standard 46 below.
+
+  **P1 is deliberately not a catalog rule.** The remaining discriminator is heuristic — see the
+  acceptance criteria — and promoting it would make that heuristic normative by implementation
+  accident rather than by a decision anyone took. Normative ownership is left open as
+  [#58](https://github.com/mikeycdavis/EngineeringStandards/issues/58), and *"leave it audit-only
+  permanently"* is among its legitimate answers.
+
+  **Standard 46 is rejected as the normative home**, measured against its own preamble: it scopes
+  itself to *"the prohibitions whose damage cannot be undone by a later commit"*. A committed
+  conflict marker is reversible and `18857e9` reversed this one. Putting the clause there would
+  widen the standard's stated scope in order to gain a rule, which is the kind of trade this
+  repository refuses elsewhere.
 - **Acceptance Criteria:**
-  - **Known positive:** a file containing genuine unresolved markers is detected.
+  - **Known positive:** the actual `8870a43` specimen — unfenced markers in Markdown — is reported.
+    The test uses that shape rather than an invented one.
   - **Known negative:** documentation that *mentions* conflict-marker syntax is not flagged —
     including issue #21 itself, this plan item, and any standard or design document explaining merge
     conflicts. A naive content scan would flag the very documents describing the rule, which is the
     use/mention defect ([ADR 0009](../adr/0009-detectors-distinguish-instances-of-a-subject-from-discussion-of-it.md))
     that has already shipped five times here.
+  - **A group is required, not a token.** An isolated `<<<<<<<` in prose is not enough to fire; an opener
+    and a terminator must both be present, at column 0, in order.
+  - **Non-Markdown tracked content is covered.** A fence is a Markdown construct; a `.mjs` or
+    `.json` file has none, so every column-0 group in it counts — including one wrapped in three
+    backticks, which are three backticks there and not a fence.
+  - **A second limitation, inherited rather than introduced, is disclosed with the first.** The
+    audit's existing readable-extension set decides which files the walk opens at all, so `.txt`,
+    `.xml` and `.csv` are outside this check because they are outside the audit. Both limits are
+    named in the finding's own message: a reader who knows about only one of them will read a clean
+    result as stronger than it is. A test pins the `.txt` case, which also keeps the untracked-file
+    test honest — written against a `.txt` it would have passed for the wrong reason.
+  - **The known miss is asserted, not papered over.** A genuine marker group inside a fenced block
+    is **not** reported, and a test pins that as the limitation rather than leaving it as untested
+    behaviour that might be mistaken for coverage.
   - The regression is a known-negative guard, not only a known-positive one.
-- **Verification:** `npm test` with both fixtures; `git diff --check` exits 0 on a clean tree.
+- **The discriminator is heuristic, and this is the reason P1 stays audit-only.** No git-native
+  mechanism separates an instance from an illustration, and the range-scoped form only defers the
+  problem by one commit:
+
+  ```text
+  git diff --check <empty-tree> <the-commit-that-adds-the-documentation>
+    doc.md:4: leftover conflict marker
+    doc.md:6: leftover conflict marker
+    doc.md:8: leftover conflict marker
+  ```
+
+  Those three lines are inside a fenced block in a document about merge conflicts. Git's `--check`
+  is fence-blind. Marker well-formedness does not separate them either: the `8870a43` specimen is
+  column-0, exactly seven characters, complete and ordered, in Markdown — and so is any textbook
+  example, including the ones in this item.
+
+  What is left is fenced-region exclusion, which is a trade rather than a solution. It catches the
+  real specimen, spares the documentation, and **misses a genuine group inside a fence**. The
+  finding says so in its own message, so absence is never read as proof of absence.
+- **Verification:** `npm test`. Seventeen tests in
+  [`test/conflict-markers.test.mjs`](../../test/conflict-markers.test.mjs) for P1, each building a
+  real repository — not a directory — because the detector asks the index which paths are tracked
+  and refuses to answer from the filesystem. Two more in
+  [`test/local-ci.test.mjs`](../../test/local-ci.test.mjs) for P2, one driving four conflicted
+  repositories through the real script and one holding the PowerShell twin to the same signals as
+  text. ~~`git diff --check` exits 0 on a clean tree.~~ **Withdrawn:** it exits 0 on a clean tree
+  holding committed markers too, so it verifies nothing here.
+- **Twelve mutants, all killed — and three of the tests were passing for the wrong reason until they
+  were.** Relaxing the grammar to accept a lone token, or a terminator with no separator, left the
+  suite green: those three negatives were written against a `.txt` fixture, and `.txt` is outside
+  the audit's readable-extension set, so nothing was ever scanned. They asserted an absence produced
+  by the file's name. Moving them to `.mjs` is what made them tests. Two more survivors were real
+  gaps in the same way: nothing isolated the index signal from the operation metadata (every P2
+  fixture had both, so a build that never asked the index passed), and nothing pinned the opener's
+  exact length independently of the separator's. Both now have a fixture of their own.
 - **Dependencies:** none.
 - **One specimen removed is not one class prevented.** `18857e9` deleted the markers that reached
   `develop` and the repository is currently clean. That establishes nothing about whether the next

--- a/scripts/ci-context.ps1
+++ b/scripts/ci-context.ps1
@@ -123,6 +123,56 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     throw "git was not found on PATH. It is required to materialise the CI context."
 }
 
+# An unresolved conflict is refused BEFORE the generic dirty-tree check, and by name.
+#
+# It would already be refused below: a conflicted tree is a dirty tree. But "the working tree has
+# uncommitted changes" sends a developer looking for an edit they forgot to commit, when what is
+# actually true is that a merge, cherry-pick, rebase or revert is still open. Issue #21's specimen
+# reached `develop` because three cherry-pick markers were committed while every gate reported
+# clean; this is the half of that defect that never gets to be committed, and naming it is the whole
+# value of checking it separately.
+#
+# TWO SIGNALS, because neither implies the other. `ls-files --unmerged` reports index stages, which
+# a delete/modify conflict produces over a file whose content holds no markers at all. The operation
+# metadata reports a paused operation, which survives even where every path has been staged. The
+# metadata list is deliberately not just MERGE_HEAD: the incident was a CHERRY-PICK, which writes
+# CHERRY_PICK_HEAD and no MERGE_HEAD, so a check written for merges alone would have missed the
+# specimen this exists for.
+#
+# WHERE GIT CANNOT ANSWER, THIS SAYS SO. `Invoke-Git` throws rather than returning empty, so an
+# unreadable index refuses the run instead of being read as an absent conflict. Failure to know is
+# never converted into a fact about the repository (ADR 0008).
+$unmerged = Invoke-Git @('-C', $RepoRoot, 'ls-files', '--unmerged') 'reading unmerged index entries; whether a conflict is open is unknown'
+$gitDir = Invoke-Git @('-C', $RepoRoot, 'rev-parse', '--absolute-git-dir') 'locating the git directory; whether a conflict is open is unknown'
+
+# One entry per operation that can pause with a conflict. AUTO_MERGE is written by the merge
+# machinery itself and is listed so a conflicted state mid-resolution is still named.
+$operations = @()
+foreach ($marker in @('MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'REBASE_HEAD', 'AUTO_MERGE')) {
+    if (Test-Path (Join-Path $gitDir $marker)) { $operations += $marker }
+}
+foreach ($marker in @('rebase-merge', 'rebase-apply', 'sequencer')) {
+    if (Test-Path (Join-Path $gitDir $marker) -PathType Container) { $operations += "$marker/" }
+}
+
+if ($unmerged -or $operations.Count -gt 0) {
+    $detail = ''
+    if ($operations.Count -gt 0) { $detail += "`n  operation in progress: $($operations -join ' ')" }
+    if ($unmerged) {
+        $paths = Invoke-Git @('-C', $RepoRoot, 'diff', '--name-only', '--diff-filter=U') 'listing unmerged paths'
+        $detail += "`n  unmerged paths:`n$($paths -split "`n" | ForEach-Object { "    $_" } | Out-String)"
+    }
+    throw @"
+this working tree has an unresolved conflict, and local CI verifies committed content at HEAD.
+
+Nothing about this state can reach a commit: git refuses to commit an unmerged index, and staging
+the files clears it. So the run is refused here rather than producing a verdict about a tree that
+does not yet exist.
+$detail
+Finish or abort the operation, then re-run.
+"@
+}
+
 $sha = Invoke-Git @('-C', $RepoRoot, 'rev-parse', 'HEAD') 'reading HEAD'
 $branch = Invoke-Git @('-C', $RepoRoot, 'rev-parse', '--abbrev-ref', 'HEAD') 'reading the current branch'
 

--- a/scripts/ci-context.sh
+++ b/scripts/ci-context.sh
@@ -58,6 +58,64 @@ command -v git >/dev/null 2>&1 || {
   exit 2
 }
 
+# An unresolved conflict is refused BEFORE the generic dirty-tree check, and by name.
+#
+# It would already be refused below: a conflicted tree is a dirty tree. But "the working tree has
+# uncommitted changes" sends a developer looking for an edit they forgot to commit, when what is
+# actually true is that a merge, cherry-pick, rebase or revert is still open. Issue #21's specimen
+# reached `develop` because three cherry-pick markers were committed while every gate reported
+# clean; this is the half of that defect that never gets to be committed, and naming it is the whole
+# value of checking it separately.
+#
+# TWO SIGNALS, because neither implies the other. `ls-files --unmerged` reports index stages, which
+# a delete/modify conflict produces over a file whose content holds no markers at all. The operation
+# metadata reports a paused operation, which survives even where every path has been staged. The
+# metadata list is deliberately not just MERGE_HEAD: the incident was a CHERRY-PICK, which writes
+# CHERRY_PICK_HEAD and no MERGE_HEAD, so a check written for merges alone would have missed the
+# specimen this exists for.
+#
+# WHERE GIT CANNOT ANSWER, THIS SAYS SO. An unreadable index is not an absent conflict. Reporting
+# `unknown` and refusing is the ADR 0008 seam's rule applied here: failure to know is never
+# converted into a fact about the repository.
+if ! unmerged="$(git -C "$repo_root" ls-files --unmerged 2>/dev/null)"; then
+  echo "whether this working tree holds an unresolved conflict is unknown: the index could not be read," >&2
+  echo "or this directory is not a git work tree." >&2
+  echo "That is not the same as a clean tree, so the run is refused rather than started." >&2
+  exit 2
+fi
+if ! git_dir="$(git -C "$repo_root" rev-parse --absolute-git-dir 2>/dev/null)"; then
+  echo "whether this working tree holds an unresolved conflict is unknown: the git directory could not be located." >&2
+  echo "That is not the same as a clean tree, so the run is refused rather than started." >&2
+  exit 2
+fi
+
+operations=""
+# One entry per operation that can pause with a conflict. AUTO_MERGE is written by the merge
+# machinery itself and is listed so a conflicted state mid-resolution is still named.
+for marker in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD REBASE_HEAD AUTO_MERGE; do
+  if [ -e "$git_dir/$marker" ]; then operations="$operations $marker"; fi
+done
+for marker in rebase-merge rebase-apply sequencer; do
+  if [ -d "$git_dir/$marker" ]; then operations="$operations $marker/"; fi
+done
+
+if [ -n "$unmerged" ] || [ -n "$operations" ]; then
+  cat >&2 <<EOF
+this working tree has an unresolved conflict, and local CI verifies committed content at HEAD.
+
+Nothing about this state can reach a commit: git refuses to commit an unmerged index, and staging
+the files clears it. So the run is refused here rather than producing a verdict about a tree that
+does not yet exist.
+EOF
+  [ -n "$operations" ] && printf '\n  operation in progress:%s\n' "$operations" >&2
+  if [ -n "$unmerged" ]; then
+    printf '\n  unmerged paths:\n' >&2
+    git -C "$repo_root" diff --name-only --diff-filter=U 2>/dev/null | sed 's/^/    /' >&2 || true
+  fi
+  printf '\nFinish or abort the operation, then re-run.\n' >&2
+  exit 2
+fi
+
 sha="$(git -C "$repo_root" rev-parse HEAD)"
 branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
 # Carried over rather than left pointing at the temporary clone: the pipeline records

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -2569,6 +2569,179 @@ function detectCommittedEnvFiles(files, repoRoot, repo, run) {
 }
 
 /**
+ * Committed conflict markers — P1 of issue #21, and deliberately NOT a catalog rule.
+ *
+ * VIEW: raw text (`textOf`). None of the three derived views applies, and saying which one was
+ * rejected is the ADR 0009 declaration this detector owes: a conflict marker is not a comment, not
+ * a language construct and not a string literal. It is a line-shaped artifact in the bytes. The
+ * specimen that reached `develop` was in Markdown, which has no derived view at all.
+ *
+ * WHAT THIS IS NOT. It is not `git diff --check`. That reads *added lines in a diff*, so it saw the
+ * markers while they were unstaged and went silent the moment `8870a43` committed them — which is
+ * the only state that ever reached the branch. Measured: on a clean tree holding committed markers
+ * it exits 0 and prints nothing.
+ *
+ * WHY A GROUP AND NOT A TOKEN. An opener alone is prose about conflicts. A group — opener, then a
+ * separator, then a terminator, in that order, each at column 0 and exactly seven characters — is
+ * the shape Git actually writes. Requiring the group is what keeps a sentence naming `<<<<<<<` from
+ * being a finding.
+ *
+ * WHY FENCED REGIONS ARE EXCLUDED, AND WHAT IT COSTS. A well-formed group is lexically identical to
+ * a textbook illustration of one; the `8870a43` specimen is column-0, seven characters, complete and
+ * correctly ordered, and so is every example in the documentation of this very check. No git-native
+ * mechanism separates them — `git diff --check` over the commit that ADDS the documentation reports
+ * its fenced example as three leftover markers. The one discriminator left is where the lines sit,
+ * and it is a trade rather than a solution: **a genuine group inside a fenced block is missed.** The
+ * finding says so in its own message, and `test/conflict-markers.test.mjs` asserts the miss rather
+ * than leaving it as untested behaviour a reader could mistake for coverage.
+ *
+ * That heuristic is exactly why this emits an audit finding carrying no `rule`. Binding it to the
+ * catalog would make the fence exclusion normative by implementation accident rather than by a
+ * decision anyone took; issue #58 owns that decision, and "leave it audit-only" is one of its
+ * legitimate answers.
+ *
+ * TWO BOUNDARIES, NOT ONE. The fence exclusion is this detector's own. The second is inherited and
+ * governs every content detector here: `TEXT_EXT` decides which files the walk reads at all, so
+ * `.txt`, `.xml` and `.csv` are outside this check because they are outside the audit. Both are
+ * named in the finding's message, because a reader who knows about only one of them will read a
+ * clean result as stronger than it is.
+ *
+ * TRACKED FILES ONLY, through the ADR 0008 seam. A marker group in an untracked scratch file is one
+ * developer's working state, not the repository's content. Where the index cannot be read,
+ * tracked-ness is unestablished and the detector says so rather than reporting either a violation or
+ * a pass. The candidate set is the intersection of the index and the walk, which is a disclosed
+ * narrowing rather than a silent one: content has to be read to be examined, so a file that is
+ * tracked but absent from this checkout — a sparse checkout, an unstaged deletion — is outside what
+ * this can see. Unlike `scm.no-committed-env-files`, whose question the index answers alone, there is
+ * no version of this check that reads content the walk never collected.
+ */
+const CONFLICT_OPEN = /^<{7}(?!<)/;
+const CONFLICT_BASE = /^\|{7}(?!\|)/;
+const CONFLICT_SEP = /^={7}(?!=)\s*$/;
+const CONFLICT_END = /^>{7}(?!>)/;
+// CommonMark allows up to three leading spaces and three or more fence characters. Both forms are
+// recognised because both appear in this repository, and a closing fence must use the same
+// character and be at least as long as the one that opened the block.
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+const FENCED_EXT = new Set([".md", ".markdown"]);
+
+/**
+ * Line numbers of every conflict-marker group in a file, ignoring fenced regions where the file
+ * type has them.
+ *
+ * Returns one entry per complete group. An opener with no terminator is not reported: it is either
+ * prose or a file so damaged that a marker group is the least of it, and reporting partial groups
+ * would reintroduce the token-level matching this check exists to avoid.
+ */
+function conflictGroups(text, fenced) {
+  const lines = text.split(/\r?\n/);
+  const groups = [];
+  let fence = null; // the opening run, when inside a fenced block
+  // `open` and `sep` deliberately survive a fenced block rather than resetting at its edge. A real
+  // conflict region can contain a fence -- the merge cut through a code example -- and pairing
+  // across it catches that case. The cost is theoretical: two column-0 marker lines of opposite
+  // kinds, in prose, on either side of a block.
+  let open = null;
+  let sep = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (fenced) {
+      const f = line.match(FENCE_OPEN);
+      if (fence !== null) {
+        // Closing requires the same character and at least the opening length; anything else is
+        // ordinary content inside the block, and out of scope.
+        if (f && f[1][0] === fence[0] && f[1].length >= fence.length) fence = null;
+        continue;
+      }
+      // A fence line is never itself a marker. Everything else outside a block falls through to
+      // the matching below, which is where the `8870a43` specimen lived: immediately after a
+      // closing fence, not inside one.
+      if (f) {
+        fence = f[1];
+        continue;
+      }
+    }
+    if (CONFLICT_OPEN.test(line)) {
+      open = i + 1;
+      sep = null;
+      continue;
+    }
+    if (open === null) continue;
+    // The diff3 style inserts a common-ancestor section between the opener and the separator. It is
+    // consumed rather than treated as a reset, so `merge.conflictStyle=diff3` is covered.
+    if (CONFLICT_BASE.test(line)) continue;
+    if (CONFLICT_SEP.test(line)) {
+      sep = i + 1;
+      continue;
+    }
+    if (sep !== null && CONFLICT_END.test(line)) {
+      groups.push({ open, end: i + 1 });
+      open = null;
+      sep = null;
+    }
+  }
+  return groups;
+}
+
+function detectConflictMarkers(files, repoRoot, repo, run) {
+  const { rel, textOf, addFinding } = run;
+
+  const scan = (f) => {
+    const t = textOf(f);
+    // A file nobody could read holds no markers only in the sense that nobody looked. The evidence
+    // surface already reports unread and truncated files for the run as a whole, so this adds no
+    // second channel for the same fact.
+    if (t.lost || !t.available) return [];
+    const fenced = FENCED_EXT.has(path.extname(f).toLowerCase());
+    return conflictGroups(t.text, fenced).map((g) => `${rel(f)}:${g.open}-${g.end}`);
+  };
+
+  const listed = repo.available ? trackedMatching(repoRoot, ["*"]) : { ok: false, files: null };
+  if (!listed.ok) {
+    // Same shape as scm.no-committed-env-files: say nothing when there is nothing concrete to name,
+    // so auditing a directory that is simply not a repository does not collect a warning on every
+    // run for a question it never asked. What is suppressed is noise, never a claim of cleanliness.
+    const anywhere = files.flatMap(scan).sort();
+    if (anywhere.length === 0) return;
+    addFinding({
+      id: "repository-evidence-unavailable",
+      category: "evidence-surface",
+      severity: "warning",
+      label: "OBSERVED",
+      evidence: anywhere,
+      message:
+        `Whether these files are tracked could not be established: ` +
+        `${repo.reason ?? "the repository index could not be read"}. Each holds a conflict-marker ` +
+        `group, but an untracked file is one developer's working state rather than repository ` +
+        `content, so this is reported as unknown rather than as a finding.`,
+      standardRef: R.search,
+    });
+    return;
+  }
+
+  const tracked = new Set(listed.files);
+  const hits = files.filter((f) => tracked.has(rel(f))).flatMap(scan).sort();
+  if (hits.length === 0) return;
+
+  addFinding({
+    id: "committed-conflict-markers",
+    category: "Unresolved merge conflicts",
+    severity: "warning",
+    label: "INFERRED",
+    evidence: hits,
+    message:
+      `${hits.length} conflict-marker group(s) in tracked files. Markdown fenced blocks are ` +
+      `outside this check, because documentation of merge conflicts is written in them and is ` +
+      `indistinguishable from the real thing; so are file types this audit does not read. A clean ` +
+      `result is therefore not proof that none exists.`,
+    remediation:
+      "Resolve the conflict and commit the resolution. `git diff --check` will not find these: it " +
+      "reads added lines in a diff, so it is silent once the markers are committed.",
+    standardRef: R.evidence,
+  });
+}
+
+/**
  * security.no-secrets-in-artifacts — Standard 16 R2, evaluated from 2.0.0 (Standard 46 R1).
  *
  * VIEW: `sourceOf` for code — comments removed, strings intact — because a credential lives inside
@@ -3246,6 +3419,7 @@ export async function main(args) {
   // repository, and asking twice would spend a second subprocess to learn the same thing.
   const repoAvailability = repositoryAvailable(root);
   const envCheck = detectCommittedEnvFiles(files, root, repoAvailability, run);
+  detectConflictMarkers(files, root, repoAvailability, run);
   detectSecretsInArtifacts(files, run);
   detectSwallowedExceptions(files, run);
   detectCertBypass(files, run);

--- a/test/conflict-markers.test.mjs
+++ b/test/conflict-markers.test.mjs
@@ -1,0 +1,361 @@
+/**
+ * Committed conflict markers are reported; documentation of them is not.
+ *
+ * Issue #21 framed this as one question about one layer. The measurement split it into two
+ * propositions that share a vocabulary and nothing else, and this file covers only the first:
+ * *this tracked file's committed content contains a conflict-marker group*. The second — *this
+ * working tree is mid-conflict* — cannot reach a commit at all, so it lives in the local preflight
+ * (`scripts/ci-context.sh` / `.ps1`) rather than here.
+ *
+ * They are disjoint, and each misses the other's case entirely. A delete/modify conflict leaves
+ * unmerged stages in the index over a file whose content holds no markers. A committed marker
+ * leaves a clean index and clean status. `git diff --check` sees neither: it reads added lines in a
+ * diff, so it went silent the moment `8870a43` committed the specimen this file is built from.
+ *
+ * The known-negative half is the hard half, and it is why every fixture here is a real repository
+ * rather than a directory. A well-formed group is lexically identical to an illustration of one, so
+ * the only discriminator left is where the lines sit — outside a fenced block, or inside it. That
+ * buys the real specimen and the real documentation at the price of a genuine group inside a fence,
+ * which is missed. The last test asserts the miss rather than leaving it as untested behaviour
+ * somebody could mistake for coverage.
+ *
+ * The markers are built with `repeat` rather than written out, so this file is not itself a
+ * specimen of what it tests.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(HERE, "..", "scripts", "standards.mjs");
+const AMPLE = 8_000_000;
+
+const OPEN = "<".repeat(7);
+const SEP = "=".repeat(7);
+const BASE = "|".repeat(7);
+const END = ">".repeat(7);
+const FENCE = "`".repeat(3);
+
+function cli(command, dir) {
+  const r = spawnSync(
+    process.execPath,
+    [CLI, command, `--dir=${dir}`, "--json", `--max-total-read-bytes=${AMPLE}`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return assert.fail(`${command} stdout was not JSON.\nstderr: ${r.stderr.slice(0, 2000)}`);
+  }
+}
+
+const findingsById = (json, id) => (json.findings ?? []).filter((f) => f.id === id);
+const markerEvidence = (json) =>
+  findingsById(json, "committed-conflict-markers").flatMap((f) => f.evidence ?? []);
+const unavailableEvidence = (json) =>
+  findingsById(json, "repository-evidence-unavailable").flatMap((f) => f.evidence ?? []);
+
+function git(root, args) {
+  const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8", windowsHide: true });
+  assert.equal(r.status, 0, `git ${args.join(" ")} failed: ${r.stderr}`);
+}
+
+/**
+ * Build a repository whose files are `files`, commit everything except `untracked`, and run the
+ * audit over it.
+ *
+ * A real repository rather than a directory, because the detector asks the index which paths are
+ * tracked and refuses to answer from the filesystem. A fixture that skipped `git init` would
+ * exercise the unavailable branch on every test and prove nothing about the other one.
+ */
+async function withRepo(files, fn, { init = true, untracked = [] } = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "conflict-markers-"));
+  try {
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await writeFile(path.join(root, "src", "index.ts"), "export const x = 1;\n");
+    await writeFile(path.join(root, "README.md"), "# Fixture\n\nA repository built for one test.\n");
+    for (const [rel, body] of Object.entries(files)) {
+      await mkdir(path.dirname(path.join(root, rel)), { recursive: true });
+      await writeFile(path.join(root, rel), body);
+    }
+    if (init) {
+      git(root, ["init", "--quiet"]);
+      git(root, ["config", "user.email", "fixture@example.invalid"]);
+      git(root, ["config", "user.name", "fixture"]);
+      git(root, ["config", "core.autocrlf", "false"]);
+      const add = ["add", "--"];
+      for (const rel of ["src/index.ts", "README.md", ...Object.keys(files)]) {
+        if (!untracked.includes(rel)) add.push(rel);
+      }
+      git(root, add);
+      git(root, ["commit", "--quiet", "-m", "fixture"]);
+    }
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+/** The `8870a43` shape: a closing fence, then a marker group in ordinary Markdown prose. */
+const REAL_SPECIMEN = [
+  "# 08 — Open defects",
+  "",
+  "### An item",
+  "",
+  `${FENCE}bash`,
+  "gh api repos/:owner/:repo/actions/jobs/93929943347",
+  FENCE,
+  `${OPEN} HEAD`,
+  "The first command verifies the deliverable. The second and third verify the *absence* of the",
+  "evidence the acceptance criterion required.",
+  SEP,
+  `${END} 344d15a (An adoption attempt found three defects; two of them were new)`,
+  "- **Dependencies:** account-side restoration.",
+  "",
+].join("\n");
+
+/** The canonical shape of documentation about the subject: the same bytes, inside a fence. */
+const CANONICAL_DOC = [
+  "# Explaining merge conflicts",
+  "",
+  "An unresolved conflict looks like this:",
+  "",
+  `${FENCE}text`,
+  `${OPEN} HEAD`,
+  "ours",
+  SEP,
+  "theirs",
+  `${END} other-branch`,
+  FENCE,
+  "",
+  "Resolve it by choosing one side and deleting the markers.",
+  "",
+].join("\n");
+
+// ------------------------------------------------------------------- falsifier 1: the real thing
+
+test("the unfenced Markdown specimen from 8870a43 is reported", async () => {
+  await withRepo({ "artifacts/08.md": REAL_SPECIMEN }, (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(
+      markerEvidence(json),
+      ["artifacts/08.md:8-12"],
+      "the specimen that actually reached develop was not reported",
+    );
+  });
+});
+
+test("the finding says fenced content is outside the check, so absence is not proof", async () => {
+  await withRepo({ "artifacts/08.md": REAL_SPECIMEN }, (root) => {
+    const json = cli("audit", root);
+    const [finding] = findingsById(json, "committed-conflict-markers");
+    assert.ok(finding, "no finding to read");
+    assert.equal(finding.label, "INFERRED", "a heuristic reported as OBSERVED");
+    assert.equal(finding.rule, null, "an audit heuristic must not be bound to a catalog rule");
+    assert.match(finding.message, /fenced blocks are\s+outside this check/);
+    assert.match(finding.message, /file types this audit does not read/);
+    assert.match(finding.message, /not proof that none exists/);
+  });
+});
+
+// -------------------------------------------------------------- falsifier 2: the known negative
+
+test("the canonical fenced documentation example is not reported", async () => {
+  await withRepo({ "docs/merge-conflicts.md": CANONICAL_DOC }, (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(
+      markerEvidence(json),
+      [],
+      "documentation explaining the subject was reported as an instance of it",
+    );
+  });
+});
+
+test("a document that both explains and contains one reports only the unfenced group", async () => {
+  // The non-vacuity partner for the test above: the same file holds a fenced illustration and a
+  // real group, so a detector that had simply stopped reading Markdown would fail here.
+  const mixed = [CANONICAL_DOC, "", `${OPEN} HEAD`, "left", SEP, "right", `${END} other`, ""].join("\n");
+  await withRepo({ "docs/merge-conflicts.md": mixed }, (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(markerEvidence(json), ["docs/merge-conflicts.md:16-20"]);
+  });
+});
+
+// --------------------------------------------------------- falsifier 3: a group, never a token
+
+test("an isolated opener in prose is not enough to fire", async () => {
+  const prose = [
+    "# Notes",
+    "",
+    `A conflict begins with a line of seven less-than characters, ${OPEN}, followed by a label.`,
+    "",
+    `${OPEN} HEAD`,
+    "and nothing closes it",
+    "",
+  ].join("\n");
+  await withRepo({ "docs/notes.md": prose }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), [], "a lone opener was reported as a group");
+  });
+});
+
+test("an opener and a separator with no terminator is not a group", async () => {
+  const partial = ["x", `${OPEN} HEAD`, "a", SEP, "b", ""].join("\n");
+  await withRepo({ "src/partial.mjs": partial }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), []);
+  });
+});
+
+test("an opener and a terminator with no separator between them is not a group", async () => {
+  const partial = ["x", `${OPEN} HEAD`, "a", `${END} other`, ""].join("\n");
+  await withRepo({ "src/partial.mjs": partial }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), []);
+  });
+});
+
+test("eight characters is not a marker; Git writes exactly seven", async () => {
+  const eight = ["x", `${"<".repeat(8)} HEAD`, "a", "=".repeat(8), "b", `${">".repeat(8)} other`, ""].join("\n");
+  await withRepo({ "src/eight.mjs": eight }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), []);
+  });
+});
+
+test("a longer run is not a marker even when the rest of the group is well formed", async () => {
+  // The narrower case the test above does not reach: mutation testing showed that relaxing the
+  // OPENER alone to "seven or more" survived, because that fixture lengthened all three lines and
+  // the separator's own exactness rejected it anyway. Each of the three carries the constraint
+  // independently, and an ASCII divider of eight or more angle brackets above ordinary prose is
+  // exactly what would start firing without it.
+  const mixed = ["x", `${"<".repeat(9)} decorative`, "a", SEP, "b", `${END} other`, ""].join("\n");
+  await withRepo({ "src/divider.mjs": mixed }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), []);
+  });
+});
+
+// ------------------------------------------------------ falsifier 4: non-Markdown is covered
+
+test("non-Markdown tracked content is covered", async () => {
+  const group = ["const a = 1;", `${OPEN} HEAD`, "const b = 2;", SEP, "const b = 3;", `${END} other`, ""].join("\n");
+  await withRepo({ "src/merged.mjs": group, "config/data.json": group }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), ["config/data.json:2-6", "src/merged.mjs:2-6"]);
+  });
+});
+
+test("a file type the audit does not read is outside this check - the second limitation", async () => {
+  // Not a property of this detector. `TEXT_EXT` decides which files the walk reads at all, and it
+  // governs every content detector in this tool; `.txt`, `.xml` and `.csv` are outside it. Pinned
+  // here because the falsifier for "non-Markdown content is covered" would otherwise read as a
+  // stronger claim than the code makes, and because the untracked-file test below would be vacuous
+  // if it used one of these extensions - the group would go unreported for the wrong reason.
+  const group = ["x", `${OPEN} HEAD`, "a", SEP, "b", `${END} other`, ""].join("\n");
+  await withRepo({ "data/notes.txt": group }, (root) => {
+    assert.deepEqual(
+      markerEvidence(cli("audit", root)),
+      [],
+      "the readable-extension set changed; this limitation and the finding's message move together",
+    );
+  });
+});
+
+test("a backtick run in a non-Markdown file does not shelter a group", async () => {
+  // A fence is a Markdown construct. Three backticks in a .mjs file are three backticks, so the
+  // same bytes that would be excluded in a .md are reported here — which is what makes the exclusion a
+  // property of the file type rather than of the characters.
+  const withTicks = ["x", FENCE, `${OPEN} HEAD`, "a", SEP, "b", `${END} other`, FENCE, ""].join("\n");
+  await withRepo({ "src/ticks.mjs": withTicks }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), ["src/ticks.mjs:3-7"]);
+  });
+});
+
+test("the diff3 conflict style is covered", async () => {
+  const diff3 = [
+    "x",
+    `${OPEN} HEAD`,
+    "ours",
+    `${BASE} merged common ancestors`,
+    "base",
+    SEP,
+    "theirs",
+    `${END} other`,
+    "",
+  ].join("\n");
+  await withRepo({ "src/diff3.mjs": diff3 }, (root) => {
+    assert.deepEqual(markerEvidence(cli("audit", root)), ["src/diff3.mjs:2-8"]);
+  });
+});
+
+// ---------------------------------------------------------------- tracked files only
+
+test("an untracked file holding a real group is not reported", async () => {
+  const group = ["x", `${OPEN} HEAD`, "a", SEP, "b", `${END} other`, ""].join("\n");
+  await withRepo(
+    { "src/scratch.mjs": group },
+    (root) => {
+      assert.deepEqual(
+        markerEvidence(cli("audit", root)),
+        [],
+        "one developer's untracked working state was reported as repository content",
+      );
+    },
+    { untracked: ["src/scratch.mjs"] },
+  );
+});
+
+test("where the index cannot be read, tracked-ness is unknown rather than clean", async () => {
+  const group = ["x", `${OPEN} HEAD`, "a", SEP, "b", `${END} other`, ""].join("\n");
+  await withRepo(
+    { "src/notes.mjs": group },
+    (root) => {
+      const json = cli("audit", root);
+      assert.deepEqual(markerEvidence(json), [], "a finding was asserted over an unreadable index");
+      assert.ok(
+        unavailableEvidence(json).includes("src/notes.mjs:2-6"),
+        "absence of the repository was reported as absence of the marker",
+      );
+    },
+    { init: false },
+  );
+});
+
+// ------------------------------------------- the known limitation, asserted rather than implied
+
+test("a genuine group inside a fence is NOT reported — the recorded limitation", async () => {
+  // This is a real miss, not a preference. A conflict can land inside a fenced example, and this
+  // check will not see it. The test exists so the gap is a pinned, deliberate property rather than
+  // untested behaviour a later reader mistakes for coverage. Issue #58 owns whether the trade is
+  // acceptable as a normative rule; until then the finding's own message discloses it.
+  const insideFence = [
+    "# A plan item",
+    "",
+    `${FENCE}text`,
+    `${OPEN} HEAD`,
+    "ours",
+    SEP,
+    "theirs",
+    `${END} other`,
+    FENCE,
+    "",
+  ].join("\n");
+  await withRepo({ "artifacts/08.md": insideFence }, (root) => {
+    assert.deepEqual(
+      markerEvidence(cli("audit", root)),
+      [],
+      "the fence exclusion changed; update issue #58 and this test together",
+    );
+  });
+});
+
+// ------------------------------------------------------------------------------- anti-vacuity
+
+test("a repository with no markers raises nothing", async () => {
+  await withRepo({ "docs/plain.md": "# Plain\n\nNothing to see.\n" }, (root) => {
+    const json = cli("audit", root);
+    assert.deepEqual(markerEvidence(json), []);
+    assert.deepEqual(unavailableEvidence(json), []);
+  });
+});

--- a/test/local-ci.test.mjs
+++ b/test/local-ci.test.mjs
@@ -348,6 +348,170 @@ test("a project name cannot choose what the context builder deletes", (t) => {
   assert.match(ps, /not a usable project name/, "the PowerShell twin does not name the refusal");
 });
 
+test("an unresolved conflict is refused by name, before the generic dirty-tree message", (t) => {
+  // P2 of issue #21. A conflicted tree is already a dirty tree, so this changes no verdict — it
+  // changes the sentence. "The working tree has uncommitted changes" sends a developer looking for
+  // an edit they forgot to commit; what is actually true is that a merge, cherry-pick, rebase or
+  // revert is still open.
+  //
+  // Driven for real, because the two signals it reads are exactly the ones a text assertion cannot
+  // tell apart. A delete/modify conflict leaves unmerged index stages over a file whose content
+  // holds NO conflict markers, so the audit-side check for committed markers cannot see it; and
+  // once the paths are staged the index goes clean while the operation is still open, so
+  // `ls-files --unmerged` cannot see that. Each case below is one of those halves.
+  const bash = spawnSync("bash", ["-c", "exit 0"], { encoding: "utf8" });
+  if (bash.error || bash.status !== 0) {
+    t.skip("bash is unavailable, so the POSIX twin cannot be driven here");
+    return;
+  }
+
+  const sandbox = mkdtempSync(path.join(tmpdir(), "ci-context-conflict-"));
+  const git = (cwd, args) => spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  const build = (name) => {
+    const repo = path.join(sandbox, name);
+    mkdirSync(repo);
+    git(repo, ["init", "--quiet"]);
+    git(repo, ["config", "user.email", "fixture@example.invalid"]);
+    git(repo, ["config", "user.name", "fixture"]);
+    git(repo, ["config", "core.autocrlf", "false"]);
+    return repo;
+  };
+  const context = (repo, project) =>
+    spawnSync("bash", [path.join(ROOT, "scripts/ci-context.sh"), repo, project], {
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: path.join(sandbox, "temp") },
+    });
+
+  try {
+    mkdirSync(path.join(sandbox, "temp"));
+
+    // A delete/modify conflict: unmerged stages, and a file with no markers in it at all.
+    const del = build("deletemodify");
+    writeFileSync(path.join(del, "k.txt"), "base\n");
+    git(del, ["add", "k.txt"]);
+    git(del, ["commit", "--quiet", "-m", "base"]);
+    git(del, ["checkout", "--quiet", "-b", "other"]);
+    git(del, ["rm", "--quiet", "k.txt"]);
+    git(del, ["commit", "--quiet", "-m", "delete"]);
+    git(del, ["checkout", "--quiet", "-"]);
+    writeFileSync(path.join(del, "k.txt"), "base\nmodified\n");
+    git(del, ["commit", "--quiet", "-a", "-m", "modify"]);
+    git(del, ["merge", "other"]);
+
+    const conflicted = context(del, "conflict-a");
+    assert.notEqual(conflicted.status, 0, "a conflicted working tree was accepted");
+    assert.match(
+      `${conflicted.stderr}`,
+      /unresolved conflict/,
+      "a conflicted tree was refused as a generic dirty tree, which names the wrong cause",
+    );
+    assert.doesNotMatch(
+      readFileSync(path.join(del, "k.txt"), "utf8"),
+      /^<{7}/m,
+      "the fixture leaked marker text, so this no longer proves the marker-free case is caught",
+    );
+
+    // The other half: the paths are staged, so the index is clean and only the operation metadata
+    // is left. A check written as `git rev-parse --verify MERGE_HEAD` would also miss this one,
+    // because a cherry-pick writes CHERRY_PICK_HEAD and no MERGE_HEAD.
+    const cp = build("cherrypick");
+    writeFileSync(path.join(cp, "f.txt"), "one\n");
+    git(cp, ["add", "f.txt"]);
+    git(cp, ["commit", "--quiet", "-m", "base"]);
+    git(cp, ["checkout", "--quiet", "-b", "side"]);
+    writeFileSync(path.join(cp, "f.txt"), "side\n");
+    git(cp, ["commit", "--quiet", "-a", "-m", "side"]);
+    git(cp, ["checkout", "--quiet", "-"]);
+    writeFileSync(path.join(cp, "f.txt"), "trunk\n");
+    git(cp, ["commit", "--quiet", "-a", "-m", "trunk"]);
+    git(cp, ["cherry-pick", "side"]);
+    git(cp, ["add", "f.txt"]); // resolution staged; the cherry-pick is still open
+
+    assert.equal(git(cp, ["ls-files", "--unmerged"]).stdout.trim(), "", "the fixture is not staged");
+    const paused = context(cp, "conflict-b");
+    assert.notEqual(paused.status, 0, "a paused cherry-pick with a clean index was accepted");
+    assert.match(
+      `${paused.stderr}`,
+      /operation in progress:[^\n]*CHERRY_PICK_HEAD/,
+      "the open operation was not named",
+    );
+
+    // A third shape, and the one that makes the index signal independent rather than redundant: a
+    // conflicted `git stash pop` leaves unmerged stages and NO MERGE_HEAD or CHERRY_PICK_HEAD. The
+    // operation list catches it here only because AUTO_MERGE is on it, and AUTO_MERGE is written by
+    // a merge strategy rather than promised by the porcelain — so an index that is never consulted
+    // would make this case depend on which strategy resolved the stash.
+    const st = build("stashpop");
+    writeFileSync(path.join(st, "f.txt"), "one\n");
+    git(st, ["add", "f.txt"]);
+    git(st, ["commit", "--quiet", "-m", "base"]);
+    writeFileSync(path.join(st, "f.txt"), "stashed\n");
+    git(st, ["stash", "--quiet"]);
+    writeFileSync(path.join(st, "f.txt"), "other\n");
+    git(st, ["commit", "--quiet", "-a", "-m", "other"]);
+    git(st, ["stash", "pop"]);
+
+    assert.notEqual(git(st, ["ls-files", "--unmerged"]).stdout.trim(), "", "the fixture is not conflicted");
+    assert.ok(
+      !existsSync(path.join(st, ".git", "MERGE_HEAD")) &&
+        !existsSync(path.join(st, ".git", "CHERRY_PICK_HEAD")),
+      "the fixture grew merge metadata, so it no longer isolates the index signal",
+    );
+    const stashed = context(st, "conflict-d");
+    assert.notEqual(stashed.status, 0, "a conflicted stash pop was accepted");
+    assert.match(`${stashed.stderr}`, /unresolved conflict/, "the refusal does not name the cause");
+
+    // AUTO_MERGE removed, leaving unmerged stages and no operation metadata whatsoever. That is
+    // what this same conflict looks like under a git old enough not to write it, and it is the only
+    // fixture here in which the index is the ONLY signal — without it, a build that never asked the
+    // index would pass every test in this file while missing a whole class of conflicted tree.
+    rmSync(path.join(st, ".git", "AUTO_MERGE"), { force: true });
+    assert.notEqual(git(st, ["ls-files", "--unmerged"]).stdout.trim(), "", "the stages went away too");
+    const indexOnly = context(st, "conflict-e");
+    assert.notEqual(indexOnly.status, 0, "unmerged stages with no metadata were read as a clean tree");
+    assert.match(`${indexOnly.stderr}`, /unresolved conflict/, "the index signal alone does not refuse");
+    assert.doesNotMatch(
+      `${indexOnly.stderr}`,
+      /operation in progress/,
+      "the fixture still has metadata, so this does not isolate the index signal",
+    );
+
+    // Unavailable is not clean. A directory that is not a work tree cannot answer the question, and
+    // the refusal says so rather than starting a run over an unexamined tree (ADR 0008).
+    const bare = path.join(sandbox, "notarepo");
+    mkdirSync(bare);
+    const unknown = context(bare, "conflict-c");
+    assert.notEqual(unknown.status, 0, "a directory that cannot answer was treated as clean");
+    assert.match(`${unknown.stderr}`, /unknown/, "an unanswerable question was not reported as unknown");
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("both context builders read the same conflict signals", () => {
+  // The PowerShell twin cannot be driven here, so it is held to the same alphabet as text — the
+  // limitation this file already records for every environment assertion. Both halves are named:
+  // the index signal misses a staged resolution, and the metadata signal misses nothing about a
+  // cherry-pick only because CHERRY_PICK_HEAD is listed beside MERGE_HEAD.
+  for (const file of ["scripts/ci-context.ps1", "scripts/ci-context.sh"]) {
+    const text = withoutComments(read(file));
+    assert.match(text, /ls-files['", ]+--unmerged/, `${file} never asks the index about a conflict`);
+    for (const marker of ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "REBASE_HEAD", "AUTO_MERGE"]) {
+      assert.match(text, new RegExp(marker), `${file} does not look for ${marker}`);
+    }
+    for (const dir of ["rebase-merge", "rebase-apply", "sequencer"]) {
+      assert.match(text, new RegExp(dir), `${file} does not look for ${dir}`);
+    }
+    assert.match(text, /unresolved conflict/, `${file} does not name the cause`);
+    // Ordering, held as text in both twins: the specific message has to come first, or the generic
+    // one answers a question the developer did not ask.
+    assert.ok(
+      text.indexOf("unresolved conflict") < text.indexOf("uncommitted changes"),
+      `${file} reports a conflicted tree as a generic dirty tree`,
+    );
+  }
+});
+
 test("the context is removed by exact path and never by a sweep of the temp directory", () => {
   // The same rule as container teardown: this can remove what this run created and nothing else.
   for (const file of ["scripts/ci.ps1", "scripts/ci.sh", "scripts/verify-materialisation.ps1"]) {


### PR DESCRIPTION
Issue #21 asked which layer detects unresolved merge-conflict state. The measurement answered by
splitting the question, and by falsifying the mechanism the item recommended.

## `git diff --check` cannot protect the specimen this item exists for

| State | `git diff --check` |
| --- | --- |
| Markers unstaged | rc 2, names all three lines |
| Markers committed — **what reached `develop`** | **rc 0, silent** |

It reads *added lines in a diff*, not repository content. The item's Evidence line recommending it
is withdrawn and corrected in place rather than deleted.

## Two propositions, two owners, and neither sees the other's case

| | Proposition | Owner | Reaches `develop`? |
| --- | --- | --- | --- |
| **P1** | this tracked file's committed content contains a conflict-marker group | an `audit` finding, `INFERRED`, **no catalog rule** | **yes — it did** |
| **P2** | this working tree is mid-conflict | a preflight in `scripts/ci-context.sh` / `.ps1` | no |

A delete/modify conflict leaves unmerged stages over a file holding **no markers at all**. A
committed marker leaves a clean index, clean status, and no metadata. P2 also cannot reach CI even
in principle: git refuses to commit an unmerged index, and `git add` clears it — the state is erased
by the act that would carry it forward.

## P1 is audit-only on purpose

A well-formed group is lexically identical to an illustration of one. The `8870a43` specimen is
column-0, exactly seven characters, complete and ordered, in Markdown — and so is every textbook
example. Range-scoped `--check` looked like it dissolved this and only defers it by one commit:

```
git diff --check <empty-tree> <the-commit-that-adds-the-documentation>
  doc.md:4: leftover conflict marker
  doc.md:6: leftover conflict marker
  doc.md:8: leftover conflict marker
```

Those lines are inside a fenced block in a document about merge conflicts. Git's `--check` is
fence-blind.

What is left is fenced-region exclusion, a trade rather than a solution: it catches the real
specimen, spares the documentation, and **misses a genuine group inside a fence**. Binding that to
the catalog would make the trade normative by implementation accident, so the finding carries no
`rule` and #58 owns the decision — *"leave it audit-only"* being one of its legitimate answers.
**Standard 46 is measured and rejected as the home**: it scopes itself to *"the prohibitions whose
damage cannot be undone by a later commit"*, and `18857e9` undid this one.

Two limitations, both disclosed in the finding's own message: fenced blocks, and file types the
audit does not read.

## P2 reads both signals, because each misses cases the other catches

`git ls-files --unmerged`, plus `MERGE_HEAD`, `CHERRY_PICK_HEAD`, `REVERT_HEAD`, `REBASE_HEAD`,
`AUTO_MERGE`, `rebase-merge/`, `rebase-apply/`, `sequencer/`. The incident was a **cherry-pick**, so
a probe written as `git rev-parse --verify MERGE_HEAD` would have missed it. A staged resolution
empties the index while the operation is still open; a conflicted `git stash pop` writes no merge
metadata at all. The refusal runs ahead of every other repository read, so a directory that cannot
answer is refused as `unknown` rather than failing later with git's own unexplained error.

## Twelve mutants, all killed — and three tests were passing for the wrong reason

Relaxing the grammar to accept a lone token, or a terminator with no separator, left the suite
green. Those negatives were written against a `.txt` fixture, and `.txt` is outside the audit's
readable-extension set, so nothing was ever scanned: they asserted an absence produced by the file's
name. Two further survivors were the same shape — nothing isolated the index signal from the
operation metadata, and nothing pinned the opener's exact length independently of the separator's.
Each now has its own fixture.

## Verification

- Local CI **PASSED** at `b057b7f` — inventory, fidelity, policy, diagrams, test, audit; `validate`
  advisory-failed as designed.
- **458 tests, 454 passing, 0 failures, 4 skipped.**
- `validate` unchanged at 14 passed / 4 failed / 32 skipped — the four standing human rejections.
- Zero findings against this repository's own content, including the `08` section this change
  amends, which now contains several fenced marker groups of its own.

Reproduced and settled for issue #21; closed deliberately after the gate rather than by this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
