### PR TITLE
A rule that reported on a subject it never read

### DIFF
--- a/rules/audit.json
+++ b/rules/audit.json
@@ -9,7 +9,7 @@
       "level": "required",
       "severity": "error",
       "validationType": "code-analysis",
-      "assurance": "partial",
+      "assurance": "none",
       "nonExemptible": false,
       "introducedIn": "1.0.0",
       "description": "Every meaningful change to business state is recorded. Derived, transient, or serialized metadata may be excluded where it can be safely reconstructed and has no compliance, security, or business-history value.",
@@ -19,7 +19,7 @@
       "deprecatedIn": null,
       "supersededBy": null,
       "removedIn": null,
-      "$assuranceNote": "The evaluator observes whether audit infrastructure exists. It does not observe whether mutations use it. A pass is partial evidence and MUST NOT be reported as 'all business mutations are audited' (Standard 24 R2)."
+      "$assuranceNote": "No analyzer exists. Reported as not-evaluated rather than passing (Standard 24 R4). Until 2026-09-06 this rule was bound to a detector that observed only test and CI infrastructure, so it passed on repositories with no audit path and failed on audited repositories with no test suite — the assurance elevation Standard 24 R2 forbids. The binding and the EVALUATED_RULES membership were removed together; see issue #62."
     },
     {
       "id": "audit.actor-attribution",

--- a/scripts/standards.mjs
+++ b/scripts/standards.mjs
@@ -79,7 +79,6 @@ const EVALUATED_RULES = [
   "planning.breakdown-directory",
   "planning.item-fields",
   "planning.plan-code-consistency",
-  "audit.business-state",
   "verification.before-completion",
   "quality.unfinished-work",
   "quality.dead-code",
@@ -1741,27 +1740,6 @@ function detectMissingPlanningArtifacts(files, run) {
       standardRef: R.artifacts,
     });
   }
-}
-
-function detectMissingAuditInfrastructure(files, run) {
-  const { rel, has, addFinding } = run;
-  const tests = files.filter((f) => TEST_RE.test(rel(f)));
-  const ci = CI_FILES.filter((c) => has(c));
-  const missing = [];
-  if (tests.length === 0) missing.push("no test suite");
-  if (ci.length === 0) missing.push("no CI configuration");
-  if (missing.length === 0) return;
-
-  addFinding({
-    id: "missing-audit-infrastructure",
-      rule: "audit.business-state",
-    category: "Missing audit infrastructure",
-    severity: "warning",
-    label: "OBSERVED",
-    evidence: missing,
-    message: `The repository has ${missing.join(" and ")}; nothing mechanically verifies its behavior.`,
-    standardRef: R.done,
-  });
 }
 
 function detectUnverifiedFunctionality(files, run) {
@@ -3467,7 +3445,6 @@ export async function main(args) {
   detectMissingDocs(files, run);
   detectArchitectureArtifacts(files, run);
   detectMissingPlanningArtifacts(files, run);
-  detectMissingAuditInfrastructure(files, run);
   detectUnverifiedFunctionality(files, run);
   detectUnfinished(files, run);
   detectDeadCode(files, run);

--- a/test/audit-rule-wiring.test.mjs
+++ b/test/audit-rule-wiring.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Tests for the binding between a catalog rule and the detector that evaluates it.
+ *
+ * `audit.business-state` was bound to `detectMissingAuditInfrastructure`, which consumed only the
+ * presence of a test suite and a CI configuration. It never read a mutation, an actor, or an audit
+ * call, so its verdicts tracked test/CI presence and were insensitive to whether the repository
+ * audited anything. Two specific defective verdicts followed, and the fixtures below are those two
+ * cases held apart from each other rather than a claim about repositories in general:
+ *
+ *   A  infrastructure, no audit path   -> passed   false assurance
+ *   C  audit path, no infrastructure   -> failed   false violation
+ *
+ * A and B differ only in whether an audit path exists, and shared a verdict. B and C share their
+ * source and differ only in infrastructure, and had opposite verdicts. That is the rule reporting on
+ * a subject that is not its own — the assurance elevation Standard 24 R2 forbids, whose remedy
+ * Standard 24 R4 supplies: with no analyzer, report not-evaluated rather than passing.
+ *
+ * The normative requirement is untouched. Standard 3 R1 still requires business-state changes to be
+ * auditable, and the rule keeps its `remediation`. What was removed is a claim to have checked it.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, "..");
+const CLI = path.join(ROOT, "scripts", "standards.mjs");
+const fixture = (name) => path.join(HERE, "fixtures", name);
+
+function run(command, dir) {
+  const r = spawnSync(process.execPath, [CLI, command, `--dir=${dir}`, "--json"], { encoding: "utf8" });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return assert.fail(`stdout was not JSON.\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  }
+}
+
+/**
+ * The three fixtures share one domain — an orders service that changes order status, issues refunds
+ * and, unaudited, grants permissions. Standard 3 R1's own test names exactly those as auditable, so
+ * the rule plainly applies to all three and none of them is out of scope by the core rule.
+ */
+const FIXTURES = [
+  ["audit-unaudited-with-infrastructure", "tests and CI, no audit path — used to pass falsely"],
+  ["audit-audited-with-infrastructure", "tests and CI with a conformant audit path"],
+  ["audit-audited-without-infrastructure", "a conformant audit path, no tests and no CI — used to fail falsely"],
+];
+
+for (const [name, description] of FIXTURES) {
+  test(`audit.business-state is not evaluated: ${description}`, () => {
+    const result = run("validate", fixture(name));
+    const rule = result.results.find((r) => r.ruleId === "audit.business-state");
+    assert.ok(rule, "audit.business-state is missing from the result set entirely");
+    assert.equal(rule.status, "skipped", `${name}: expected skipped, got ${rule.status} — ${rule.message}`);
+    assert.equal(rule.disposition, "not-evaluated");
+    assert.deepEqual(rule.evidence, [], "a rule nothing evaluated must rest on no evidence");
+  });
+
+  test(`no finding is bound to audit.business-state: ${description}`, () => {
+    const bound = (run("audit", fixture(name)).findings ?? []).filter((f) => f.rule === "audit.business-state");
+    assert.deepEqual(bound, [], `${name} produced ${bound.length} finding(s) for a rule with no evaluator`);
+  });
+}
+
+test("the audited and unaudited fixtures differ in exactly the thing under test", async () => {
+  // Guards the guard. If a refactor collapsed the fixtures into each other the tests above would
+  // still pass while testing one repository three times, and the discrimination would be fictional.
+  const read = (f) => readFile(path.join(fixture(f[0]), f[1]), "utf8");
+  const auditedOrders = await read(["audit-audited-with-infrastructure", "src/orders.js"]);
+  const unauditedOrders = await read(["audit-unaudited-with-infrastructure", "src/orders.js"]);
+
+  assert.match(auditedOrders, /recordAuditEvent/, "the audited fixture records no audit events");
+  assert.doesNotMatch(unauditedOrders, /recordAuditEvent/, "the unaudited fixture records audit events");
+  assert.equal(existsSync(path.join(fixture("audit-unaudited-with-infrastructure"), "src/audit.js")), false,
+    "the unaudited fixture has an audit module");
+  assert.ok(existsSync(path.join(fixture("audit-audited-with-infrastructure"), "src/audit.js")),
+    "the audited fixture has no audit module");
+  assert.match(unauditedOrders, /grantAdmin|refund/, "the unaudited fixture mutates no business state");
+
+  // B and C share a source tree and differ only in test/CI infrastructure — the pair that used to
+  // produce opposite verdicts.
+  const withoutInfra = await read(["audit-audited-without-infrastructure", "src/orders.js"]);
+  assert.equal(withoutInfra, auditedOrders, "B and C must differ only in infrastructure");
+});
+
+test("the normative auditing requirement and its remediation survive", async () => {
+  // Withdrawing an evaluator withdraws a claim to have checked something. It must not quietly
+  // withdraw the requirement, which is Standard 3 R1 and is not this change's to weaken.
+  const catalog = JSON.parse(await readFile(path.join(ROOT, "rules", "audit.json"), "utf8"));
+  const rules = Array.isArray(catalog) ? catalog : catalog.rules;
+  const rule = rules.find((r) => r.id === "audit.business-state");
+  assert.equal(rule.level, "required");
+  assert.equal(rule.severity, "error");
+  assert.equal(rule.remediation, "Record business mutations through an audit path that captures what changed.");
+  assert.equal(rule.assurance, "none", "a rule with no evaluator claims no assurance (Standard 27 R3)");
+});
+
+/**
+ * The falsifier.
+ *
+ * Removing the detector and removing the EVALUATED_RULES membership are one change, not two. Doing
+ * only the first is worse than doing neither: the rule stays in the evaluated set with nothing able
+ * to produce a finding for it, so it reports `passed / No violation was observed` on every
+ * repository in the world, including the ones it used to catch. That is a silent false green, and it
+ * is invisible to every other test in this file — all three fixtures would still be non-failing.
+ *
+ * The existing agreement test in compliance.test.mjs checks that every bound detector is declared.
+ * This checks the other direction, which is the one that was open.
+ */
+test("every rule in EVALUATED_RULES has a detector that can produce a finding for it", async () => {
+  const source = await readFile(path.join(ROOT, "scripts", "standards.mjs"), "utf8");
+  const block = source.match(/const EVALUATED_RULES = \[([\s\S]*?)\];/);
+  assert.ok(block, "EVALUATED_RULES not found");
+  const declared = [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  const bound = new Set([...source.matchAll(/^\s*rule: "([^"]+)"/gm)].map((m) => m[1]));
+
+  const unbacked = declared.filter((id) => !bound.has(id));
+  assert.deepEqual(
+    unbacked,
+    [],
+    `declared evaluated with no detector, so ${unbacked.join(", ")} would report passed on every ` +
+      "repository without anything having looked (Standard 24 R4)",
+  );
+});

--- a/test/audit.test.mjs
+++ b/test/audit.test.mjs
@@ -203,7 +203,7 @@ test("a delegated item resolved to done is checked against its deliverables", ()
 
 test("a complete repository provokes none of the missing-* categories", () => {
   const found = ids(audit(fixture("compliant")));
-  for (const id of ["missing-documentation", "missing-planning-artifacts", "missing-audit-infrastructure"]) {
+  for (const id of ["missing-documentation", "missing-planning-artifacts"]) {
     assert.ok(!found.has(id), `${id} fired on a fixture that satisfies it`);
   }
 });
@@ -211,7 +211,6 @@ test("a complete repository provokes none of the missing-* categories", () => {
 test("an incomplete repository provokes the missing-* categories", () => {
   const found = ids(audit(fixture("delegated")));
   assert.ok(found.has("missing-documentation"), "no docs/architecture.md and a one-line README");
-  assert.ok(found.has("missing-audit-infrastructure"), "no tests and no CI");
 });
 
 test("a repository with no plan breakdown is reported", () => {

--- a/test/fixtures/audit-audited-with-infrastructure/.github/workflows/ci.yml
+++ b/test/fixtures/audit-audited-with-infrastructure/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node --test test/

--- a/test/fixtures/audit-audited-with-infrastructure/src/audit.js
+++ b/test/fixtures/audit-audited-with-infrastructure/src/audit.js
@@ -1,0 +1,13 @@
+// An audit path carrying the Standard 3 R2 fields. Present in fixtures B and C, absent in A.
+const events = [];
+
+function recordAuditEvent({ entityType, entityId, action, actorType, actorId, before, after, reason, correlationId, requestId, source }) {
+  if (!entityType || !entityId || !action || !actorType) {
+    throw new Error("audit event missing a mandatory field");
+  }
+  events.push({ entityType, entityId, action, actorType, actorId, timestamp: new Date().toISOString(), before, after, reason, correlationId, requestId, source });
+}
+
+function auditLog() { return events.slice(); }
+
+module.exports = { recordAuditEvent, auditLog };

--- a/test/fixtures/audit-audited-with-infrastructure/src/orders.js
+++ b/test/fixtures/audit-audited-with-infrastructure/src/orders.js
@@ -1,0 +1,29 @@
+const { recordAuditEvent } = require("./audit");
+
+const orders = new Map();
+
+function setOrderStatus(orderId, status, actor, correlationId) {
+  const before = orders.get(orderId) ?? null;
+  const after = { ...(before ?? { id: orderId }), status };
+  orders.set(orderId, after);
+  recordAuditEvent({
+    entityType: "Order", entityId: orderId, action: "STATUS_CHANGED",
+    actorType: actor.type, actorId: actor.id, before, after,
+    reason: "status transition", correlationId, requestId: correlationId, source: "orders-service",
+  });
+  return after;
+}
+
+function refund(orderId, amountCents, actor, correlationId) {
+  const before = orders.get(orderId) ?? null;
+  const after = { ...(before ?? { id: orderId }), refundedCents: amountCents };
+  orders.set(orderId, after);
+  recordAuditEvent({
+    entityType: "Order", entityId: orderId, action: "REFUNDED",
+    actorType: actor.type, actorId: actor.id, before, after,
+    reason: "customer refund", correlationId, requestId: correlationId, source: "orders-service",
+  });
+  return after;
+}
+
+module.exports = { setOrderStatus, refund, orders };

--- a/test/fixtures/audit-audited-with-infrastructure/test/orders.test.js
+++ b/test/fixtures/audit-audited-with-infrastructure/test/orders.test.js
@@ -1,0 +1,14 @@
+const assert = require("node:assert");
+const { test } = require("node:test");
+const { setOrderStatus, refund } = require("../src/orders");
+
+test("status transitions are applied", () => {
+  assert.equal(setOrderStatus("o1", "SHIPPED", { type: "USER", id: "u1" }, "c1").status, "SHIPPED");
+});
+test("refunds are applied", () => {
+  assert.equal(refund("o2", 500, { type: "USER", id: "u1" }, "c2").refundedCents, 500);
+});
+test("a later transition overwrites the earlier status", () => {
+  setOrderStatus("o3", "PAID", { type: "USER", id: "u1" }, "c3");
+  assert.equal(setOrderStatus("o3", "SHIPPED", { type: "USER", id: "u1" }, "c4").status, "SHIPPED");
+});

--- a/test/fixtures/audit-audited-without-infrastructure/src/audit.js
+++ b/test/fixtures/audit-audited-without-infrastructure/src/audit.js
@@ -1,0 +1,13 @@
+// An audit path carrying the Standard 3 R2 fields. Present in fixtures B and C, absent in A.
+const events = [];
+
+function recordAuditEvent({ entityType, entityId, action, actorType, actorId, before, after, reason, correlationId, requestId, source }) {
+  if (!entityType || !entityId || !action || !actorType) {
+    throw new Error("audit event missing a mandatory field");
+  }
+  events.push({ entityType, entityId, action, actorType, actorId, timestamp: new Date().toISOString(), before, after, reason, correlationId, requestId, source });
+}
+
+function auditLog() { return events.slice(); }
+
+module.exports = { recordAuditEvent, auditLog };

--- a/test/fixtures/audit-audited-without-infrastructure/src/orders.js
+++ b/test/fixtures/audit-audited-without-infrastructure/src/orders.js
@@ -1,0 +1,29 @@
+const { recordAuditEvent } = require("./audit");
+
+const orders = new Map();
+
+function setOrderStatus(orderId, status, actor, correlationId) {
+  const before = orders.get(orderId) ?? null;
+  const after = { ...(before ?? { id: orderId }), status };
+  orders.set(orderId, after);
+  recordAuditEvent({
+    entityType: "Order", entityId: orderId, action: "STATUS_CHANGED",
+    actorType: actor.type, actorId: actor.id, before, after,
+    reason: "status transition", correlationId, requestId: correlationId, source: "orders-service",
+  });
+  return after;
+}
+
+function refund(orderId, amountCents, actor, correlationId) {
+  const before = orders.get(orderId) ?? null;
+  const after = { ...(before ?? { id: orderId }), refundedCents: amountCents };
+  orders.set(orderId, after);
+  recordAuditEvent({
+    entityType: "Order", entityId: orderId, action: "REFUNDED",
+    actorType: actor.type, actorId: actor.id, before, after,
+    reason: "customer refund", correlationId, requestId: correlationId, source: "orders-service",
+  });
+  return after;
+}
+
+module.exports = { setOrderStatus, refund, orders };

--- a/test/fixtures/audit-unaudited-with-infrastructure/.github/workflows/ci.yml
+++ b/test/fixtures/audit-unaudited-with-infrastructure/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node --test test/

--- a/test/fixtures/audit-unaudited-with-infrastructure/src/orders.js
+++ b/test/fixtures/audit-unaudited-with-infrastructure/src/orders.js
@@ -1,0 +1,22 @@
+// Business state that moves money and grants permissions. Nothing records who changed it, when,
+// or from what to what. There is no audit path anywhere in this fixture.
+const orders = new Map();
+
+function setOrderStatus(orderId, status) {
+  const after = { ...(orders.get(orderId) ?? { id: orderId }), status };
+  orders.set(orderId, after);
+  return after;
+}
+
+function refund(orderId, amountCents) {
+  const after = { ...(orders.get(orderId) ?? { id: orderId }), refundedCents: amountCents };
+  orders.set(orderId, after);
+  return after;
+}
+
+function grantAdmin(userId) {
+  orders.set(`perm:${userId}`, { admin: true });
+  return true;
+}
+
+module.exports = { setOrderStatus, refund, grantAdmin, orders };

--- a/test/fixtures/audit-unaudited-with-infrastructure/test/orders.test.js
+++ b/test/fixtures/audit-unaudited-with-infrastructure/test/orders.test.js
@@ -1,0 +1,14 @@
+const assert = require("node:assert");
+const { test } = require("node:test");
+const { setOrderStatus, refund } = require("../src/orders");
+
+test("status transitions are applied", () => {
+  assert.equal(setOrderStatus("o1", "SHIPPED", { type: "USER", id: "u1" }, "c1").status, "SHIPPED");
+});
+test("refunds are applied", () => {
+  assert.equal(refund("o2", 500, { type: "USER", id: "u1" }, "c2").refundedCents, 500);
+});
+test("a later transition overwrites the earlier status", () => {
+  setOrderStatus("o3", "PAID", { type: "USER", id: "u1" }, "c3");
+  assert.equal(setOrderStatus("o3", "SHIPPED", { type: "USER", id: "u1" }, "c4").status, "SHIPPED");
+});


### PR DESCRIPTION
Closes #62. Splits out #64.

`audit.business-state` was bound to `detectMissingAuditInfrastructure`, which consumed only the
presence of a test suite and a CI configuration. It never read a mutation, an actor, or an audit
call, so the rule's verdicts tracked test/CI presence and were **insensitive to whether anything was
audited**.

## The measurement

Three fixtures share one orders domain — status changes, refunds, and (unaudited) permission grants.
Standard 3 R1's own test names exactly those as auditable, so the rule plainly applies to all three.

| Fixture | Tests + CI | Audit path | Before | After |
| --- | --- | --- | --- | --- |
| A | yes | **none** | **`passed`** — false assurance | `skipped / not-evaluated` |
| B | yes | conformant R2 | `passed` | `skipped / not-evaluated` |
| C | **no** | conformant R2 | **`failed`** — false violation | `skipped / not-evaluated` |

A and B differ only in whether an audit path exists and shared a verdict. B and C share a source tree
and differ only in infrastructure, and had opposite verdicts. These are two specific defective
verdicts demonstrated by construction — not a claim about repositories in general.

## Why not fix the remediation

That was #62's original framing, and it was wrong. The remediation is correct English for
Standard 3 R1; the verdict it was attached to is wrong in both directions. Rewording it would make a
broken verdict read more plausibly.

**Standard 24 R2 uses this exact case as its worked example**: a structural check may say *"PASS:
audit infrastructure files exist"* and MUST NOT be summarised as *"PASS: all business mutations are
audited."* **Standard 24 R4** supplies the remedy and pre-approves it — with no analyzer, report
`not-evaluated`, *"the correct behaviour, not a gap to paper over."* **ADR 0010** recorded on
2026-08-09 that no analyzer implements this rule. The sibling `audit.actor-attribution` already
reports `not-evaluated`, so this rule was the anomaly, not the pattern. No new owner decision was
needed; this implements existing policy.

Standard 27 R6 is **not** extended — it governs state-dependence, not subject correspondence.

## The change

- The detector binding and the `EVALUATED_RULES` membership are removed **together**. Either alone is
  worse than neither: removing the detector while leaving the membership yields a vacuous `passed` on
  every repository, silently. Verified by injection — both A and C report `passed / No violation was
  observed` in that state.
- `$assuranceNote` corrected; `assurance` drops `partial` -> `none`, which is what Standard 27 R3
  calls a rule the catalog carries and no machine checks.
- **The normative requirement is untouched.** `level`, `severity`, `description`, `rationale` and
  `remediation` are unchanged, and a test asserts it.

## Coverage

Nine new tests in `test/audit-rule-wiring.test.mjs`: A/B/C each assert `skipped / not-evaluated` with
no bound finding; a guard asserts the fixtures actually differ in the thing under test; a test
asserts the normative requirement survived.

The **falsifier** closes the direction the existing agreement test left open. `compliance.test.mjs`
checks every bound detector is declared; nothing checked that every declared rule has a detector.
That gap is exactly the vacuous-pass regression. Confirmed to fire on the half-change rather than
merely passing today.

## Consequences

- **Withdrawing the detector withdraws its tests/CI observation**, which was true and useful. It is
  **not** remapped onto another rule here — rebinding a detector to whichever rule it happens to fit
  is how this defect started. `verification.before-completion` does not currently cover it (measured:
  it reports `passed` on fixture C). Tracked as #64.
- **Four owner attestations are now stale** — `architecture.no-hidden-global-state`,
  `architecture.no-duplicate-implementations`, `meta.standards-not-weakened`,
  `testing.no-weakening-to-pass` — because ADR 0011 keys freshness to committed blob identity and
  this PR changes `scripts/standards.mjs` and the test suite. That is the mechanism working as
  designed, and re-review is the owner's to record; nothing here forges it. They affect only the
  advisory `validate` job.
- This repository's own audit output is unchanged: it has tests and CI, so the withdrawn detector
  never fired here. `audit.business-state` is `not-applicable` under this repo's own policy, so the
  rule's verdict here is unchanged too.

## Gate

`scripts/ci.sh` against the exact committed candidate, in the main tree, per ADR 0015.
