### PR TITLE
Advice that assumes a state it cannot see is executed, not questioned (#32)

### DIFF
--- a/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
+++ b/artifacts/project-plan-breakdown/08-open-defects-and-deferred-tracks.md
@@ -2439,7 +2439,53 @@ falsifies, and renaming it would erase the record of a framing this item had to 
 
 ### Make remediation carry the sequencing its repository state requires
 
-- **Status:** READY
+- **Status:** COMPLETE — 2026-08-29. The remedy is state-free conditional remediation, and the
+  measurement is what ruled the alternatives out rather than a preference between them.
+
+  **The same rule, two states, byte-identical advice — while the framework already distinguishes
+  them.** Reproduced at `6662262` on two real repositories built for the comparison:
+
+  | State | What `init` says next | What `validate` emits for `planning.breakdown-directory` |
+  | --- | --- | --- |
+  | greenfield | *"Run /plan-structure and /plan-handoff, then standards validate."* | *"Run /plan-structure and /plan-handoff, writing each top-level section…"* |
+  | reconstruction-required | *"Run the project-reconstruction skill (Standard 44). **Do NOT author a plan** as though this project were starting now."* | **the same string, byte for byte** |
+
+  So the sequencing was never missing from the framework. It was missing from the layer that emits
+  the remediation, and `validate` cannot supply it: `detectMode` has exactly one caller, `runInit`,
+  and neither `audit` nor `validate` computes the repository's mode at all.
+
+  **Following the current remediation erases the evidence that ordering was needed.** Measured by
+  doing it — authoring `00-overview.md` and one section file in the reconstruction fixture, with no
+  reconstruction:
+
+  ```text
+  BEFORE  Mode: reconstruction-required   Next: ... Do NOT author a plan ...
+  AFTER   Mode: existing-with-plan        Next: Normalise the existing plan ...; do not replace it.
+          planning.breakdown-directory: failed -> passed
+  ```
+
+  The defect is **self-concealing**, and that is what settles it as more than presentation. Acting on
+  the under-specified advice moves the repository into a state whose own next step is to *preserve*
+  the material [Standard 44](../../standards/44-existing-project-reconstruction.md) R11 says is not
+  evidence. Nothing afterwards reports that reconstruction was ever required.
+
+  **Rule-intrinsic sequencing and repository-state-dependent sequencing are different problems, and
+  only the second is this item's.** Seven of the fifty catalog remediations already carry an order in
+  prose — `security.no-secrets-in-artifacts` (*"Replace the value… then rotate"*),
+  `quality.dead-code` (*"Confirm reachability, then delete"*), `data.migration-rollback`,
+  `verification.before-completion`, `testing.no-weakening-to-pass`, `security.no-sql-concat`,
+  `reconstruction.open-questions`. Those orders are knowable from the rule alone, so structure could
+  carry them. This one is not, and **structuring the string would only have made the wrong advice
+  easier to execute**: machine-readable steps resting on a prerequisite the producer cannot see are
+  still wrong.
+
+  **No envelope or schema change.** [Standard 25](../../standards/25-validator-output.md) R3's
+  `remediation` field is unchanged in shape and in type, and no consumer has to learn anything new.
+  What changed is what a catalog author is permitted to write into it, which is
+  [Standard 27](../../standards/27-rule-catalog.md)'s business.
+
+  **Previously: READY.**
+- **Superseded status line:** READY
 - **Tracked by:** GitHub issue
   [#32](https://github.com/mikeycdavis/EngineeringStandards/issues/32)
 - **Evidence:** open as of 2026-08-16, verified at `e842a5a`.
@@ -2477,13 +2523,26 @@ falsifies, and renaming it would erase the record of a framing this item had to 
   material without the reconstruction evidence that gives it meaning. **The defective part is the
   remediation, not the finding** — `planning.breakdown-directory` failing in the reconstruction state
   may well be correct, and "make reconstruction pass" is explicitly out of scope.
-- **Deliverables:** a measured decision among the remediation alternatives, the normative invariant,
-  implementation of the selected mechanism, and regression coverage over the reconstruction state.
-  **The mechanism is deliberately not chosen here**, but the candidates are no longer equally
-  motivated. State-conditional remediation and a reconstruction-specific remediation string are the
-  two the specimen directly supports. **Suppression is not**, because the finding may be legitimate;
-  a deeper applicability change stays open for measurement but is no longer implied, since it was
-  implied only by a contradiction that does not exist.
+- **Deliverables:** ~~a measured decision among the remediation alternatives… **The mechanism is
+  deliberately not chosen here**~~ **Chosen 2026-08-29: state-free conditional remediation**, plus
+  [Standard 27](../../standards/27-rule-catalog.md) R6 as the normative invariant and regression
+  coverage over both states.
+
+  The remediation states the prerequisite as a *condition* and never claims which branch applies. It
+  is therefore true in every state, needs no mode signal, and asserts no repository state — which is
+  what keeps it inside [ADR 0008](../adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md).
+
+  **State-conditional remediation is rejected for this slice, and the measurement is why it is the
+  hardest candidate rather than the obvious one.** #53's precedent permits narrowing advice on
+  *measured* state. `detectMode` is labelled `[INFERRED]` by `init` itself, so specialising prose on
+  it would make a detector depend on a heuristic classification of intent — the fabrication ADR 0008
+  forbids, arriving through the fix. A later slice may earn result-specific text from a genuinely
+  measured signal (implementation markers present **and** no
+  `artifacts/project-baseline/reconstructed-baseline.md` is observable, where the *mode* is not);
+  this item does not need one, and introducing a second state classifier to close it would be paying
+  a permanent cost for a sentence.
+
+  **Suppression stays rejected** for the reason already recorded: the finding may be legitimate.
 - **Acceptance Criteria:**
   - The invariant is recorded normatively, in a form a future rule author is bound by: *for every
     repository state the framework explicitly recognises, remediation must preserve the
@@ -2496,7 +2555,32 @@ falsifies, and renaming it would erase the record of a framing this item had to 
     sequencing `init`'s `nextStep` establishes for that same state.
   - `planning.breakdown-directory` remains a legitimate finding in the reconstruction state unless a
     measured decision says otherwise.
-- **Verification:** `npm test` with the reconstruction-state fixture; the self-audit unchanged.
+  - **A second live specimen is covered, not only the one this item was filed for.**
+    `architecture.project-manifest` fails in the same state with *"PROJECT.md still carries the
+    template's own prompts"*, and told the reader to *"Copy templates/PROJECT.md to the repository
+    root and fill it in"* — over a file `init` had already created. Its first step is a no-op at
+    best and destroys work at worst, since a human following it has no `--force-overwrite` guard.
+    Creating a manifest and completing a template-derived one are now distinguished without
+    asserting which holds. The item as filed named only `planning.handoff`, which is
+    `manual-review` and emits nothing.
+  - **No detector acquires a `detectMode` dependency**, and a test asserts it, so specialising prose
+    can never be the reason a heuristic classification enters the evaluation path.
+- **Verification:** `npm test`. Nine tests in
+  [`test/remediation-state.test.mjs`](../../test/remediation-state.test.mjs) build real repositories
+  in both states, run the real `init` and the real `validate`, and read the remediation out of the
+  emitted envelope. Asserting the catalog strings directly would have passed while the envelope said
+  something else, which is the layer the defect lived in. Two of the nine are anti-vacuity: that the
+  fixtures really do land in different modes, and that both rules really do fail in both.
+- **Seven mutants, all killed.** Restoring either original string, dropping the
+  no-branch-claimed disclaimer, emitting the branches in the wrong order, dropping the greenfield
+  branch, adding `detectMode` to `standards.mjs`'s imports, and making `init` stop distinguishing
+  the two states.
+- **`planning.handoff` is knowingly left alone, and this is the reason rather than an oversight.**
+  Its remediation reads *"Run /plan-handoff over the breakdown, or reproduce its behaviour
+  manually"* — which names the breakdown as its object, so where there is none the instruction is
+  inapplicable rather than harmful. That is a weaker case than either specimen fixed here, and the
+  item recorded it from the start as catalog-wide scope evidence rather than a live one. Standard 27
+  R6 now binds it if it is ever rewritten.
 - **Dependencies:** none. **Do not modify rule, remediation, or reconstruction semantics before the
   mechanism is measured and selected.**
 - **Boundaries, recorded so they are not crossed later.** Section 04 owns the compliance and policy

--- a/rules/architecture.json
+++ b/rules/architecture.json
@@ -14,7 +14,7 @@
       "introducedIn": "1.0.0",
       "description": "PROJECT.md or artifacts/project-manifest.md records purpose, stack, commands, environments, integrations, architectural rules, artifact locations, and current state.",
       "rationale": "It is the file a fresh engineer or agent reads first, and nothing else answers what this is and what state it is in.",
-      "remediation": "Copy templates/PROJECT.md to the repository root and fill it in.",
+      "remediation": "Where the project has no manifest, start one from templates/PROJECT.md. Where one is already present -- including one a bootstrap wrote -- complete it in place rather than copying over it, which would discard whatever has been filled in. Either way its content must come from what this project is; a manifest answering the template's own prompts is scaffolding rather than a record (Standard 44 R11). This run has not established which of the two holds.",
       "aliases": [
         "architecture.requireProjectManifest"
       ],

--- a/rules/planning.json
+++ b/rules/planning.json
@@ -14,7 +14,7 @@
       "introducedIn": "1.0.0",
       "description": "A project with active work has a decomposed plan on disk, one ordered file per top-level section.",
       "rationale": "A plan that exists only in a conversation is unavailable to the next agent, which is the failure Standard 5 exists to prevent.",
-      "remediation": "Run /plan-structure and /plan-handoff, writing each top-level section to its own file under artifacts/project-plan-breakdown/.",
+      "remediation": "If this project already has an implementation and has not been reconstructed, run the project-reconstruction skill first (Standard 44), then apply /plan-structure and /plan-handoff to the reconstructed plan. Otherwise run /plan-structure and /plan-handoff, writing each top-level section to its own file under artifacts/project-plan-breakdown/. This run has not established which of the two holds.",
       "aliases": ["planning.requireBreakdownDirectory"],
       "deprecatedIn": null,
       "supersededBy": null,

--- a/standards/27-rule-catalog.md
+++ b/standards/27-rule-catalog.md
@@ -146,6 +146,41 @@ in *that* version — a rule with `introducedIn: 2.0.0` does not apply to a proj
 Without this the version pin means nothing, which is the failure
 [Standard 21](21-versioning.md) R5 describes.
 
+### R6 — Remediation MUST NOT assume repository state the producer has not established
+
+A rule's `remediation` is executed by someone — or something — that trusts it.
+[Standard 25](25-validator-output.md) R3 already says why the field matters: the consumers are CI
+and agents, and *"an agent given a failure with no remediation will invent one."* An agent given a
+**confidently wrong** one does not invent anything. It complies.
+
+Three constraints, and they are separable because they fail separately.
+
+**Remediation MUST NOT prescribe an action whose safety or ordering depends on repository state the
+producer has not established.** A repair that is correct in one state and destructive in another is
+not a repair; it is a coin toss the reader cannot see they are making.
+
+**Where a prerequisite is knowable but not established, remediation MUST express it conditionally
+rather than imply it is satisfied.** *"Do X"* asserts that nothing has to happen first. When
+something might, the conditional form — *"if P, do Y first; otherwise do X"* — is true in every
+state, so it neither withholds the advice nor smuggles in a claim about which state holds.
+
+**Remediation MUST NOT fabricate repository state in order to be more specific.** Specificity bought
+by guessing is the failure
+[ADR 0008](../artifacts/adr/0008-detectors-do-not-assert-repository-state-they-have-not-measured.md)
+names, arriving through the remediation rather than the finding. A producer that *has* measured the
+state may narrow the advice on it; one that has inferred the state has measured nothing.
+
+**Two kinds of ordering, and only one of them is this requirement's subject.** Ordering internal to a
+single repair — *"replace the value, then rotate the credential"*, *"confirm reachability, then
+delete"* — is knowable from the rule alone and is unaffected here. This requirement governs ordering
+that depends on the *state of the repository being remediated*, which the rule cannot know and the
+producer may not have looked at.
+
+**This introduces no field and no envelope change**, which is the point. The constraint is on what a
+catalog author may write in `remediation`, not on its shape, so a consumer of
+[Standard 25](25-validator-output.md) R3 sees the same contract it always did. A requirement needing
+a new field here would be describing a different problem.
+
 ## Additions this standard makes beyond the source
 
 - The `assurance` field and R3's separation of it from `validationType` — the mechanism that makes
@@ -156,6 +191,9 @@ Without this the version pin means nothing, which is the failure
 - The lifecycle trio, and the rule that they exist from the first release even when empty.
 - R4's division-of-labour table and the mechanical check.
 - R5 in full — that rules are evaluated against the version in force for the project.
+- R6 in full. The source specifies that a rule carries remediation; it does not constrain what the
+  remediation may assume about the repository it is aimed at. The failure it prevents was produced
+  by this framework's own catalog after the source was written — see the Implementation note.
 
 ## Relationship to other standards
 
@@ -193,6 +231,20 @@ rule ids.
 A further check asserts every catalog `standard` reference resolves to a document that exists. The
 converse — every enforceable requirement having a catalog entry — is **not** checked, and the catalog
 does not claim to cover all 53 standards. It covers what the evaluator and the policy speak in.
+
+**R6 was written from a measured specimen, not from principle.**
+`planning.breakdown-directory` emitted *"Run /plan-structure and /plan-handoff…"* byte-identically
+in two repository states that `scripts/init.mjs` itself distinguishes — one where that is the whole
+repair, and one where `init`'s own next step reads *"Do NOT author a plan as though this project were
+starting now."* Following it in the second state moved the repository from `reconstruction-required`
+to `existing-with-plan`, whose next step is to *preserve* the plan just written, and the finding that
+prompted it changed to `passed`. The advice erased the evidence that it had been wrong.
+
+Neither `audit` nor `validate` computes the repository's mode — `detectMode` has one caller, in
+`init` — so the fix could not be state-conditional text without giving a detector a dependency on an
+inferred classification of intent. Both remediations are conditional and claim no branch;
+`test/remediation-state.test.mjs` holds them to it in both states, and asserts that no detector
+acquired that dependency.
 
 **That gap is now a reported metric rather than a footnote.** `coverage()` emits
 `frameworkCoverage` alongside every verdict — catalogued rules, evaluated rules, standards with

--- a/test/remediation-state.test.mjs
+++ b/test/remediation-state.test.mjs
@@ -1,0 +1,213 @@
+/**
+ * Remediation states its prerequisite as a condition, and claims no branch.
+ *
+ * Issue #32's specimen: `planning.breakdown-directory` emitted the same bytes in two repository
+ * states that `scripts/init.mjs` itself distinguishes — one where "run /plan-structure and
+ * /plan-handoff" is the whole repair, and one where `init`'s own next step reads "Do NOT author a
+ * plan as though this project were starting now."
+ *
+ * The measurement that decided the fix: following that advice in the second state moved the
+ * repository from `reconstruction-required` to `existing-with-plan`, whose next step is to
+ * *preserve* the plan just written, and flipped the finding to `passed`. The advice erased the
+ * evidence that it had been wrong, which is why this is not a presentation defect.
+ *
+ * Neither `audit` nor `validate` computes the repository's mode — `detectMode` has one caller, in
+ * `init` — so the remediation cannot be specialised per state without giving a detector a
+ * dependency on an INFERRED classification of intent. Instead both remediations state the
+ * prerequisite conditionally and say outright that the run has not established which branch holds.
+ * That text is true in every state, so it needs no signal and asserts none (Standard 27 R6).
+ *
+ * Every fixture is a real repository run through the real `init` and the real `validate`. Asserting
+ * the catalog strings directly would pass while the emitted envelope said something else, which is
+ * the layer the defect lived in.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, "..");
+const CLI = path.join(ROOT, "scripts", "standards.mjs");
+const AMPLE = 8_000_000;
+
+const PLAN_RULE = "planning.breakdown-directory";
+const MANIFEST_RULE = "architecture.project-manifest";
+
+/** Long enough that `documentation.architecture` does not fire and clutter the comparison. */
+const README =
+  "# Fixture\n\nA repository built for one test, with a README long enough to clear the " +
+  "four-hundred character threshold the documentation rule applies, so that the only thing under " +
+  "measurement is the remediation text for the planning and manifest rules rather than an " +
+  "unrelated finding about documentation that would say nothing about the question being asked " +
+  "here, which is whether two repository states receive advice that is safe in both of them.\n";
+
+function cli(args, dir) {
+  const r = spawnSync(process.execPath, [CLI, ...args, `--dir=${dir}`], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  return r;
+}
+
+/**
+ * Build a repository in one of the two states, bootstrap it, and return what `validate` emitted.
+ *
+ * `implemented` is the whole difference between the fixtures: implementation markers with no plan
+ * and no prompt is what `init` classifies as reconstruction-required.
+ */
+async function withState(implemented, fn) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remediation-state-"));
+  try {
+    await writeFile(path.join(root, "README.md"), README);
+    if (implemented) {
+      await mkdir(path.join(root, "src"), { recursive: true });
+      await writeFile(path.join(root, "src", "index.ts"), "export const x = 1;\n");
+      await writeFile(path.join(root, "package.json"), '{"name":"legacy","version":"1.0.0"}\n');
+    }
+    const init = cli(["init"], root);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const run = cli(["validate", ".", "--json", `--max-total-read-bytes=${AMPLE}`], root);
+    let json;
+    try {
+      json = JSON.parse(run.stdout);
+    } catch {
+      return assert.fail(`validate stdout was not JSON.\nstderr: ${run.stderr.slice(0, 2000)}`);
+    }
+    const byRule = new Map(json.results.map((r) => [r.ruleId, r]));
+    return await fn({ root, initOutput: init.stdout, byRule });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+// --------------------------------------------------------------- the fixtures are the two states
+
+test("the fixtures really are the two states init distinguishes", async () => {
+  // Anti-vacuity for everything below. If both fixtures landed in the same mode, every assertion
+  // about "two states" would be an assertion about one.
+  await withState(true, ({ initOutput }) => {
+    assert.match(initOutput, /Mode: reconstruction-required/);
+    assert.match(initOutput, /Do NOT author a plan/);
+  });
+  await withState(false, ({ initOutput }) => {
+    assert.match(initOutput, /Mode: greenfield/);
+    assert.doesNotMatch(initOutput, /Do NOT author a plan/);
+  });
+});
+
+test("both rules actually fail in both states", async () => {
+  // The second half of anti-vacuity: a remediation assertion over a rule nobody evaluated proves
+  // nothing, and both of these rules pass as soon as a fixture is built slightly differently.
+  for (const implemented of [true, false]) {
+    await withState(implemented, ({ byRule }) => {
+      for (const id of [PLAN_RULE, MANIFEST_RULE]) {
+        assert.equal(byRule.get(id)?.status, "failed", `${id} did not fail (implemented=${implemented})`);
+      }
+    });
+  }
+});
+
+// ------------------------------------------------- falsifier 1: greenfield stays actionable
+
+test("greenfield remediation still names the skills and the destination", async () => {
+  await withState(false, ({ byRule }) => {
+    const text = byRule.get(PLAN_RULE).remediation;
+    assert.match(text, /\/plan-structure and \/plan-handoff/);
+    assert.match(text, /artifacts\/project-plan-breakdown\//);
+  });
+});
+
+// ------------------------ falsifier 2: plan authoring is never the first unconditional action
+
+test("plan authoring is never the first unconditional instruction", async () => {
+  await withState(true, ({ byRule }) => {
+    const text = byRule.get(PLAN_RULE).remediation;
+    assert.doesNotMatch(
+      text,
+      /^\s*Run \/plan-structure/,
+      "the remediation opens by telling a reconstruction-state project to author a plan",
+    );
+    const reconstruct = text.indexOf("project-reconstruction");
+    const author = text.search(/Otherwise run \/plan-structure/);
+    assert.ok(reconstruct >= 0, "reconstruction is not mentioned at all");
+    assert.ok(author >= 0, "the ordinary repair is not offered at all");
+    assert.ok(
+      reconstruct < author,
+      "a reader following the text in order would author the plan before reconstructing",
+    );
+  });
+});
+
+// ---------------- falsifier 3: following the text cannot erase the evidence, and claims no branch
+
+test("the remediation states a condition and refuses to say which branch holds", async () => {
+  // The self-concealing failure is what this guards. Advice that asserted "you are greenfield"
+  // would, when wrong, be executed and then be unfalsifiable — the act of following it moves the
+  // repository to `existing-with-plan` and the finding to `passed`.
+  for (const implemented of [true, false]) {
+    await withState(implemented, ({ byRule }) => {
+      const text = byRule.get(PLAN_RULE).remediation;
+      assert.match(text, /^If this project already has an implementation and has not been reconstructed/);
+      assert.match(text, /has not established which of the two holds/);
+    });
+  }
+});
+
+test("the same bytes are emitted in both states, which is the property being bought", async () => {
+  // Not incidental. Text that varied by state would mean something computed the state, and nothing
+  // on this path may (Standard 27 R6; ADR 0008).
+  const seen = [];
+  for (const implemented of [true, false]) {
+    await withState(implemented, ({ byRule }) => {
+      seen.push([byRule.get(PLAN_RULE).remediation, byRule.get(MANIFEST_RULE).remediation]);
+    });
+  }
+  assert.deepEqual(seen[0], seen[1], "remediation varied by repository state");
+});
+
+// ------------------------------- falsifier 4: an existing manifest is never copied over
+
+test("an existing PROJECT.md is never instructed to be copied afresh", async () => {
+  await withState(true, ({ byRule, root }) => {
+    const text = byRule.get(MANIFEST_RULE).remediation;
+    assert.doesNotMatch(
+      text,
+      /^\s*Copy templates\/PROJECT\.md/,
+      "the remediation opens by telling the reader to copy over a file init has already written",
+    );
+    assert.match(text, /complete it in place rather than copying over it/);
+    assert.match(text, /has not established which of the two holds/);
+    assert.ok(root, "fixture root missing");
+  });
+});
+
+test("init really did write the manifest the remediation must not overwrite", async () => {
+  // Without this the test above is a claim about a string. The hazard is only real because the file
+  // exists by the time the advice is read, and a reader following "copy" would discard their work.
+  await withState(true, async ({ root }) => {
+    const manifest = await readFile(path.join(root, "PROJECT.md"), "utf8");
+    assert.ok(manifest.length > 0, "init did not create PROJECT.md, so there is nothing to overwrite");
+  });
+});
+
+// -------------------------------- falsifier 5: no detector gains an inferred state dependency
+
+test("no detector depends on init's inferred mode", async () => {
+  // `detectMode` labels its answer INFERRED, and #53's precedent permits narrowing remediation on
+  // MEASURED state only. Specialising prose is never a good enough reason to route a heuristic
+  // classification of intent into the evaluation path — which is the fix this item did not take,
+  // pinned here so a later slice has to argue for it rather than drift into it.
+  const source = await readFile(path.join(ROOT, "scripts", "standards.mjs"), "utf8");
+  assert.doesNotMatch(
+    source,
+    /\bdetectMode\b/,
+    "standards.mjs referenced detectMode; audit and validate must not classify the repository's mode",
+  );
+});


### PR DESCRIPTION
Issue #32's remediation prescribed `/plan-structure` and `/plan-handoff` with no mention of what
must happen first. The measurement changed what the fix had to be.

## The specimen, reproduced at `6662262`

The same rule emits the same bytes in two states the framework itself distinguishes:

| State | What `init` says next | What `validate` emits for `planning.breakdown-directory` |
| --- | --- | --- |
| greenfield | "Run /plan-structure and /plan-handoff, then standards validate." | "Run /plan-structure and /plan-handoff, writing each top-level section…" |
| reconstruction-required | "Run the project-reconstruction skill (Standard 44). **Do NOT author a plan** as though this project were starting now." | **the same string, byte for byte** |

The sequencing was never missing from the framework — only from the layer that emits the
remediation, and that layer cannot supply it: `detectMode` has exactly one caller, `runInit`.
Neither `audit` nor `validate` computes the repository's mode at all.

## Following the advice erases the evidence that it was wrong

Measured by doing it — authoring `00-overview.md` and one section file in the reconstruction
fixture, with no reconstruction:

```text
BEFORE  Mode: reconstruction-required   Next: ... Do NOT author a plan ...
AFTER   Mode: existing-with-plan        Next: Normalise the existing plan ...; do not replace it.
        planning.breakdown-directory: failed -> passed
```

The defect is **self-concealing**. Acting on the under-specified advice moves the repository into a
state whose own next step is to *preserve* the material Standard 44 R11 says is not evidence, and
nothing afterwards reports that reconstruction was ever required. That is what settles it as more
than presentation.

## Why not structured remediation steps

Seven of the fifty catalog remediations already carry an order in prose — "replace the value… then
rotate", "confirm reachability, then delete". Those orders are knowable from the rule alone, so
structure could carry them. **This one is not**, and structuring the string would only have made
the wrong advice easier to execute: machine-readable steps resting on a prerequisite the producer
cannot see are still wrong.

## Why not state-conditional text

`#53`'s precedent permits narrowing advice on **measured** state. `detectMode`'s answer is labelled
`[INFERRED]` by `init` itself, so specialising prose on it would route a heuristic classification of
intent into the evaluation path — the fabrication ADR 0008 forbids, arriving through the fix. A test
now forbids that dependency outright rather than leaving it to discipline.

## What landed

**Standard 27 R6**, the normative invariant: remediation MUST NOT prescribe an action whose safety
or ordering depends on repository state the producer has not established; where a prerequisite is
knowable but not established it MUST be expressed conditionally; and specificity MUST NOT be bought
by fabricating state. It also separates rule-intrinsic ordering, which it does not govern, from
repository-state-dependent ordering, which it does.

**No envelope or schema change.** Standard 25 R3's `remediation` field is unchanged in shape and
type; what changed is what a catalog author may write into it.

**Both remediations are now conditional and claim no branch**, ending with "This run has not
established which of the two holds."

**`architecture.project-manifest` is covered as a second live specimen the issue did not record.**
It fails in the same state with *"PROJECT.md still carries the template's own prompts"* and told the
reader to *"Copy templates/PROJECT.md to the repository root and fill it in"* — over a file `init`
had already written. A human following that has no `--force-overwrite` guard, so the first step is a
no-op at best and discards their work at worst. Creating a manifest and completing a
template-derived one are now distinguished without asserting which holds.

**`planning.handoff` is knowingly left alone**, with the reason recorded: it names the breakdown as
its object, so where there is none the instruction is inapplicable rather than harmful. R6 binds it
if it is ever rewritten.

## Verification

- **467 tests, 463 passing, 0 failures, 4 skipped.** Nine new, in
  `test/remediation-state.test.mjs`, building real repositories in both states and reading the
  remediation out of the emitted envelope — asserting the catalog strings directly would pass while
  the envelope said something else, which is the layer the defect lived in. Two of the nine are
  anti-vacuity.
- **Seven mutants, all killed**: restoring either original string, dropping the no-branch-claimed
  disclaimer, reversing the branch order, dropping the greenfield branch, adding `detectMode` to
  `standards.mjs`'s imports, and making `init` stop distinguishing the two states.
- `inventory`, `fidelity`, `policy`, `diagrams` pass; self-audit 0 errors; `validate` unchanged at
  14 passed / 4 failed / 32 skipped.

Reproduced and settled for issue #32; closed deliberately after the gate rather than by this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
